### PR TITLE
Add dual ACP v1 and draft v2 support (1.0.0-alpha.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,15 @@
 name: Release
 
 # Push a version tag (vX.Y.Z matching package.json) to create a GitHub Release
-# and publish the package to npm.
+# and publish the package to npm — only if the tagged commit is already on main.
 #
 # Stable:     v1.2.3           → GitHub Release + npm --tag latest
 # Pre-release: v1.0.0-alpha.0  → GitHub pre-release + npm --tag alpha
 #              v1.0.0-beta.1   → GitHub pre-release + npm --tag beta
 #              v1.0.0-rc.1     → GitHub pre-release + npm --tag rc
+#
+# Tags on feature branches (or any commit not reachable from origin/main) fail
+# the "must be on main" check and do not publish.
 on:
   push:
     tags:
@@ -22,6 +25,26 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Full history so we can verify the tag is an ancestor of main.
+          fetch-depth: 0
+
+      - name: Require tagged commit is on main
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          tag_sha="$(git rev-parse "${GITHUB_REF_NAME}^{}")"
+          main_sha="$(git rev-parse origin/main)"
+          echo "Tag ${GITHUB_REF_NAME} → ${tag_sha}"
+          echo "origin/main         → ${main_sha}"
+
+          # A commit is "on main" if it is origin/main or an ancestor of it.
+          if ! git merge-base --is-ancestor "$tag_sha" origin/main; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points to ${tag_sha}, which is not on origin/main."
+            echo "Merge the release commit into main first, then tag and push the tag."
+            exit 1
+          fi
+          echo "OK: tagged commit is on main"
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 # Push a version tag (vX.Y.Z matching package.json) to create a GitHub Release
 # and publish the package to npm.
+#
+# Stable:     v1.2.3           → GitHub Release + npm --tag latest
+# Pre-release: v1.0.0-alpha.0  → GitHub pre-release + npm --tag alpha
+#              v1.0.0-beta.1   → GitHub pre-release + npm --tag beta
+#              v1.0.0-rc.1     → GitHub pre-release + npm --tag rc
 on:
   push:
     tags:
@@ -25,7 +30,8 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
-      - name: Verify tag matches package.json
+      - name: Verify tag matches package.json and detect channel
+        id: version
         run: |
           tag="${GITHUB_REF_NAME#v}"
           version="$(node -p "require('./package.json').version")"
@@ -33,7 +39,26 @@ jobs:
             echo "::error::Tag v${tag} does not match package.json version ${version}"
             exit 1
           fi
-          echo "Releasing ${version}"
+
+          # SemVer pre-release: anything after the first hyphen (e.g. alpha.0).
+          if [[ "$version" == *-* ]]; then
+            pre="${version#*-}"
+            # npm dist-tag from the pre-release id: alpha.0 → alpha, beta.1 → beta
+            npm_tag="${pre%%.*}"
+            if [[ ! "$npm_tag" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+              echo "::error::Cannot derive a valid npm dist-tag from pre-release '${pre}'"
+              exit 1
+            fi
+            prerelease=true
+          else
+            npm_tag=latest
+            prerelease=false
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=${npm_tag}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
+          echo "Releasing ${version} (prerelease=${prerelease}, npm tag=${npm_tag})"
 
       - name: Install dependencies
         run: npm ci
@@ -53,7 +78,7 @@ jobs:
       - name: Extract release notes from CHANGELOG
         id: notes
         run: |
-          version="${GITHUB_REF_NAME#v}"
+          version="${{ steps.version.outputs.version }}"
           notes_file="${RUNNER_TEMP}/release-notes.md"
           awk -v ver="$version" '
             $0 ~ ("^## \\[" ver "\\]") { found = 1; next }
@@ -69,12 +94,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "${GITHUB_REF_NAME#v}" \
-            --notes-file "${{ steps.notes.outputs.path }}" \
+          args=(
+            "$GITHUB_REF_NAME"
+            --title "${{ steps.version.outputs.version }}"
+            --notes-file "${{ steps.notes.outputs.path }}"
             --verify-tag
+          )
+          if [ "${{ steps.version.outputs.prerelease }}" = "true" ]; then
+            args+=(--prerelease)
+          fi
+          gh release create "${args[@]}"
 
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: |
+          npm publish --access public --tag "${{ steps.version.outputs.npm_tag }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [1.0.0-alpha.0] - 2026-07-22
 
-Pre-release: dual ACP **v1** + experimental draft **v2** support. Not published.
+Pre-release: dual ACP **v1** + experimental draft **v2** support.
+Publish by tagging `v1.0.0-alpha.0` (GitHub pre-release + npm dist-tag `alpha`).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
-This project follows semantic versioning before `1.0.0` with the usual
-pre-1.0 caveat that minor versions may include breaking changes.
+This project follows semantic versioning. Pre-1.0 releases used the usual
+pre-1.0 caveat that minor versions may include breaking changes. Starting with
+`1.0.0-alpha.0`, package pre-releases track ACP v2 draft work; the wire protocol
+for draft v2 may still change before ACP v2 stabilizes.
 
 ## [Unreleased]
+
+## [1.0.0-alpha.0] - 2026-07-22
+
+Pre-release: dual ACP **v1** + experimental draft **v2** support. Not published.
+
+### Added
+
+- Dual-protocol router (`agentProtocolRouter`) negotiates ACP v1 or draft v2 from
+  the client's `initialize.protocolVersion`. Runtime entry (`runAcp`) serves both.
+- Experimental draft ACP v2 surface via `@agentclientprotocol/sdk/experimental/v2`:
+  - Role-agnostic `info` / `capabilities` on initialize
+  - Baseline session methods including required `session/list`
+  - Prompt lifecycle: immediate `{}` acceptance, `user_message` ack with
+    `messageId`, `state_update` (`running` / `idle` + `stopReason`)
+  - `session/resume` with optional `replayFrom: { "type": "start" }` (replaces
+    v1 `session/load` for v2 peers)
+  - `tool_call` → `tool_call_update`, structured diff `changes` + optional
+    `git_patch`, required message IDs on message chunks
+  - Config options use `configId` (v1 still uses `id`)
+- `session/list` on both protocol versions (backed by the session store).
+
+### Changed
+
+- Bumped `@agentclientprotocol/sdk` to `^1.3.0`.
+- Package version jumps to `1.0.0-alpha.0` for the ACP v2 pre-release track.
 
 ## [0.2.4] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,16 @@ for draft v2 may still change before ACP v2 stabilizes.
 ## [1.0.0-alpha.0] - 2026-07-22
 
 Pre-release: dual ACP **v1** + experimental draft **v2** support.
-Publish by tagging `v1.0.0-alpha.0` (GitHub pre-release + npm dist-tag `alpha`).
+
+After this commit is on `main`, publish with:
+
+```sh
+git tag -a v1.0.0-alpha.0 -m "Release 1.0.0-alpha.0"
+git push origin v1.0.0-alpha.0
+```
+
+That creates a GitHub **pre-release** and publishes npm under dist-tag **`alpha`**
+(`npx agy-acp@alpha`). Tags must point at a commit already on `main`.
 
 ### Added
 
@@ -29,11 +38,13 @@ Publish by tagging `v1.0.0-alpha.0` (GitHub pre-release + npm dist-tag `alpha`).
     `git_patch`, required message IDs on message chunks
   - Config options use `configId` (v1 still uses `id`)
 - `session/list` on both protocol versions (backed by the session store).
+- Release workflow support for SemVer pre-releases (`alpha` / `beta` / `rc`):
+  GitHub pre-release + matching npm dist-tag; only tags on `main` publish.
 
 ### Changed
 
 - Bumped `@agentclientprotocol/sdk` to `^1.3.0`.
-- Package version jumps to `1.0.0-alpha.0` for the ACP v2 pre-release track.
+- Package version is `1.0.0-alpha.0` for the ACP v2 pre-release track.
 
 ## [0.2.4] - 2026-07-22
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,10 @@ stdio `initialize` path and at least one real session with an ACP client.
 Pushing a version tag triggers [`.github/workflows/release.yml`](.github/workflows/release.yml),
 which runs the test suite, creates a GitHub Release, and publishes to npm.
 
+**Only tags whose commit is already on `main` are released.** Tagging a
+feature-branch tip fails the workflow and does not publish. Merging a PR alone
+does not publish; you must push a tag after the release commit is on `main`.
+
 | Tag example | GitHub | npm dist-tag | Install |
 |-------------|--------|--------------|---------|
 | `v0.2.5` | Full release | `latest` | `npx agy-acp` |
@@ -61,12 +65,14 @@ One-time setup: store an npm automation token as the repository secret
 1. Update `CHANGELOG.md` with a `## [X.Y.Z] - YYYY-MM-DD` section (move items
    out of `[Unreleased]`).
 2. Bump `version` in `package.json` and `package-lock.json` to `X.Y.Z`.
-3. Commit on `main` (for example `Release X.Y.Z`).
-4. Tag and push:
+3. Land that commit on `main` (merge PR or push).
+4. Tag **that** commit and push the tag:
 
 ```sh
+git checkout main
+git pull origin main
 git tag -a "vX.Y.Z" -m "Release X.Y.Z"
-git push origin main "vX.Y.Z"
+git push origin "vX.Y.Z"
 ```
 
 ### Pre-release (alpha / beta / rc) checklist
@@ -74,12 +80,14 @@ git push origin main "vX.Y.Z"
 1. Update `CHANGELOG.md` with a `## [X.Y.Z-alpha.N] - YYYY-MM-DD` section.
 2. Bump `version` in `package.json` and `package-lock.json` to that pre-release
    (for example `1.0.0-alpha.0`).
-3. Commit on `main`.
-4. Tag and push with the **exact** pre-release version:
+3. Land that commit on `main` (merge PR or push).
+4. Tag **that** commit and push the tag:
 
 ```sh
+git checkout main
+git pull origin main
 git tag -a "v1.0.0-alpha.0" -m "Release 1.0.0-alpha.0"
-git push origin main "v1.0.0-alpha.0"
+git push origin "v1.0.0-alpha.0"
 ```
 
 CI marks the GitHub Release as a pre-release and runs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,21 @@ stdio `initialize` path and at least one real session with an ACP client.
 Pushing a version tag triggers [`.github/workflows/release.yml`](.github/workflows/release.yml),
 which runs the test suite, creates a GitHub Release, and publishes to npm.
 
+| Tag example | GitHub | npm dist-tag | Install |
+|-------------|--------|--------------|---------|
+| `v0.2.5` | Full release | `latest` | `npx agy-acp` |
+| `v1.0.0-alpha.0` | **Pre-release** | `alpha` | `npx agy-acp@alpha` or `@1.0.0-alpha.0` |
+| `v1.0.0-beta.1` | **Pre-release** | `beta` | `npx agy-acp@beta` |
+| `v1.0.0-rc.1` | **Pre-release** | `rc` | `npx agy-acp@rc` |
+
+The npm dist-tag is the first segment of the SemVer pre-release id
+(`1.0.0-alpha.0` → `alpha`). Stable versions (no hyphen) publish as `latest`.
+Bare `npx agy-acp` always follows `latest`, so alphas never become default.
+
 One-time setup: store an npm automation token as the repository secret
 `NPM_TOKEN` (Settings → Secrets and variables → Actions).
 
-Release checklist:
+### Stable release checklist
 
 1. Update `CHANGELOG.md` with a `## [X.Y.Z] - YYYY-MM-DD` section (move items
    out of `[Unreleased]`).
@@ -58,6 +69,23 @@ git tag -a "vX.Y.Z" -m "Release X.Y.Z"
 git push origin main "vX.Y.Z"
 ```
 
+### Pre-release (alpha / beta / rc) checklist
+
+1. Update `CHANGELOG.md` with a `## [X.Y.Z-alpha.N] - YYYY-MM-DD` section.
+2. Bump `version` in `package.json` and `package-lock.json` to that pre-release
+   (for example `1.0.0-alpha.0`).
+3. Commit on `main`.
+4. Tag and push with the **exact** pre-release version:
+
+```sh
+git tag -a "v1.0.0-alpha.0" -m "Release 1.0.0-alpha.0"
+git push origin main "v1.0.0-alpha.0"
+```
+
+CI marks the GitHub Release as a pre-release and runs
+`npm publish --tag alpha` (or `beta` / `rc` as above).
+
 The tag must be `v` plus the exact `package.json` version (for example
-`v0.2.5` for `"version": "0.2.5"`). Do not publish to npm locally; let CI own
-the publish so the GitHub Release and npm version stay in lockstep.
+`v0.2.5` for `"version": "0.2.5"`, or `v1.0.0-alpha.0` for
+`"version": "1.0.0-alpha.0"`). Do not publish to npm locally; let CI own the
+publish so the GitHub Release and npm version stay in lockstep.

--- a/README.md
+++ b/README.md
@@ -97,20 +97,35 @@ node dist/main.js
 Published package / Zed:
 
 ```sh
-npx agy-acp
+npx agy-acp                 # latest stable
+npx agy-acp@alpha           # latest alpha pre-release channel
+npx agy-acp@1.0.0-alpha.0   # pin a specific pre-release
 ```
 
-Example Zed custom agent shape:
+Example Zed custom agent shape (stable):
 
 ```json
 {
   "agent_servers": {
     "Google Antigravity": {
       "command": "npx",
-      "args": ["agy-acp"],
+      "args": ["-y", "agy-acp"],
       "env": {
         "PATH": "/path/to/agy/bin" // Optional
       }
+    }
+  }
+}
+```
+
+Alpha pre-release (after `v1.0.0-alpha.0` is tagged and CI publishes):
+
+```json
+{
+  "agent_servers": {
+    "Google Antigravity (alpha)": {
+      "command": "npx",
+      "args": ["-y", "agy-acp@alpha"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -7,11 +7,18 @@ The implementation is a TypeScript, `npx`-runnable ACP server built on
 keeps the adapter aligned with the logged-in Antigravity CLI experience and
 avoids a separate runtime startup path.
 
+**Current package:** `1.0.0-alpha.0` (pre-release). Supports **ACP v1** and
+**experimental draft ACP v2** side by side via version negotiation on
+`initialize`. See the [ACP v2 draft announcement](https://agentclientprotocol.com/announcements/acp-v2-draft)
+and [migration guide](https://agentclientprotocol.com/protocol/v2/migration).
+Draft v2 may still change before stabilization.
+
 ## Architecture
 
 ```text
 Zed / ACP client
-  -> agy-acp SDK NDJSON server over stdio
+  -> agy-acp dual protocol router (v1 or draft v2 from initialize)
+  -> AgyAcpAgent (sessions, config, prompt lifecycle)
   -> AgyCliSession (spawns agy, tracks --conversation id)
   -> agy --print --conversation <id> --sandbox ...
        \-> writes to ~/.gemini/antigravity-cli/conversations/<id>.db
@@ -36,16 +43,20 @@ titles all included. `agy-acp` now reads that database directly instead:
   conversation id is learned from the first turn and reused after),
 - stdout is drained but never parsed; a `StreamPoller` polls the conversation
   database on an interval while the process runs, translating newly-appended
-  steps into ACP updates (`agent_message_chunk`, `tool_call`,
-  `session_info_update`, ...) via `src/db/translator.ts` and
-  `src/db/updates.ts`,
-- `session/load` replays a conversation's full history from its database (with
-  an incremental cache keyed on file `(mtime, size)` — see
-  `src/db/replay.ts`); `session/resume` restores the same session binding
-  without replaying,
+  steps into ACP updates (`agent_message_chunk`, `tool_call` /
+  v2 `tool_call_update`, `session_info_update`, ...) via `src/db/translator.ts`
+  and `src/db/updates.ts`,
+- **ACP v1:** `session/load` replays history; `session/resume` reattaches without
+  replay. **ACP v2:** only `session/resume` — pass `replayFrom: { "type": "start" }`
+  to replay (replaces v1 load). Replay uses an incremental cache keyed on file
+  `(mtime, size)` — see `src/db/replay.ts`,
+- **ACP v2 prompt lifecycle:** `session/prompt` returns `{}` on acceptance;
+  foreground progress uses `state_update` (`running` / `idle` with `stopReason`);
+  the user message is acknowledged with a required `messageId`,
 - session bindings (which agy conversation a session is bound to, last model
-  choice, etc.) persist to `~/.agy-acp-state/sessions.json` so `session/load`
-  and `session/resume` survive a server restart — see `src/session-store.ts`,
+  choice, etc.) persist to `~/.agy-acp-state/sessions.json` so list/load/resume
+  survive a server restart — see `src/session-store.ts`,
+- `session/list` is advertised on both protocol versions,
 - separate ACP session `Model` and `Reasoning Effort` pickers populated from
   `agy models` when available (effort maps to `agy --effort`),
 - an ACP session `Fast Mode` selector that prepends `/fast` to print-mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agy-acp",
