### PR TITLE
Fix platform smoke hang and use npm Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,16 @@
 name: Release
 
 # Push a version tag (vX.Y.Z matching package.json) to create a GitHub Release
-# and publish the package to npm — only if the tagged commit is already on main.
+# and publish the package to npm via Trusted Publishing (OIDC) — only if the
+# tagged commit is already on main.
+#
+# Configure the matching Trusted Publisher on npmjs.com for this repo and
+# workflow file (`.github/workflows/release.yml`). No long-lived NPM_TOKEN.
 #
 # Stable:     v1.2.3           → GitHub Release + npm --tag latest
 # Pre-release: v1.0.0-alpha.0  → GitHub pre-release + npm --tag alpha
 #              v1.0.0-beta.1   → GitHub pre-release + npm --tag beta
 #              v1.0.0-rc.1     → GitHub pre-release + npm --tag rc
-#
-# Tags on feature branches (or any commit not reachable from origin/main) fail
-# the "must be on main" check and do not publish.
 on:
   push:
     tags:
@@ -17,6 +18,8 @@ on:
 
 permissions:
   contents: write
+  # Required for npm Trusted Publishing (OIDC).
+  id-token: write
 
 jobs:
   release:
@@ -52,6 +55,10 @@ jobs:
           node-version: "22"
           cache: npm
           registry-url: https://registry.npmjs.org
+
+      # Trusted Publishing needs a recent npm with OIDC support.
+      - name: Install npm with OIDC support
+        run: npm install -g npm@11
 
       - name: Verify tag matches package.json and detect channel
         id: version
@@ -117,6 +124,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "GitHub release ${GITHUB_REF_NAME} already exists; leaving it in place."
+            exit 0
+          fi
           args=(
             "$GITHUB_REF_NAME"
             --title "${{ steps.version.outputs.version }}"
@@ -128,8 +139,8 @@ jobs:
           fi
           gh release create "${args[@]}"
 
-      - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # No NODE_AUTH_TOKEN / NPM_TOKEN: npm exchanges the Actions OIDC token
+      # for a short-lived publish credential via Trusted Publishing.
+      - name: Publish to npm (Trusted Publisher)
         run: |
-          npm publish --access public --tag "${{ steps.version.outputs.npm_tag }}"
+          npm publish --access public --tag "${{ steps.version.outputs.npm_tag }}" --provenance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,16 @@ The npm dist-tag is the first segment of the SemVer pre-release id
 (`1.0.0-alpha.0` → `alpha`). Stable versions (no hyphen) publish as `latest`.
 Bare `npx agy-acp` always follows `latest`, so alphas never become default.
 
-One-time setup: store an npm automation token as the repository secret
-`NPM_TOKEN` (Settings → Secrets and variables → Actions).
+One-time setup (npm **Trusted Publisher**, no long-lived token):
+
+1. On [npmjs.com](https://www.npmjs.com) → package `agy-acp` → **Trusted Publisher**.
+2. Provider: **GitHub Actions**.
+3. Organization / user: `shindgew`, repository: `agy-acp`.
+4. Workflow filename: `release.yml` (must match `.github/workflows/release.yml`).
+5. Leave environment empty unless you add a GitHub Environment to the job.
+
+The release workflow uses OIDC (`permissions: id-token: write`) and
+`npm publish --provenance`. Do **not** set `NPM_TOKEN` for publish.
 
 ### Stable release checklist
 

--- a/scripts/smoke-install.mjs
+++ b/scripts/smoke-install.mjs
@@ -5,7 +5,14 @@
 // the platform's real prebuilt (or compiled) native binary, which is the
 // part that can silently break per OS/arch and unit tests never spawn a
 // subprocess for.
+//
+// A stub `agy` is injected on PATH so initialize does not network-download
+// the real CLI (that was flaky / slow on some runners and is not what this
+// smoke test is measuring).
 import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { Readable, Writable } from "node:stream";
 import { setTimeout as delay } from "node:timers/promises";
 import { client as acpClient, methods, ndJsonStream, PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
@@ -16,10 +23,30 @@ if (!cliPath) {
   process.exit(2);
 }
 
-const child = spawn(process.execPath, [cliPath], { stdio: ["pipe", "pipe", "inherit"] });
+const stubBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-smoke-agy-"));
+// Minimal executable that satisfies resolveAgyExecutable / PATH lookups.
+// initialize must not network-download a real agy CLI during smoke.
+if (process.platform === "win32") {
+  // Windows resolves `agy` via PATHEXT (.COM/.EXE/.BAT/.CMD). A tiny .cmd is enough.
+  fs.writeFileSync(path.join(stubBinDir, "agy.cmd"), "@echo off\r\nexit /b 0\r\n");
+} else {
+  const stubAgyPath = path.join(stubBinDir, "agy");
+  fs.writeFileSync(stubAgyPath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+}
 
-const timeout = delay(15_000).then(() => {
-  throw new Error("timed out waiting for initialize response");
+const childEnv = {
+  ...process.env,
+  PATH: `${stubBinDir}${path.delimiter}${process.env.PATH ?? ""}`
+};
+
+const child = spawn(process.execPath, [cliPath], {
+  stdio: ["pipe", "pipe", "inherit"],
+  env: childEnv
+});
+
+const timeoutMs = 30_000;
+const timeout = delay(timeoutMs).then(() => {
+  throw new Error(`timed out waiting for initialize response after ${timeoutMs}ms`);
 });
 
 async function run() {
@@ -54,4 +81,9 @@ try {
   process.exitCode = 1;
 } finally {
   child.kill();
+  try {
+    fs.rmSync(stubBinDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
 }


### PR DESCRIPTION
Inject a stub agy on PATH so initialize does not download the real CLI during smoke, and publish via OIDC (id-token) with provenance instead of NPM_TOKEN/OTP.