-  "version": "0.2.4",
+  "version": "1.0.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agy-acp",
-      "version": "0.2.4",
+      "version": "1.0.0-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^1.1.0",
+        "@agentclientprotocol/sdk": "^1.3.0",
         "@bufbuild/protobuf": "^2.12.1",
         "better-sqlite3": "^12.11.1",
         "zod": "^4.4.3"
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.1.0.tgz",
-      "integrity": "sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agy-acp",
-  "version": "0.2.4",
-  "description": "Agent Client Protocol adapter that wraps the Google Antigravity CLI",
+  "version": "1.0.0-alpha.0",
+  "description": "Agent Client Protocol adapter that wraps the Google Antigravity CLI (ACP v1 + experimental draft ACP v2)",
   "type": "module",
   "author": {
     "name": "shidngew"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^1.1.0",
+    "@agentclientprotocol/sdk": "^1.3.0",
     "@bufbuild/protobuf": "^2.12.1",
     "better-sqlite3": "^12.11.1",
     "zod": "^4.4.3"

--- a/src/acp-server.ts
+++ b/src/acp-server.ts
@@ -1,34 +1,57 @@
 import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 import { Readable, Writable } from "node:stream";
-import {
-  agent as acpAgent,
-  methods,
-  ndJsonStream,
-  PROTOCOL_VERSION,
-  type AgentContext,
-  type AgentApp,
-  type CloseSessionRequest,
-  type CloseSessionResponse,
-  type InitializeRequest,
-  type InitializeResponse,
-  type LoadSessionRequest,
-  type LoadSessionResponse,
-  type NewSessionRequest,
-  type NewSessionResponse,
-  type PromptRequest,
-  type PromptResponse,
-  type ResumeSessionRequest,
-  type ResumeSessionResponse,
-  type SessionConfigOption,
-  type SetSessionConfigOptionRequest,
-  type SetSessionConfigOptionResponse
+import * as v1 from "@agentclientprotocol/sdk";
+import * as v2 from "@agentclientprotocol/sdk/experimental/v2";
+import type {
+  AgentContext as V1AgentContext,
+  AgentApp as V1AgentApp,
+  CloseSessionRequest,
+  CloseSessionResponse,
+  InitializeRequest as V1InitializeRequest,
+  InitializeResponse as V1InitializeResponse,
+  LoadSessionRequest,
+  LoadSessionResponse,
+  NewSessionRequest as V1NewSessionRequest,
+  NewSessionResponse as V1NewSessionResponse,
+  PromptRequest as V1PromptRequest,
+  PromptResponse as V1PromptResponse,
+  ResumeSessionRequest as V1ResumeSessionRequest,
+  ResumeSessionResponse as V1ResumeSessionResponse,
+  SessionConfigOption as V1SessionConfigOption,
+  SetSessionConfigOptionRequest as V1SetSessionConfigOptionRequest,
+  SetSessionConfigOptionResponse as V1SetSessionConfigOptionResponse
 } from "@agentclientprotocol/sdk";
+import type {
+  AgentContext as V2AgentContext,
+  AgentApp as V2AgentApp,
+  InitializeRequest as V2InitializeRequest,
+  InitializeResponse as V2InitializeResponse,
+  ListSessionsRequest,
+  ListSessionsResponse,
+  NewSessionRequest as V2NewSessionRequest,
+  NewSessionResponse as V2NewSessionResponse,
+  PromptRequest as V2PromptRequest,
+  PromptResponse as V2PromptResponse,
+  ResumeSessionRequest as V2ResumeSessionRequest,
+  ResumeSessionResponse as V2ResumeSessionResponse,
+  SessionConfigOption as V2SessionConfigOption,
+  SetSessionConfigOptionRequest as V2SetSessionConfigOptionRequest,
+  SetSessionConfigOptionResponse as V2SetSessionConfigOptionResponse
+} from "@agentclientprotocol/sdk/experimental/v2";
 import { ReplayCache } from "./db/replay.js";
 import { ensureAgyInstalled } from "./installer.js";
 import { AgyCliBackend, configFromEnv, type AgyCliConfig, type AgyCliSession, type SpawnFactory } from "./cli.js";
 import { promptBlocksToAgyPrompt } from "./prompt-content.js";
 import { defaultStateDir, SessionStore, type StoredSession } from "./session-store.js";
+import { sessionUpdateToV1, sessionUpdateToV2 } from "./session-updates.js";
+
+/** Prefer re-exporting stable v1 symbols used by existing tests and consumers. */
+export const methods = v1.methods;
+export const PROTOCOL_VERSION = v1.PROTOCOL_VERSION;
+export type SessionConfigOption = V1SessionConfigOption;
+export type AgentApp = V1AgentApp;
+export type AgentContext = V1AgentContext;
 
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json") as { version?: string };
@@ -81,6 +104,8 @@ interface SessionState {
   selectedBaseModel: string;
   selectedReasoningEffect: string;
   activePrompt: boolean;
+  /** Active v2 prompt-turn abort controller, if any. */
+  promptAbort?: AbortController;
 }
 
 export class AgyAcpAgent {
@@ -99,10 +124,11 @@ export class AgyAcpAgent {
     this.#store = new SessionStore(defaultStateDir(this.#env));
   }
 
-  async initialize(params: InitializeRequest): Promise<InitializeResponse> {
+  async initializeV1(params: V1InitializeRequest): Promise<V1InitializeResponse> {
     await this.ensureAgyReady();
     return {
-      protocolVersion: params.protocolVersion === PROTOCOL_VERSION ? params.protocolVersion : PROTOCOL_VERSION,
+      protocolVersion:
+        params.protocolVersion === v1.PROTOCOL_VERSION ? params.protocolVersion : v1.PROTOCOL_VERSION,
       agentCapabilities: {
         loadSession: true,
         promptCapabilities: {
@@ -116,6 +142,7 @@ export class AgyAcpAgent {
           acp: false
         },
         sessionCapabilities: {
+          list: {},
           additionalDirectories: {},
           resume: {},
           close: {}
@@ -129,6 +156,35 @@ export class AgyAcpAgent {
     };
   }
 
+  async initializeV2(params: V2InitializeRequest): Promise<V2InitializeResponse> {
+    await this.ensureAgyReady();
+    return {
+      protocolVersion:
+        params.protocolVersion === v2.PROTOCOL_VERSION ? params.protocolVersion : v2.PROTOCOL_VERSION,
+      info: {
+        name: "agy-acp",
+        title: "Google Antigravity CLI",
+        version: packageJson.version ?? "0.0.0"
+      },
+      // Advertising `session` commits to the v2 baseline methods (new/list/resume/close/prompt/cancel/update).
+      capabilities: {
+        session: {
+          prompt: {
+            image: {},
+            embeddedContext: {}
+          },
+          additionalDirectories: {}
+        }
+      },
+      authMethods: []
+    };
+  }
+
+  /** @deprecated Use initializeV1 — kept for tests that call initialize directly. */
+  async initialize(params: V1InitializeRequest): Promise<V1InitializeResponse> {
+    return this.initializeV1(params);
+  }
+
   private ensureAgyReady(): Promise<string | null> {
     this.#ensureAgyPromise ??= ensureAgyInstalled({
       env: this.#env,
@@ -137,111 +193,134 @@ export class AgyAcpAgent {
     return this.#ensureAgyPromise;
   }
 
-  async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
-    const cwd = params.cwd || process.cwd();
-    const additionalDirectories = params.additionalDirectories ?? [];
-    const workspaces = dedupe([cwd, ...additionalDirectories]);
-    const id = randomUUID();
-    const session = await this.buildSession(cwd, workspaces, null);
-    session.id = id;
-    this.#sessions.set(id, session);
-    await this.persistSession(id, session);
+  async newSessionV1(params: V1NewSessionRequest): Promise<V1NewSessionResponse> {
+    const session = await this.createSession(params.cwd, params.additionalDirectories);
     return {
-      sessionId: id,
-      configOptions: sessionConfigOptions(session)
+      sessionId: session.id,
+      configOptions: sessionConfigOptionsV1(session)
+    };
+  }
+
+  async newSessionV2(params: V2NewSessionRequest): Promise<V2NewSessionResponse> {
+    const session = await this.createSession(params.cwd, params.additionalDirectories);
+    return {
+      sessionId: session.id,
+      configOptions: sessionConfigOptionsV2(session)
+    };
+  }
+
+  /** @deprecated Prefer newSessionV1. */
+  async newSession(params: V1NewSessionRequest): Promise<V1NewSessionResponse> {
+    return this.newSessionV1(params);
+  }
+
+  async listSessions(params: ListSessionsRequest = {}): Promise<ListSessionsResponse> {
+    const listed = await this.#store.list({ cwd: params.cwd ?? null });
+    return {
+      sessions: listed.map((entry) => ({
+        sessionId: entry.sessionId,
+        cwd: entry.cwd,
+        additionalDirectories: entry.workspaces.filter((w) => w !== entry.cwd),
+        updatedAt: entry.updatedAt
+      }))
     };
   }
 
   /**
-   * `session/load`: reconstruct a previously persisted session and replay its
+   * v1 `session/load`: reconstruct a previously persisted session and replay its
    * agy conversation history (if bound to one) before returning.
    */
-  async loadSession(params: LoadSessionRequest, client: AgentContext): Promise<LoadSessionResponse> {
-    const { session, cwd, stored } = await this.reloadSession(params.sessionId, params.cwd, params.additionalDirectories);
+  async loadSession(params: LoadSessionRequest, client: V1AgentContext): Promise<LoadSessionResponse> {
+    const { session, cwd, stored } = await this.reloadSession(
+      params.sessionId,
+      params.cwd,
+      params.additionalDirectories
+    );
 
     if (stored.conversationId) {
-      const replay = this.#replayCache.get(session.agy.config.conversationsDir, stored.conversationId, {
-        skipNarration: false,
-        cwd
+      await this.replayConversation(params.sessionId, session, stored.conversationId, cwd, async (update) => {
+        await client.notify(v1.methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: sessionUpdateToV1(update)
+        });
       });
-      if (replay) {
-        for (const update of replay.updates) {
-          await client.notify(methods.client.session.update, { sessionId: params.sessionId, update });
-        }
-      }
     }
 
-    return { configOptions: sessionConfigOptions(session) };
+    return { configOptions: sessionConfigOptionsV1(session) };
   }
 
-  /** `session/resume`: reconstruct a previously persisted session without replaying history. */
-  async resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {
+  /** v1 `session/resume`: reattach without replaying history. */
+  async resumeSessionV1(params: V1ResumeSessionRequest): Promise<V1ResumeSessionResponse> {
     const { session } = await this.reloadSession(params.sessionId, params.cwd, params.additionalDirectories);
-    return { configOptions: sessionConfigOptions(session) };
+    return { configOptions: sessionConfigOptionsV1(session) };
   }
 
-  async setConfigOption(params: SetSessionConfigOptionRequest): Promise<SetSessionConfigOptionResponse> {
-    const session = this.requireSession(params.sessionId);
-    if (params.configId === MODEL_CONFIG_ID) {
-      if (typeof params.value !== "string") {
-        throw new Error("Model config value must be a string");
-      }
-      if (!session.catalog.baseModels().includes(params.value)) {
-        throw new Error(`Unknown model: ${params.value}`);
-      }
-
-      session.selectedBaseModel = params.value;
-      session.selectedReasoningEffect = defaultReasoningEffectForBase(params.value, session.catalog);
-      applyModelSelection(
-        session.agy,
-        session.selectedBaseModel,
-        session.selectedReasoningEffect,
-        session.catalog
-      );
-      await this.persistSession(params.sessionId, session);
-      return {
-        configOptions: sessionConfigOptions(session)
-      };
-    }
-
-    if (params.configId === REASONING_EFFORT_CONFIG_ID) {
-      if (typeof params.value !== "string") {
-        throw new Error("Reasoning effect config value must be a string");
-      }
-      const allowedEffects = reasoningEffectValues(session.selectedBaseModel, session.catalog);
-      if (!allowedEffects.includes(params.value)) {
-        throw new Error(`Unknown reasoning effect: ${params.value}`);
-      }
-
-      session.selectedReasoningEffect = params.value;
-      applyModelSelection(
-        session.agy,
-        session.selectedBaseModel,
-        session.selectedReasoningEffect,
-        session.catalog
-      );
-      await this.persistSession(params.sessionId, session);
-      return {
-        configOptions: sessionConfigOptions(session)
-      };
-    }
-
-    if (params.configId === FAST_MODE_CONFIG_ID) {
-      const enabled = fastModeValueToBoolean(params.value);
-      if (enabled === undefined) {
-        throw new Error("Fast mode config value must be on or off");
-      }
-      session.agy.setFastMode(enabled);
-      await this.persistSession(params.sessionId, session);
-      return {
-        configOptions: sessionConfigOptions(session)
-      };
-    }
-
-    throw new Error(`Unknown config option: ${params.configId}`);
+  /** @deprecated Prefer resumeSessionV1. */
+  async resumeSession(params: V1ResumeSessionRequest): Promise<V1ResumeSessionResponse> {
+    return this.resumeSessionV1(params);
   }
 
-  async prompt(params: PromptRequest, client: AgentContext, signal?: AbortSignal): Promise<PromptResponse> {
+  /**
+   * v2 `session/resume`: optional `replayFrom: { type: "start" }` replaces v1
+   * `session/load`. Omitting `replayFrom` reattaches without history.
+   */
+  async resumeSessionV2(
+    params: V2ResumeSessionRequest,
+    client: V2AgentContext
+  ): Promise<V2ResumeSessionResponse> {
+    const { session, cwd, stored } = await this.reloadSession(
+      params.sessionId,
+      params.cwd,
+      params.additionalDirectories
+    );
+
+    const replayFrom = params.replayFrom ?? null;
+    if (replayFrom != null) {
+      if (replayFrom.type !== "start") {
+        throw new Error(`Unsupported replay cursor: ${String((replayFrom as { type?: string }).type)}`);
+      }
+      if (stored.conversationId) {
+        await this.replayConversation(params.sessionId, session, stored.conversationId, cwd, async (update) => {
+          await client.notify(v2.methods.client.session.update, {
+            sessionId: params.sessionId,
+            update: sessionUpdateToV2(update)
+          });
+        });
+      }
+    }
+
+    return { configOptions: sessionConfigOptionsV2(session) };
+  }
+
+  async setConfigOptionV1(
+    params: V1SetSessionConfigOptionRequest
+  ): Promise<V1SetSessionConfigOptionResponse> {
+    await this.applyConfigOption(params.sessionId, params.configId, readConfigValue(params));
+    return { configOptions: sessionConfigOptionsV1(this.requireSession(params.sessionId)) };
+  }
+
+  async setConfigOptionV2(
+    params: V2SetSessionConfigOptionRequest
+  ): Promise<V2SetSessionConfigOptionResponse> {
+    await this.applyConfigOption(params.sessionId, params.configId, readConfigValue(params));
+    return { configOptions: sessionConfigOptionsV2(this.requireSession(params.sessionId)) };
+  }
+
+  /** @deprecated Prefer setConfigOptionV1. */
+  async setConfigOption(
+    params: V1SetSessionConfigOptionRequest
+  ): Promise<V1SetSessionConfigOptionResponse> {
+    return this.setConfigOptionV1(params);
+  }
+
+  /**
+   * v1 prompt lifecycle: response carries stopReason after the full turn.
+   */
+  async promptV1(
+    params: V1PromptRequest,
+    client: V1AgentContext,
+    signal?: AbortSignal
+  ): Promise<V1PromptResponse> {
     const session = this.requireSession(params.sessionId);
     if (session.activePrompt) {
       throw new Error(`Session already has an active prompt: ${params.sessionId}`);
@@ -258,7 +337,10 @@ export class AgyAcpAgent {
 
     try {
       const outcome = await session.agy.prompt(prompt, async (update) => {
-        await client.notify(methods.client.session.update, { sessionId: params.sessionId, update });
+        await client.notify(v1.methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: sessionUpdateToV1(update)
+        });
       });
       await this.persistSession(params.sessionId, session);
       return {
@@ -276,16 +358,221 @@ export class AgyAcpAgent {
     }
   }
 
+  /**
+   * v2 prompt lifecycle: respond `{}` immediately on acceptance. Foreground
+   * progress and stopReason arrive as `state_update` notifications.
+   */
+  async promptV2(params: V2PromptRequest, client: V2AgentContext): Promise<V2PromptResponse> {
+    const session = this.requireSession(params.sessionId);
+    if (session.activePrompt) {
+      throw new Error(`Session already has an active prompt: ${params.sessionId}`);
+    }
+
+    // Content block shapes are compatible at runtime; v1/v2 TS types diverge on open enums.
+    const promptText = await promptBlocksToAgyPrompt(params.prompt as v1.ContentBlock[], session.cwd);
+    session.activePrompt = true;
+    const controller = new AbortController();
+    session.promptAbort = controller;
+
+    // Queue the empty acceptance response before any session/update from the turn.
+    // Work starts on the next event-loop task (see dual-version-agent example).
+    const responseQueued = new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    void responseQueued
+      .then(() => this.runV2PromptTurn(params, client, session, promptText, controller.signal))
+      .catch((error) => {
+        console.error(`[agy-acp] v2 prompt turn failed: ${(error as Error).message}`);
+      })
+      .finally(() => {
+        if (session.promptAbort === controller) {
+          session.promptAbort = undefined;
+        }
+        session.activePrompt = false;
+      });
+
+    return {};
+  }
+
+  /** @deprecated Prefer promptV1. */
+  async prompt(
+    params: V1PromptRequest,
+    client: V1AgentContext,
+    signal?: AbortSignal
+  ): Promise<V1PromptResponse> {
+    return this.promptV1(params, client, signal);
+  }
+
   async cancel(params: { sessionId: string }): Promise<void> {
     const session = this.#sessions.get(params.sessionId);
+    session?.promptAbort?.abort();
     await session?.agy.cancel();
   }
 
   async closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
     const session = this.#sessions.get(params.sessionId);
     this.#sessions.delete(params.sessionId);
+    session?.promptAbort?.abort();
     await session?.agy.close();
     return {};
+  }
+
+  private async createSession(
+    requestedCwd: string | undefined,
+    requestedDirs: string[] | undefined
+  ): Promise<SessionState> {
+    const cwd = requestedCwd || process.cwd();
+    const additionalDirectories = requestedDirs ?? [];
+    const workspaces = dedupe([cwd, ...additionalDirectories]);
+    const id = randomUUID();
+    const session = await this.buildSession(cwd, workspaces, null);
+    session.id = id;
+    this.#sessions.set(id, session);
+    await this.persistSession(id, session);
+    return session;
+  }
+
+  private async applyConfigOption(sessionId: string, configId: string, value: unknown): Promise<void> {
+    const session = this.requireSession(sessionId);
+    if (configId === MODEL_CONFIG_ID) {
+      if (typeof value !== "string") {
+        throw new Error("Model config value must be a string");
+      }
+      if (!session.catalog.baseModels().includes(value)) {
+        throw new Error(`Unknown model: ${value}`);
+      }
+
+      session.selectedBaseModel = value;
+      session.selectedReasoningEffect = defaultReasoningEffectForBase(value, session.catalog);
+      applyModelSelection(
+        session.agy,
+        session.selectedBaseModel,
+        session.selectedReasoningEffect,
+        session.catalog
+      );
+      await this.persistSession(sessionId, session);
+      return;
+    }
+
+    if (configId === REASONING_EFFORT_CONFIG_ID) {
+      if (typeof value !== "string") {
+        throw new Error("Reasoning effect config value must be a string");
+      }
+      const allowedEffects = reasoningEffectValues(session.selectedBaseModel, session.catalog);
+      if (!allowedEffects.includes(value)) {
+        throw new Error(`Unknown reasoning effect: ${value}`);
+      }
+
+      session.selectedReasoningEffect = value;
+      applyModelSelection(
+        session.agy,
+        session.selectedBaseModel,
+        session.selectedReasoningEffect,
+        session.catalog
+      );
+      await this.persistSession(sessionId, session);
+      return;
+    }
+
+    if (configId === FAST_MODE_CONFIG_ID) {
+      const enabled = fastModeValueToBoolean(value);
+      if (enabled === undefined) {
+        throw new Error("Fast mode config value must be on or off");
+      }
+      session.agy.setFastMode(enabled);
+      await this.persistSession(sessionId, session);
+      return;
+    }
+
+    throw new Error(`Unknown config option: ${configId}`);
+  }
+
+  private async replayConversation(
+    sessionId: string,
+    session: SessionState,
+    conversationId: string,
+    cwd: string,
+    emit: (update: v1.SessionUpdate) => Promise<void>
+  ): Promise<void> {
+    const replay = this.#replayCache.get(session.agy.config.conversationsDir, conversationId, {
+      skipNarration: false,
+      cwd
+    });
+    if (!replay) return;
+    for (const update of replay.updates) {
+      await emit(update);
+    }
+    void sessionId;
+  }
+
+  private async runV2PromptTurn(
+    params: V2PromptRequest,
+    client: V2AgentContext,
+    session: SessionState,
+    promptText: string,
+    signal: AbortSignal
+  ): Promise<void> {
+    const notify = async (update: v2.SessionUpdate) => {
+      await client.notify(v2.methods.client.session.update, {
+        sessionId: params.sessionId,
+        update
+      });
+    };
+
+    const userMessageId = randomUUID();
+    try {
+      signal.throwIfAborted();
+
+      // User message acknowledgment — source of truth for agent-owned messageId.
+      await notify({
+        sessionUpdate: "user_message",
+        messageId: userMessageId,
+        content: params.prompt as v2.ContentBlock[]
+      });
+
+      signal.throwIfAborted();
+      await notify({ sessionUpdate: "state_update", state: "running" });
+
+      const cancelPrompt = () => {
+        session.agy.cancel().catch(() => {});
+      };
+      signal.addEventListener("abort", cancelPrompt, { once: true });
+
+      try {
+        const outcome = await session.agy.prompt(promptText, async (update) => {
+          await notify(sessionUpdateToV2(update));
+        });
+        await this.persistSession(params.sessionId, session);
+
+        const stopReason =
+          outcome.stopReason === "cancelled" || signal.aborted ? "cancelled" : "end_turn";
+        await notify({
+          sessionUpdate: "state_update",
+          state: "idle",
+          stopReason
+        });
+      } finally {
+        signal.removeEventListener("abort", cancelPrompt);
+      }
+    } catch (error) {
+      await this.persistSession(params.sessionId, session).catch(() => {});
+      if (signal.aborted) {
+        await notify({
+          sessionUpdate: "state_update",
+          state: "idle",
+          stopReason: "cancelled"
+        });
+        return;
+      }
+      // Surface a failed turn as idle so the client is not left in `running`.
+      await notify({
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: "end_turn"
+      });
+      throw error;
+    }
   }
 
   private requireSession(sessionId: string): SessionState {
@@ -374,27 +661,57 @@ export class AgyAcpAgent {
   }
 }
 
-export function createAgyAcpApp(options: AgyAcpOptions = {}): AgentApp {
+/** ACP v1 agent app (stable protocol). */
+export function createAgyAcpApp(options: AgyAcpOptions = {}): V1AgentApp {
   const agy = new AgyAcpAgent(options);
-  return acpAgent({ name: "agy-acp" })
-    .onRequest(methods.agent.initialize, (ctx) => agy.initialize(ctx.params))
-    .onRequest(methods.agent.session.new, (ctx) => agy.newSession(ctx.params))
-    .onRequest(methods.agent.session.load, (ctx) => agy.loadSession(ctx.params, ctx.client))
-    .onRequest(methods.agent.session.resume, (ctx) => agy.resumeSession(ctx.params))
-    .onRequest(methods.agent.session.setConfigOption, (ctx) => agy.setConfigOption(ctx.params))
-    .onRequest(methods.agent.session.prompt, (ctx) => agy.prompt(ctx.params, ctx.client, ctx.signal))
-    .onRequest(methods.agent.session.close, (ctx) => agy.closeSession(ctx.params))
-    .onNotification(methods.agent.session.cancel, (ctx) => agy.cancel(ctx.params));
+  return v1
+    .agent({ name: "agy-acp" })
+    .onRequest(v1.methods.agent.initialize, (ctx) => agy.initializeV1(ctx.params))
+    .onRequest(v1.methods.agent.session.new, (ctx) => agy.newSessionV1(ctx.params))
+    .onRequest(v1.methods.agent.session.list, (ctx) => agy.listSessions(ctx.params))
+    .onRequest(v1.methods.agent.session.load, (ctx) => agy.loadSession(ctx.params, ctx.client))
+    .onRequest(v1.methods.agent.session.resume, (ctx) => agy.resumeSessionV1(ctx.params))
+    .onRequest(v1.methods.agent.session.setConfigOption, (ctx) => agy.setConfigOptionV1(ctx.params))
+    .onRequest(v1.methods.agent.session.prompt, (ctx) => agy.promptV1(ctx.params, ctx.client, ctx.signal))
+    .onRequest(v1.methods.agent.session.close, (ctx) => agy.closeSession(ctx.params))
+    .onNotification(v1.methods.agent.session.cancel, (ctx) => agy.cancel(ctx.params));
+}
+
+/**
+ * Experimental draft ACP v2 agent app.
+ * Prefer {@link createDualAgyAcpApp} / {@link runAcp} so v1 clients still work.
+ */
+export function createAgyAcpV2App(options: AgyAcpOptions = {}): V2AgentApp {
+  const agy = new AgyAcpAgent(options);
+  return v2
+    .agent({ name: "agy-acp" })
+    .onRequest(v2.methods.agent.initialize, (ctx) => agy.initializeV2(ctx.params))
+    .onRequest(v2.methods.agent.session.new, (ctx) => agy.newSessionV2(ctx.params))
+    .onRequest(v2.methods.agent.session.list, (ctx) => agy.listSessions(ctx.params))
+    .onRequest(v2.methods.agent.session.resume, (ctx) => agy.resumeSessionV2(ctx.params, ctx.client))
+    .onRequest(v2.methods.agent.session.setConfigOption, (ctx) => agy.setConfigOptionV2(ctx.params))
+    .onRequest(v2.methods.agent.session.prompt, (ctx) => agy.promptV2(ctx.params, ctx.client))
+    .onRequest(v2.methods.agent.session.close, (ctx) => agy.closeSession(ctx.params))
+    .onNotification(v2.methods.agent.session.cancel, (ctx) => agy.cancel(ctx.params));
+}
+
+/**
+ * Dual-version agent connector: negotiates ACP v1 or experimental draft v2 from
+ * the client's `initialize.protocolVersion`.
+ */
+export function createDualAgyAcpApp(options: AgyAcpOptions = {}): v2.AgentProtocolRouter {
+  return v2.agentProtocolRouter().withV1(createAgyAcpApp(options)).withV2(createAgyAcpV2App(options));
 }
 
 export function runAcp(options: AgyAcpOptions = {}) {
   const stdout = (options.stdout ?? process.stdout) as Writable;
   const stdin = (options.stdin ?? process.stdin) as Readable;
-  const stream = ndJsonStream(
+  // v1 ndJsonStream is sufficient: framing is shared; the router peeks initialize.
+  const stream = v1.ndJsonStream(
     Writable.toWeb(stdout) as WritableStream<Uint8Array>,
     Readable.toWeb(stdin) as ReadableStream<Uint8Array>
   );
-  return createAgyAcpApp(options).connect(stream);
+  return createDualAgyAcpApp(options).connect(stream);
 }
 
 export { promptBlocksToAgyPrompt, promptBlocksToText } from "./prompt-content.js";
@@ -470,7 +787,7 @@ export function buildModelCatalog(entries: string[]): ModelCatalog {
   };
 }
 
-export function modelConfigOption(selectedBaseModel: string, catalog: ModelCatalog): SessionConfigOption {
+export function modelConfigOption(selectedBaseModel: string, catalog: ModelCatalog): V1SessionConfigOption {
   return {
     id: MODEL_CONFIG_ID,
     name: "Model",
@@ -489,7 +806,7 @@ export function reasoningEffectConfigOption(
   selectedBaseModel: string,
   selectedReasoningEffect: string,
   catalog: ModelCatalog
-): SessionConfigOption {
+): V1SessionConfigOption {
   return {
     id: REASONING_EFFORT_CONFIG_ID,
     name: "Reasoning Effort",
@@ -501,7 +818,7 @@ export function reasoningEffectConfigOption(
   };
 }
 
-export function fastModeConfigOption(enabled: boolean): SessionConfigOption {
+export function fastModeConfigOption(enabled: boolean): V1SessionConfigOption {
   return {
     id: FAST_MODE_CONFIG_ID,
     name: "Fast Mode",
@@ -522,7 +839,7 @@ export function fastModeConfigOption(enabled: boolean): SessionConfigOption {
   };
 }
 
-function sessionConfigOptions(session: SessionState): SessionConfigOption[] {
+function sessionConfigOptionsV1(session: SessionState): V1SessionConfigOption[] {
   return [
     modelConfigOption(session.selectedBaseModel, session.catalog),
     reasoningEffectConfigOption(
@@ -532,6 +849,20 @@ function sessionConfigOptions(session: SessionState): SessionConfigOption[] {
     ),
     fastModeConfigOption(session.agy.config.fastMode)
   ];
+}
+
+/** v2 renames config option `id` → `configId`. */
+function sessionConfigOptionsV2(session: SessionState): V2SessionConfigOption[] {
+  return sessionConfigOptionsV1(session).map(v1ConfigOptionToV2);
+}
+
+function v1ConfigOptionToV2(option: V1SessionConfigOption): V2SessionConfigOption {
+  const { id, ...rest } = option as V1SessionConfigOption & { id: string };
+  return { ...rest, configId: id } as V2SessionConfigOption;
+}
+
+function readConfigValue(params: { value?: unknown; type?: string }): unknown {
+  return params.value;
 }
 
 /**
@@ -645,7 +976,7 @@ export function prettifyModelSlug(slug: string): string {
 function reasoningEffectOptions(
   selectedBaseModel: string,
   catalog: ModelCatalog
-): Extract<SessionConfigOption, { type: "select" }>["options"] {
+): Extract<V1SessionConfigOption, { type: "select" }>["options"] {
   const effects = catalog.effectsFor(selectedBaseModel);
   if (effects.length === 0) {
     return [

--- a/src/db/tool-call-updates.ts
+++ b/src/db/tool-call-updates.ts
@@ -31,12 +31,14 @@ export function toolCallId(stepRow: StepRow): string {
 }
 
 /** Map agy's step `status` column to an ACP tool_call status.
- *  2 = in progress, 3 = completed, 6 = cancelled/aborted, 7 = failed. */
-function toolCallStatus(stepRow: StepRow): "in_progress" | "completed" | "failed" {
+ *  2 = in progress, 3 = completed, 6 = cancelled/aborted, 7 = failed.
+ *  `cancelled` is ACP v2; v1 clients map it to `failed` at the protocol boundary. */
+function toolCallStatus(stepRow: StepRow): "in_progress" | "completed" | "failed" | "cancelled" {
   switch (stepRow.status) {
     case 2:
       return "in_progress";
     case 6:
+      return "cancelled";
     case 7:
       return "failed";
     default:
@@ -86,7 +88,7 @@ export function toolCallUpdate(opts: {
   stepRow: StepRow;
   title: string;
   kind: ToolKind;
-  status?: "pending" | "in_progress" | "completed" | "failed";
+  status?: "pending" | "in_progress" | "completed" | "failed" | "cancelled";
   content?: Record<string, unknown>[];
   locations?: Record<string, unknown>[];
 }): SessionUpdate {
@@ -102,6 +104,8 @@ export function toolCallUpdate(opts: {
     ? { message: stepRow.error.message || stepRow.error.detail, detail: stepRow.error.detail, stackTrace: stepRow.error.stackTrace }
     : undefined;
 
+  // Emit `tool_call` (v1 create shape). The v2 boundary rewrites this to
+  // `tool_call_update` (first update creates the call).
   return {
     sessionUpdate: "tool_call",
     toolCallId: toolCallId(stepRow),

--- a/src/db/translator.ts
+++ b/src/db/translator.ts
@@ -28,9 +28,10 @@ export interface TranslatorOptions {
   cwd?: string;
 }
 
-function agentChunk(text: string): SessionUpdate {
+function agentChunk(text: string, messageId: string): SessionUpdate {
   return {
     sessionUpdate: "agent_message_chunk",
+    messageId,
     content: { type: "text", text }
   };
 }
@@ -42,6 +43,8 @@ export class Translator {
   private readonly emittedSteps = new Set<number>();
   // Replay: buffered consecutive agent-text parts, flushed at boundaries.
   private readonly pendingAgentParts: string[] = [];
+  // Replay: message id for the current buffered agent-text group.
+  private pendingAgentMessageId: string | null = null;
 
   private _lastTitle: string | null = null;
   private _lastStepIdx = -1;
@@ -143,19 +146,26 @@ export class Translator {
 
   private handleAgentText(row: StepRow, out: SessionUpdate[]): void {
     const text = row.stepPayload.agentText?.text ?? "";
+    const messageId = String(row.idx);
 
     if (this.opts.mode === "replay") {
-      if (text.length > 0) this.pendingAgentParts.push(text);
+      if (text.length > 0) {
+        if (this.pendingAgentMessageId === null) {
+          this.pendingAgentMessageId = messageId;
+        }
+        this.pendingAgentParts.push(text);
+      }
       return;
     }
 
     // Streaming: emit only the slice appended since the last poll for this idx.
+    // Chunks for the same step share one messageId (required by ACP v2).
     const emitted = this.agentTextLengths.get(row.idx) ?? 0;
     if (text.length <= emitted) return;
     this.agentTextLengths.set(row.idx, text.length);
     if (this.opts.skipNarration && isNarration(text)) return;
     const delta = text.slice(emitted);
-    if (delta.length > 0) out.push(agentChunk(delta));
+    if (delta.length > 0) out.push(agentChunk(delta, messageId));
   }
 
   private flushAgentBuffer(out: SessionUpdate[]): void {
@@ -163,7 +173,9 @@ export class Translator {
     const text = this.opts.skipNarration
       ? filterNarration(this.pendingAgentParts)
       : this.pendingAgentParts.join("\n");
+    const messageId = this.pendingAgentMessageId ?? "agent";
     this.pendingAgentParts.length = 0;
-    if (text && text.length > 0) out.push(agentChunk(text));
+    this.pendingAgentMessageId = null;
+    if (text && text.length > 0) out.push(agentChunk(text, messageId));
   }
 }

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -1,7 +1,7 @@
 // Persists ACP session bindings (which agy conversation a session is bound to,
 // and the caller's last config choices) across server restarts, so
-// `session/load` and `session/resume` can reconstruct a session after the ACP
-// client reconnects.
+// `session/load`, `session/resume`, and `session/list` can reconstruct a
+// session after the ACP client reconnects.
 //
 // Writes are serialized through an in-process promise chain (so concurrent
 // persists can't clobber each other) and committed atomically via temp-file +
@@ -49,6 +49,19 @@ export class SessionStore {
   async restore(sessionId: string): Promise<StoredSession | null> {
     const store = await this.load();
     return store.sessions[sessionId] ?? null;
+  }
+
+  /**
+   * List persisted session bindings, newest first.
+   * Optional `cwd` filters to sessions whose stored working directory matches.
+   */
+  async list(filter?: { cwd?: string | null }): Promise<Array<{ sessionId: string } & StoredSession>> {
+    const store = await this.load();
+    const cwd = filter?.cwd ?? null;
+    return Object.entries(store.sessions)
+      .filter(([, session]) => cwd == null || session.cwd === cwd)
+      .map(([sessionId, session]) => ({ sessionId, ...session }))
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
   }
 
   /** Persist a session binding. Resolves once written (writes are serialized). */

--- a/src/session-updates.ts
+++ b/src/session-updates.ts
@@ -1,0 +1,139 @@
+// Protocol-boundary conversion for session/update payloads.
+//
+// The db layer emits v1-shaped updates (with required messageIds on message
+// chunks). v1 clients receive them as-is; v2 clients get the draft-v2 mapping
+// (tool_call → tool_call_update, structured diffs, cancelled status, etc.).
+
+import type { SessionUpdate as V1SessionUpdate } from "@agentclientprotocol/sdk";
+import type { SessionUpdate as V2SessionUpdate } from "@agentclientprotocol/sdk/experimental/v2";
+
+/** Absolute-path friendly git_patch text for a single-file text change. */
+export function gitPatchForFile(
+  path: string,
+  oldText: string | null | undefined,
+  newText: string
+): string {
+  const oldLines = (oldText ?? "").split("\n");
+  const newLines = newText.split("\n");
+  // Trailing empty line from split of empty string is fine for the line counts.
+  if (oldText == null || oldText === "") {
+    const body = newLines.map((line) => `+${line}`).join("\n");
+    return [
+      `diff --git ${path} ${path}`,
+      "new file mode 100644",
+      "--- /dev/null",
+      `+++ ${path}`,
+      `@@ -0,0 +1,${Math.max(newLines.length, 1)} @@`,
+      body
+    ].join("\n");
+  }
+
+  const body = [
+    ...oldLines.map((line) => `-${line}`),
+    ...newLines.map((line) => `+${line}`)
+  ].join("\n");
+  return [
+    `diff --git ${path} ${path}`,
+    `--- ${path}`,
+    `+++ ${path}`,
+    `@@ -1,${Math.max(oldLines.length, 1)} +1,${Math.max(newLines.length, 1)} @@`,
+    body
+  ].join("\n");
+}
+
+function toolContentToV2(item: Record<string, unknown>): Record<string, unknown> {
+  if (item.type !== "diff") {
+    return item;
+  }
+
+  const path = typeof item.path === "string" ? item.path : "";
+  const oldText = (item.oldText as string | null | undefined) ?? null;
+  const newText = typeof item.newText === "string" ? item.newText : "";
+  const operation = oldText == null || oldText === "" ? "add" : "modify";
+
+  return {
+    type: "diff",
+    changes: [
+      {
+        operation,
+        path,
+        fileType: "text"
+      }
+    ],
+    patch: path
+      ? {
+          format: "git_patch",
+          text: gitPatchForFile(path, oldText, newText)
+        }
+      : null
+  };
+}
+
+function mapToolStatusForV2(status: unknown): unknown {
+  return status;
+}
+
+function mapToolStatusForV1(status: unknown): unknown {
+  // v1 has no `cancelled` tool-call status.
+  return status === "cancelled" ? "failed" : status;
+}
+
+/** Identity cast for the v1 wire format (builders already emit v1 shapes). */
+export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
+  const raw = update as unknown as Record<string, unknown>;
+  if (raw.sessionUpdate === "tool_call" || raw.sessionUpdate === "tool_call_update") {
+    return {
+      ...raw,
+      status: mapToolStatusForV1(raw.status)
+    } as V1SessionUpdate;
+  }
+  return update;
+}
+
+/** Map a builder-emitted (v1-shaped) update onto draft ACP v2. */
+export function sessionUpdateToV2(update: V1SessionUpdate): V2SessionUpdate {
+  const raw = { ...(update as unknown as Record<string, unknown>) };
+
+  if (raw.sessionUpdate === "tool_call") {
+    raw.sessionUpdate = "tool_call_update";
+    raw.status = mapToolStatusForV2(raw.status);
+    if (Array.isArray(raw.content)) {
+      raw.content = raw.content.map((item) =>
+        item && typeof item === "object"
+          ? toolContentToV2(item as Record<string, unknown>)
+          : item
+      );
+    }
+    return raw as V2SessionUpdate;
+  }
+
+  if (
+    raw.sessionUpdate === "agent_message_chunk" ||
+    raw.sessionUpdate === "user_message_chunk" ||
+    raw.sessionUpdate === "agent_thought_chunk"
+  ) {
+    if (typeof raw.messageId !== "string" || raw.messageId.length === 0) {
+      raw.messageId = "msg_unknown";
+    }
+    return raw as V2SessionUpdate;
+  }
+
+  if (raw.sessionUpdate === "tool_call_update" && Array.isArray(raw.content)) {
+    raw.content = raw.content.map((item) =>
+      item && typeof item === "object"
+        ? toolContentToV2(item as Record<string, unknown>)
+        : item
+    );
+    return raw as V2SessionUpdate;
+  }
+
+  return raw as V2SessionUpdate;
+}
+
+export function mapUpdatesToV1(updates: readonly V1SessionUpdate[]): V1SessionUpdate[] {
+  return updates.map(sessionUpdateToV1);
+}
+
+export function mapUpdatesToV2(updates: readonly V1SessionUpdate[]): V2SessionUpdate[] {
+  return updates.map(sessionUpdateToV2);
+}

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -6,9 +6,11 @@ import { Readable, Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import * as installer from "../src/installer.js";
 import { client as acpClient, methods, PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
+import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import {
   buildModelCatalog,
   createAgyAcpApp,
+  createAgyAcpV2App,
   modelConfigOption,
   promptBlocksToText,
   reasoningEffectConfigOption,
@@ -17,7 +19,8 @@ import {
 import type { SpawnFactory } from "../src/cli.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
-import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { sessionUpdateToV2 } from "../src/session-updates.js";
+import type { SessionConfigOption, SessionUpdate } from "@agentclientprotocol/sdk";
 
 type SelectConfigOption = Extract<SessionConfigOption, { type: "select" }>;
 
@@ -461,8 +464,197 @@ describe("session model config", () => {
   });
 });
 
+describe("ACP v2 (experimental draft)", () => {
+  it("negotiates protocolVersion 2 with role-agnostic info/capabilities", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue(null);
+    const connection = acpV2.client({ name: "test-client" }).connect(createAgyAcpV2App());
+    try {
+      const response = await connection.agent.request(acpV2.methods.agent.initialize, {
+        protocolVersion: acpV2.PROTOCOL_VERSION,
+        info: { name: "test-client", version: "0.0.0" },
+        capabilities: {}
+      });
+
+      expect(response.protocolVersion).toBe(2);
+      expect(response.info.name).toBe("agy-acp");
+      expect(response.capabilities?.session?.prompt?.image).toEqual({});
+      expect(response.capabilities?.session?.prompt?.embeddedContext).toEqual({});
+      expect(response.capabilities?.session?.additionalDirectories).toEqual({});
+      expect(installSpy).toHaveBeenCalledOnce();
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+    }
+  });
+
+  it("accepts session/prompt immediately and reports idle via state_update", async () => {
+    await withConversationsDir(async (dir) => {
+      const updates: unknown[] = [];
+      const client = acpV2.client({ name: "test-client" }).onNotification(
+        acpV2.methods.client.session.update,
+        (ctx) => {
+          updates.push(ctx.params.update);
+        }
+      );
+      const connection = client.connect(
+        createAgyAcpV2App({
+          env: { AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir },
+          spawnProcess: spawnAgyWritingConversation(dir, "conv-v2-1", [
+            { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hello v2" }) }
+          ])
+        })
+      );
+      try {
+        await connection.agent.request(acpV2.methods.agent.initialize, {
+          protocolVersion: 2,
+          info: { name: "test-client", version: "0.0.0" },
+          capabilities: {}
+        });
+        const session = await connection.agent.request(acpV2.methods.agent.session.new, {
+          cwd: "/repo"
+        });
+        const response = await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "hi" }]
+        });
+
+        // v2 prompt response is an empty acceptance ack (no stopReason).
+        expect(response).toEqual({});
+
+        await waitFor(() => updates.some((u) => (u as { state?: string }).state === "idle"));
+
+        expect(updates).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              sessionUpdate: "user_message",
+              content: [{ type: "text", text: "hi" }]
+            }),
+            expect.objectContaining({ sessionUpdate: "state_update", state: "running" }),
+            expect.objectContaining({
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "hello v2" },
+              messageId: expect.any(String)
+            }),
+            expect.objectContaining({
+              sessionUpdate: "state_update",
+              state: "idle",
+              stopReason: "end_turn"
+            })
+          ])
+        );
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  it("replays history on session/resume with replayFrom start", async () => {
+    await withConversationsDir(async (dir) => {
+      const appOptions = {
+        env: { AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir },
+        spawnProcess: spawnAgyWritingConversation(dir, "conv-v2-replay", [
+          { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "prior turn" }) }
+        ])
+      };
+
+      let sessionId: string;
+      {
+        const updates: unknown[] = [];
+        const client = acpV2.client({ name: "test-client" }).onNotification(
+          acpV2.methods.client.session.update,
+          (ctx) => {
+            updates.push(ctx.params.update);
+          }
+        );
+        const connection = client.connect(createAgyAcpV2App(appOptions));
+        try {
+          await connection.agent.request(acpV2.methods.agent.initialize, {
+            protocolVersion: 2,
+            info: { name: "test-client", version: "0.0.0" },
+            capabilities: {}
+          });
+          const session = await connection.agent.request(acpV2.methods.agent.session.new, {
+            cwd: "/repo"
+          });
+          sessionId = session.sessionId;
+          await connection.agent.request(acpV2.methods.agent.session.prompt, {
+            sessionId,
+            prompt: [{ type: "text", text: "hi" }]
+          });
+          // Drain the async turn so the conversation binding is persisted.
+          await waitFor(() => updates.some((u) => (u as { state?: string }).state === "idle"));
+        } finally {
+          connection.close();
+        }
+      }
+
+      {
+        const updates: unknown[] = [];
+        const client = acpV2.client({ name: "test-client" }).onNotification(
+          acpV2.methods.client.session.update,
+          (ctx) => {
+            updates.push(ctx.params.update);
+          }
+        );
+        const connection = client.connect(createAgyAcpV2App(appOptions));
+        try {
+          await connection.agent.request(acpV2.methods.agent.initialize, {
+            protocolVersion: 2,
+            info: { name: "test-client", version: "0.0.0" },
+            capabilities: {}
+          });
+          await connection.agent.request(acpV2.methods.agent.session.resume, {
+            sessionId,
+            cwd: "/repo",
+            replayFrom: { type: "start" }
+          });
+          expect(updates).toContainEqual(
+            expect.objectContaining({
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "prior turn" },
+              messageId: expect.any(String)
+            })
+          );
+        } finally {
+          connection.close();
+        }
+      }
+    });
+  });
+
+  it("maps tool_call to tool_call_update and diffs to structured changes", () => {
+    const update = {
+      sessionUpdate: "tool_call",
+      toolCallId: "c1",
+      title: "Edit /tmp/a.ts",
+      kind: "edit",
+      status: "completed",
+      content: [{ type: "diff", path: "/tmp/a.ts", oldText: null, newText: "export {}\n" }]
+    } as SessionUpdate;
+
+    const v2Update = sessionUpdateToV2(update) as Record<string, unknown>;
+    expect(v2Update.sessionUpdate).toBe("tool_call_update");
+    const content = v2Update.content as Array<Record<string, unknown>>;
+    expect(content[0]).toMatchObject({
+      type: "diff",
+      changes: [{ operation: "add", path: "/tmp/a.ts", fileType: "text" }],
+      patch: { format: "git_patch" }
+    });
+  });
+});
+
 const TEST_MODELS_OUTPUT =
   "gemini-3.5-flash-medium\ngemini-3.5-flash-high\nclaude-opus-4-6-thinking\nclaude-sonnet-4-6\n";
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitFor timed out");
+    }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
 
 /** Run `fn` with a throwaway conversations directory, cleaned up afterwards. */
 async function withConversationsDir(fn: (dir: string) => Promise<void>): Promise<void> {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -87,11 +87,15 @@ describe("Translator", () => {
     const conn = ConversationDb.open(dir, "conv-2")!;
 
     const first = translator.translate(conn.readAfter(0));
-    expect(first).toEqual([{ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello" } }]);
+    expect(first).toEqual([
+      { sessionUpdate: "agent_message_chunk", messageId: "1", content: { type: "text", text: "Hello" } }
+    ]);
 
     updateStepPayload(db, 1, encodeStepPayload({ agentText: "Hello world" }));
     const second = translator.translate(conn.readAfter(0));
-    expect(second).toEqual([{ sessionUpdate: "agent_message_chunk", content: { type: "text", text: " world" } }]);
+    expect(second).toEqual([
+      { sessionUpdate: "agent_message_chunk", messageId: "1", content: { type: "text", text: " world" } }
+    ]);
 
     conn.close();
     db.close();
@@ -129,7 +133,11 @@ describe("Translator", () => {
     conn.close();
 
     expect(updates).toEqual([
-      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello\n world" } }
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "Hello\n world" }
+      }
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- Upgrade to `@agentclientprotocol/sdk@^1.3.0` and serve **ACP v1 + experimental draft ACP v2** side by side via `agentProtocolRouter` version negotiation on `initialize`.
- Draft v2 surface: role-agnostic `info`/`capabilities`, prompt acceptance with `state_update` lifecycle, `session/resume` + `replayFrom`, `session/list`, `tool_call_update` / structured diffs / required message IDs, config options via `configId`.
- Keep full v1 behavior (`session/load`, prompt `stopReason`, existing config `id` field) for current clients.
- Package version set to **`1.0.0-alpha.0`** with README/CHANGELOG notes. **Does not publish to npm** — merge only; pre-release publish is a separate step (`npm publish --tag alpha`).

## Commits

1. Upgrade `@agentclientprotocol/sdk` to 1.3.0
2. Add session store listing for `session/list`
3. Require message IDs and map cancelled tool status
4. Add ACP v1/v2 session update converters
5. Add dual ACP v1 and draft v2 agent surfaces
6. Add tests for draft ACP v2 prompt and resume flows
7. Prepare 1.0.0-alpha.0 pre-release notes for ACP v2

## Test plan

- [x] `npm test` (47 tests) and `npm run build` on this branch
- [ ] CI green on the PR
- [ ] Smoke: v1 client `initialize` with `protocolVersion: 1` still works (`session/new` → `session/prompt` with `stopReason`)
- [ ] Smoke (optional): draft v2 client with `protocolVersion: 2` gets `state_update` idle + `session/resume` replayFrom
- [ ] After merge (separate): publish with `npm publish --tag alpha` only when ready; do not move `latest` yet