### PR TITLE
Release 0.2.5: progressive tools, thoughts, command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,30 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-07-22
+
+Stable release focused on ACP v1 editor UX. Dual-protocol draft ACP v2 support
+from the `1.0.0-alpha.0` line is included when clients negotiate protocol
+version 2; default `npx agy-acp` clients continue to use ACP v1.
+
+### Added
+
+- Progressive tool lifecycle: stream polls re-read in-flight steps and emit
+  `tool_call` on first sight, then `tool_call_update` when status or content
+  changes (pending / in_progress → completed / failed / cancelled).
+- Real `agent_thought_chunk` for title-attached “Think” narration and think-style
+  tool names (replacing fake `tool_call` kind `think` for those paths).
+- Decode `run_command` result payload (step field 28) and surface command
+  stdout/stderr text plus `rawOutput.exitCode` on execute tool calls.
+- `session/list` coverage and docs (implementation already present).
+
+### Changed
+
+- Title-step “Think” blocks no longer re-emit on every stream poll.
+
 ## [1.0.0-alpha.0] - 2026-07-22
 
 Pre-release: dual ACP **v1** + experimental draft **v2** support.
-
-After this commit is on `main`, publish with:
-
-```sh
-git tag -a v1.0.0-alpha.0 -m "Release 1.0.0-alpha.0"
-git push origin v1.0.0-alpha.0
-```
-
-That creates a GitHub **pre-release** and publishes npm under dist-tag **`alpha`**
-(`npx agy-acp@alpha`). Tags must point at a commit already on `main`.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ The implementation is a TypeScript, `npx`-runnable ACP server built on
 keeps the adapter aligned with the logged-in Antigravity CLI experience and
 avoids a separate runtime startup path.
 
-**Current package:** `1.0.0-alpha.0` (pre-release). Supports **ACP v1** and
+**Current package:** `0.2.5` (`latest`). Supports **ACP v1** and
 **experimental draft ACP v2** side by side via version negotiation on
-`initialize`. See the [ACP v2 draft announcement](https://agentclientprotocol.com/announcements/acp-v2-draft)
+`initialize`. Draft ACP v2 work continues on the `alpha` dist-tag
+(`1.0.0-alpha.*`). See the [ACP v2 draft announcement](https://agentclientprotocol.com/announcements/acp-v2-draft)
 and [migration guide](https://agentclientprotocol.com/protocol/v2/migration).
 Draft v2 may still change before stabilization.
 
@@ -43,9 +44,9 @@ titles all included. `agy-acp` now reads that database directly instead:
   conversation id is learned from the first turn and reused after),
 - stdout is drained but never parsed; a `StreamPoller` polls the conversation
   database on an interval while the process runs, translating newly-appended
-  steps into ACP updates (`agent_message_chunk`, `tool_call` /
-  v2 `tool_call_update`, `session_info_update`, ...) via `src/db/translator.ts`
-  and `src/db/updates.ts`,
+  steps into ACP updates (`agent_message_chunk`, `agent_thought_chunk`,
+  progressive `tool_call` → `tool_call_update`, `session_info_update`, ...)
+  via `src/db/translator.ts` and `src/db/updates.ts`,
 - **ACP v1:** `session/load` replays history; `session/resume` reattaches without
   replay. **ACP v2:** only `session/resume` — pass `replayFrom: { "type": "start" }`
   to replay (replaces v1 load). Replay uses an incremental cache keyed on file
@@ -97,7 +98,7 @@ node dist/main.js
 Published package / Zed:
 
 ```sh
-npx agy-acp                 # latest stable
+npx agy-acp                 # latest stable (0.2.5)
 npx agy-acp@alpha           # latest alpha pre-release channel
 npx agy-acp@1.0.0-alpha.0   # pin a specific pre-release
 ```
@@ -118,7 +119,7 @@ Example Zed custom agent shape (stable):
 }
 ```
 
-Alpha pre-release (after `v1.0.0-alpha.0` is tagged and CI publishes):
+Alpha pre-release channel (draft ACP v2 iteration):
 
 ```json
 {
@@ -202,6 +203,71 @@ Enabling `Fast Mode` sends `/fast` before the user prompt in the transient
 Both work by reading the session binding persisted after every prompt/config
 change (see `AGY_ACP_STATE_DIR` above) and, for `session/load`, replaying the
 bound agy conversation database from `AGY_ACP_CONVERSATIONS_DIR`.
+
+## ACP v1 roadmap
+
+`agy-acp` covers the core ACP prompt loop (sessions, config options, streamed
+tool calls, edit diffs, load/resume). Gaps below are relative to ACP v1 as
+exposed by `@agentclientprotocol/sdk` and are ordered by practical editor UX.
+Several items are constrained by wrapping `agy --print` and polling its
+conversation database rather than driving agy as a full interactive agent.
+
+### Done
+
+- [x] `initialize`, `session/new`, `session/prompt`, `session/cancel`, `session/close`
+- [x] `session/load` and `session/resume` with persisted bindings
+- [x] `session/set_config_option` (`model`, `effort`, `fast-mode`)
+- [x] `additionalDirectories` → `agy --add-dir`
+- [x] Prompt content: text, image, embedded resource, resource link (`audio: false`)
+- [x] Streamed `session/update`: `agent_message_chunk`, `agent_thought_chunk`,
+      `user_message_chunk` (replay), progressive `tool_call` / `tool_call_update`,
+      `session_info_update`
+- [x] Tool kinds, locations, `rawInput` / `rawOutput`, edit content type `diff`
+- [x] `session/list` from the session store
+- [x] Execute tool output when present in the conversation DB (field 28)
+
+### High priority
+
+- [ ] Interactive `session/request_permission` (today: permission notes only appear as
+      post-hoc text on completed tool calls; agy still owns allow/deny)
+- [ ] Structured `plan` / `plan_update` / `plan_removed` (today: brain/plan files are
+      plain tool content text)
+- [ ] Client terminals: `type: "terminal"` content + `terminal/*` (today: execute tools
+      show command + captured output as content blocks, not live terminal protocol)
+- [ ] ACP elicitation for `ask_question` (today: static tool_call text options)
+- [ ] MCP: honor `session/new` `mcpServers` and advertise real `mcpCapabilities`
+      (today: all MCP caps are `false` and servers are ignored)
+
+### Medium priority
+
+- [ ] Optional `session/delete` from the session store
+- [ ] `session/fork` if/when useful for clients
+- [ ] Session modes (`session/set_mode`, `modes`, `current_mode_update`) if they map
+      cleanly onto agy — today config options cover model/effort/fast-mode
+- [ ] `available_commands_update` for slash-command discovery in the client UI
+- [ ] Push `config_option_update` when options change outside `set_config_option`
+- [ ] `authenticate` / `logout` / `authMethods` (today: require a pre-logged-in `agy`)
+- [ ] `usage_update` and prompt-response `usage` when token data is available
+- [ ] Richer `stopReason` values (`max_tokens`, `refusal`, `max_turn_requests`) when
+      agy exposes them (today: `end_turn` or `cancelled`)
+
+### Fidelity improvements
+
+- [x] Surface command stdout/stderr on execute tool calls when present in the DB
+- [ ] Decode/show fetch and web-search result bodies (not just URL / title)
+- [ ] Agent-outbound images / richer content blocks when agy produces them
+- [ ] Better diffs for full-file writes when prior content is knowable
+- [ ] Map permission decisions into ACP permission outcomes, not only text
+
+### Lower priority / unstable ACP
+
+Usually skip unless a client needs them for this wrapper:
+
+- [ ] `providers/*` (LLM provider routing UI)
+- [ ] `nes/*` (next-edit suggestions)
+- [ ] `document/*` (editor document sync)
+- [ ] Agent-driven client `fs/read_text_file` / `fs/write_text_file` (agy does FS itself)
+- [ ] Non-stdio transports (HTTP / WebSocket) — stdio NDJSON is intentional for Zed
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agy-acp",
-  "version": "1.0.0-alpha.0",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agy-acp",
-      "version": "1.0.0-alpha.0",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agy-acp",
-  "version": "1.0.0-alpha.0",
+  "version": "0.2.5",
   "description": "Agent Client Protocol adapter that wraps the Google Antigravity CLI (ACP v1 + experimental draft ACP v2)",
   "type": "module",
   "author": {

--- a/src/db/step-payload.ts
+++ b/src/db/step-payload.ts
@@ -84,6 +84,18 @@ export interface TitleUpdate {
   title: string;
 }
 
+/**
+ * Step-payload field 28 — run_command result (decoded from real conversation DBs).
+ * Field numbers are load-bearing reverse-engineered facts, not a public schema.
+ */
+export interface CommandResult {
+  cwd: string;
+  exitCode: number;
+  /** Shell stdout/stderr text when present (may include truncation markers). */
+  output: string;
+  command: string;
+}
+
 /** The blob in the `task_details` column. */
 export interface TaskDetails {
   taskId: string;
@@ -103,6 +115,7 @@ export interface StepPayload {
   userPrompt: UserPrompt | undefined;
   agentText: AgentText | undefined;
   titleUpdate: TitleUpdate | undefined;
+  commandResult: CommandResult | undefined;
 }
 
 function decodeToolCall(bytes: Uint8Array): ToolCall {
@@ -202,6 +215,43 @@ function decodeTitleUpdate(bytes: Uint8Array): TitleUpdate {
   return readMessage(bytes, { title: "" }, { 4: (m, r) => (m.title = r.string()) });
 }
 
+/**
+ * Strip leading non-text bytes sometimes present before command output text
+ * (truncation metadata / control chars from the wire format).
+ */
+export function sanitizeCommandOutput(raw: string): string {
+  if (!raw) return raw;
+  let start = 0;
+  while (start < raw.length) {
+    const code = raw.charCodeAt(start);
+    // Keep normal whitespace; drop other C0 controls and DEL.
+    if (code === 0x09 || code === 0x0a || code === 0x0d || (code >= 0x20 && code !== 0x7f)) break;
+    start += 1;
+  }
+  return raw.slice(start);
+}
+
+function decodeCommandResult(bytes: Uint8Array): CommandResult {
+  return readMessage<CommandResult>(
+    bytes,
+    { cwd: "", exitCode: 0, output: "", command: "" },
+    {
+      2: (m, r) => (m.cwd = r.string()),
+      6: (m, r) => (m.exitCode = readInt(r)),
+      21: (m, r) => (m.output = sanitizeCommandOutput(r.string())),
+      // 23 and 25 both carry the command line in observed DBs; prefer first non-empty.
+      23: (m, r) => {
+        const command = r.string();
+        if (!m.command) m.command = command;
+      },
+      25: (m, r) => {
+        const command = r.string();
+        if (!m.command) m.command = command;
+      }
+    }
+  );
+}
+
 export function decodeTaskDetails(bytes: Uint8Array): TaskDetails {
   return readMessage(bytes, { taskId: "", logUri: "", description: "" }, {
     1: (m, r) => (m.taskId = r.string()),
@@ -222,7 +272,8 @@ export function decodeStepPayload(bytes: Uint8Array): StepPayload {
       listDirectory: undefined,
       userPrompt: undefined,
       agentText: undefined,
-      titleUpdate: undefined
+      titleUpdate: undefined,
+      commandResult: undefined
     },
     {
       1: (m, r) => (m.validityCheck = readInt(r)),
@@ -233,6 +284,7 @@ export function decodeStepPayload(bytes: Uint8Array): StepPayload {
       15: (m, r) => (m.listDirectory = readSubmessage(r, decodeListDirectoryResult)),
       19: (m, r) => (m.userPrompt = readSubmessage(r, decodeUserPrompt)),
       20: (m, r) => (m.agentText = readSubmessage(r, decodeAgentText)),
+      28: (m, r) => (m.commandResult = readSubmessage(r, decodeCommandResult)),
       30: (m, r) => (m.titleUpdate = readSubmessage(r, decodeTitleUpdate))
     }
   );

--- a/src/db/tool-call-updates.ts
+++ b/src/db/tool-call-updates.ts
@@ -139,9 +139,31 @@ function toolKind(name: string): ToolKind {
   if (/read|view|list/.test(n)) return "read";
   if (/grep|search|find/.test(n)) return "search";
   if (/command|execute|terminal/.test(n)) return "execute";
-  if (/think|thought|reason|plan/.test(n)) return "think";
+  if (/think|thought|reason/.test(n)) return "think";
   if (/url|fetch/.test(n)) return "fetch";
   return "other";
+}
+
+/** True when a tool name is pure agent reasoning (emit agent_thought_chunk). */
+export function isThoughtToolName(name: string): boolean {
+  return /^(think|thought|reason|reasoning)$/i.test(name.trim());
+}
+
+/** Build an agent_thought_chunk from a think-style tool step. */
+export function thoughtUpdate(stepRow: StepRow): SessionUpdate {
+  const rawInput = parseRawInput(stepRow);
+  const fromInput =
+    asStr(pick(rawInput, "Thought", "thought", "Text", "text", "Content", "content"))?.trim() ?? "";
+  const title =
+    asStr(stepRow.stepPayload.toolRun?.titlePrimary)?.trim() ||
+    asStr(stepRow.stepPayload.toolRun?.titleSecondary)?.trim() ||
+    "";
+  const text = fromInput || title || "Thinking";
+  return {
+    sessionUpdate: "agent_thought_chunk",
+    messageId: toolCallId(stepRow),
+    content: { type: "text", text }
+  } as SessionUpdate;
 }
 
 function pick(o: unknown, ...keys: string[]): unknown {

--- a/src/db/tool-call-updates.ts
+++ b/src/db/tool-call-updates.ts
@@ -286,20 +286,44 @@ export function searchUpdate(stepRow: StepRow, cwd?: string): SessionUpdate {
 /** Step type 21 (run_command): a shell command execution. */
 export function executeUpdate(stepRow: StepRow): SessionUpdate {
   const toolRun = stepRow.stepPayload.toolRun;
+  const commandResult = stepRow.stepPayload.commandResult;
   const rawInput = parseRawInput(stepRow);
-  const command = asStr(pick(rawInput, "CommandLine", "commandLine", "command"));
+  const command =
+    asStr(pick(rawInput, "CommandLine", "commandLine", "command")) ??
+    (commandResult?.command?.trim() ? commandResult.command : null);
   const firstLine = (command?.split("\n")[0] ?? "").trim();
 
   const title =
     firstLine || asStr(toolRun?.titlePrimary)?.trim() || asStr(toolRun?.titleSecondary)?.trim() || "Command Execution";
 
-  const content: Record<string, unknown>[] = command?.trim() ? [codeBlock(command)] : [];
+  const content: Record<string, unknown>[] = [];
+  if (command?.trim()) content.push(codeBlock(command));
+  // Prefer decoded field-28 output over empty; surface when non-empty.
+  const output = commandResult?.output ?? "";
+  if (output.trim()) content.push(codeBlock(output));
 
-  // The only path a run_command exposes is its working directory.
-  const commandCwd = fsPath(asStr(pick(rawInput, "Cwd", "cwd")));
+  // Prefer explicit Cwd from args; fall back to command-result cwd.
+  const commandCwd =
+    fsPath(asStr(pick(rawInput, "Cwd", "cwd"))) ??
+    fsPath(commandResult?.cwd?.trim() ? commandResult.cwd : null);
   const locations = commandCwd ? [{ path: commandCwd }] : [];
 
-  return toolCallUpdate({ stepRow, title, kind: "execute", content, locations });
+  const update = toolCallUpdate({
+    stepRow,
+    title,
+    kind: "execute",
+    content,
+    locations
+  }) as SessionUpdate & { rawOutput?: unknown };
+
+  // Attach structured exit/output when present (without dropping error rawOutput).
+  if (commandResult && !stepRow.error) {
+    update.rawOutput = {
+      exitCode: commandResult.exitCode,
+      ...(output.trim() ? { output } : {})
+    };
+  }
+  return update;
 }
 
 /** Step type 31 (read_url_content): a call-only step; the fetched body isn't decoded. */

--- a/src/db/translator.ts
+++ b/src/db/translator.ts
@@ -16,7 +16,6 @@
 
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { filterNarration, isNarration } from "./narration.js";
-import { toolCallId } from "./tool-call-updates.js";
 import type { StepRow } from "./types.js";
 import { buildUpdatefromStepPayload } from "./updates.js";
 
@@ -37,7 +36,15 @@ function agentChunk(text: string, messageId: string): SessionUpdate {
   };
 }
 
-/** Stable signature of a tool update for progressive re-emission. */
+function thoughtChunk(text: string, messageId: string): SessionUpdate {
+  return {
+    sessionUpdate: "agent_thought_chunk",
+    messageId,
+    content: { type: "text", text }
+  };
+}
+
+/** Stable signature of a tool/thought update for progressive re-emission. */
 function updateSnapshot(update: SessionUpdate): string {
   const raw = update as unknown as Record<string, unknown>;
   return JSON.stringify({
@@ -49,7 +56,9 @@ function updateSnapshot(update: SessionUpdate): string {
     content: raw.content,
     locations: raw.locations,
     rawInput: raw.rawInput,
-    rawOutput: raw.rawOutput
+    rawOutput: raw.rawOutput,
+    messageId: raw.messageId,
+    text: raw.content && typeof raw.content === "object" ? (raw.content as { text?: string }).text : undefined
   });
 }
 
@@ -63,10 +72,10 @@ function asToolCallUpdate(update: SessionUpdate): SessionUpdate {
 export class Translator {
   // Streaming: idx -> chars of agent text already emitted (for incremental diff).
   private readonly agentTextLengths = new Map<number, number>();
+  // Streaming: thought messageId -> chars already emitted.
+  private readonly thoughtTextLengths = new Map<string, number>();
   // Stream + replay: last emitted snapshot keyed by step idx (tool progressive lifecycle).
   private readonly toolSnapshots = new Map<number, string>();
-  // Title-attached think tool cards: emit once per step idx until content changes.
-  private readonly titleThoughtSnapshots = new Map<number, string>();
   // Replay: buffered consecutive agent-text parts, flushed at boundaries.
   private readonly pendingAgentParts: string[] = [];
   // Replay: message id for the current buffered agent-text group.
@@ -106,7 +115,7 @@ export class Translator {
         this.handleAgentText(row, out);
         return;
 
-      case 23: // conversation title
+      case 23: // conversation title (+ optional think narration)
         this.handleTitle(row, out);
         return;
 
@@ -139,12 +148,17 @@ export class Translator {
   }
 
   /**
-   * Emit a tool update, converting subsequent emissions for the same step idx
-   * into `tool_call_update` when the snapshot changes.
+   * Emit a tool/thought update, converting subsequent emissions for the same
+   * step idx into `tool_call_update` when the snapshot changes.
    */
   private emitProgressive(stepIdx: number, update: SessionUpdate, out: SessionUpdate[]): void {
     const raw = update as unknown as Record<string, unknown>;
     const kind = raw.sessionUpdate;
+
+    if (kind === "agent_thought_chunk") {
+      this.emitThought(update, out);
+      return;
+    }
 
     if (kind !== "tool_call" && kind !== "tool_call_update") {
       out.push(update);
@@ -165,6 +179,21 @@ export class Translator {
     out.push(asToolCallUpdate(update));
   }
 
+  private emitThought(update: SessionUpdate, out: SessionUpdate[]): void {
+    const raw = update as unknown as Record<string, unknown>;
+    const content = raw.content as { type?: string; text?: string } | undefined;
+    const text = typeof content?.text === "string" ? content.text : "";
+    const messageId = typeof raw.messageId === "string" && raw.messageId.length > 0 ? raw.messageId : "thought";
+
+    // Stream + replay: emit only the newly appended slice per messageId so
+    // repeated polls of an unchanged thought step produce nothing.
+    const emitted = this.thoughtTextLengths.get(messageId) ?? 0;
+    if (text.length <= emitted) return;
+    this.thoughtTextLengths.set(messageId, text.length);
+    const delta = text.slice(emitted);
+    if (delta.length > 0) out.push(thoughtChunk(delta, messageId));
+  }
+
   private handleTitle(row: StepRow, out: SessionUpdate[]): void {
     const title = row.stepPayload.titleUpdate?.title ?? null;
     const blocks = title?.split("\n\n");
@@ -177,34 +206,8 @@ export class Translator {
     const narration = blocks?.filter((b) => b.trim().length > 0).join("\n\n") ?? "";
     if (!narration) return;
 
-    // Avoid re-emitting the same title-attached Think card on every stream poll.
-    const previous = this.titleThoughtSnapshots.get(row.idx);
-    if (previous === narration) return;
-    this.titleThoughtSnapshots.set(row.idx, narration);
-
-    const thinkUpdate = {
-      sessionUpdate: "tool_call",
-      toolCallId: toolCallId(row),
-      title: "Think",
-      kind: "think",
-      status: "completed",
-      content: [
-        {
-          type: "content",
-          content: {
-            type: "text",
-            text: narration
-          }
-        }
-      ]
-    } as SessionUpdate;
-
-    // First sight for this title step is a create; content changes become updates.
-    if (previous === undefined) {
-      out.push(thinkUpdate);
-    } else {
-      out.push(asToolCallUpdate(thinkUpdate));
-    }
+    // Title-attached "Think" narration is real agent thought, not a tool card.
+    this.emitThought(thoughtChunk(narration, `title-thought-${row.idx}`), out);
   }
 
   private handleAgentText(row: StepRow, out: SessionUpdate[]): void {

--- a/src/db/translator.ts
+++ b/src/db/translator.ts
@@ -4,7 +4,8 @@
 // stream (step type 15):
 //
 //   - streaming emits the newly-appended slice each poll (text grows in place
-//     at a fixed idx), deduping tool steps it has already sent;
+//     at a fixed idx), and re-emits tool steps as `tool_call_update` when their
+//     status/content snapshot changes;
 //   - replay buffers consecutive agent-text parts and flushes them as one
 //     message at each boundary, applying narration filtering across the group.
 //
@@ -36,11 +37,36 @@ function agentChunk(text: string, messageId: string): SessionUpdate {
   };
 }
 
+/** Stable signature of a tool update for progressive re-emission. */
+function updateSnapshot(update: SessionUpdate): string {
+  const raw = update as unknown as Record<string, unknown>;
+  return JSON.stringify({
+    sessionUpdate: raw.sessionUpdate,
+    toolCallId: raw.toolCallId,
+    title: raw.title,
+    kind: raw.kind,
+    status: raw.status,
+    content: raw.content,
+    locations: raw.locations,
+    rawInput: raw.rawInput,
+    rawOutput: raw.rawOutput
+  });
+}
+
+function asToolCallUpdate(update: SessionUpdate): SessionUpdate {
+  return {
+    ...(update as object),
+    sessionUpdate: "tool_call_update"
+  } as SessionUpdate;
+}
+
 export class Translator {
   // Streaming: idx -> chars of agent text already emitted (for incremental diff).
   private readonly agentTextLengths = new Map<number, number>();
-  // Streaming: tool step indices already emitted (dedup across polls).
-  private readonly emittedSteps = new Set<number>();
+  // Stream + replay: last emitted snapshot keyed by step idx (tool progressive lifecycle).
+  private readonly toolSnapshots = new Map<number, string>();
+  // Title-attached think tool cards: emit once per step idx until content changes.
+  private readonly titleThoughtSnapshots = new Map<number, string>();
   // Replay: buffered consecutive agent-text parts, flushed at boundaries.
   private readonly pendingAgentParts: string[] = [];
   // Replay: message id for the current buffered agent-text group.
@@ -93,13 +119,11 @@ export class Translator {
 
       default: {
         // Tool calls and lifecycle steps. In replay, a tool call ends the
-        // current agent message; in streaming, dedup by idx across polls.
+        // current agent message. In both modes, progressive status/content
+        // changes re-emit as tool_call_update.
         if (this.opts.mode === "replay") {
           this.flushAgentBuffer(out);
-        } else if (this.emittedSteps.has(row.idx)) {
-          return;
         }
-        this.emittedSteps.add(row.idx);
         this.pushDispatched(row, out);
       }
     }
@@ -108,10 +132,37 @@ export class Translator {
   private pushDispatched(row: StepRow, out: SessionUpdate[]): void {
     const update = buildUpdatefromStepPayload(row, this.opts.cwd);
     if (Array.isArray(update)) {
-      out.push(...update);
+      for (const item of update) this.emitProgressive(row.idx, item, out);
     } else if (update) {
-      out.push(update);
+      this.emitProgressive(row.idx, update, out);
     }
+  }
+
+  /**
+   * Emit a tool update, converting subsequent emissions for the same step idx
+   * into `tool_call_update` when the snapshot changes.
+   */
+  private emitProgressive(stepIdx: number, update: SessionUpdate, out: SessionUpdate[]): void {
+    const raw = update as unknown as Record<string, unknown>;
+    const kind = raw.sessionUpdate;
+
+    if (kind !== "tool_call" && kind !== "tool_call_update") {
+      out.push(update);
+      return;
+    }
+
+    const snapshot = updateSnapshot(update);
+    const previous = this.toolSnapshots.get(stepIdx);
+    if (previous === undefined) {
+      this.toolSnapshots.set(stepIdx, snapshot);
+      // First sight always uses create shape; v2 boundary may rewrite to upsert.
+      out.push({ ...raw, sessionUpdate: "tool_call" } as SessionUpdate);
+      return;
+    }
+    if (previous === snapshot) return;
+
+    this.toolSnapshots.set(stepIdx, snapshot);
+    out.push(asToolCallUpdate(update));
   }
 
   private handleTitle(row: StepRow, out: SessionUpdate[]): void {
@@ -123,9 +174,15 @@ export class Translator {
       out.push({ sessionUpdate: "session_info_update", title: currentTitle });
     }
 
-    if (!blocks || blocks?.filter((b) => b.trim().length > 0).length === 0) return;
+    const narration = blocks?.filter((b) => b.trim().length > 0).join("\n\n") ?? "";
+    if (!narration) return;
 
-    out.push({
+    // Avoid re-emitting the same title-attached Think card on every stream poll.
+    const previous = this.titleThoughtSnapshots.get(row.idx);
+    if (previous === narration) return;
+    this.titleThoughtSnapshots.set(row.idx, narration);
+
+    const thinkUpdate = {
       sessionUpdate: "tool_call",
       toolCallId: toolCallId(row),
       title: "Think",
@@ -136,12 +193,18 @@ export class Translator {
           type: "content",
           content: {
             type: "text",
-            text: blocks?.join("\n\n") || (currentTitle ?? "")
+            text: narration
           }
         }
       ]
-    });
-    return;
+    } as SessionUpdate;
+
+    // First sight for this title step is a create; content changes become updates.
+    if (previous === undefined) {
+      out.push(thinkUpdate);
+    } else {
+      out.push(asToolCallUpdate(thinkUpdate));
+    }
   }
 
   private handleAgentText(row: StepRow, out: SessionUpdate[]): void {

--- a/src/db/updates.ts
+++ b/src/db/updates.ts
@@ -8,12 +8,13 @@ import {
   editUpdate,
   executeUpdate,
   fetchUpdate,
+  isThoughtToolName,
   otherUpdate,
   questionUpdate,
   readUpdate,
   searchUpdate,
   subagentUpdate,
-  toolCallId
+  thoughtUpdate
 } from "./tool-call-updates.js";
 import type { StepRow } from "./types.js";
 
@@ -38,6 +39,8 @@ function agentUpdate(stepRow: StepRow): SessionUpdate {
 /**
  * Step type 23 — the conversation's title was (re)generated. agy packs an
  * optional "Think" narration after the title, separated by a blank line.
+ * (Streaming/replay also handle type 23 in Translator.handleTitle; this path
+ * remains for direct callers of buildUpdatefromStepPayload.)
  */
 function titleUpdate(stepRow: StepRow): SessionUpdate[] {
   const title = stepRow.stepPayload.titleUpdate?.title || null;
@@ -50,12 +53,9 @@ function titleUpdate(stepRow: StepRow): SessionUpdate[] {
   if (!narration || narration.length === 0) return updates;
 
   updates.push({
-    sessionUpdate: "tool_call",
-    toolCallId: toolCallId(stepRow),
-    title: "Think",
-    kind: "think",
-    status: "completed",
-    content: [{ type: "content", content: { type: "text", text: narration.join("\n\n") } }]
+    sessionUpdate: "agent_thought_chunk",
+    messageId: `title-thought-${stepRow.idx}`,
+    content: { type: "text", text: narration.join("\n\n") }
   });
   return updates;
 }
@@ -102,6 +102,7 @@ function buildByToolName(stepRow: StepRow, cwd?: string): SessionUpdate | Sessio
   const name = stepRow.stepPayload.toolRun?.call?.namePrimary ?? "";
   if (!name) return null;
 
+  if (isThoughtToolName(name)) return thoughtUpdate(stepRow);
   if (name === "view_file" || name === "list_dir") return readUpdate(stepRow, cwd);
   if (name === "grep_search" || name === "search_web") return searchUpdate(stepRow, cwd);
   if (name === "run_command") return executeUpdate(stepRow);

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -225,6 +225,56 @@ describe("session/load and session/resume", () => {
     });
   });
 
+  it("lists persisted sessions after a restart", async () => {
+    await withConversationsDir(async (dir) => {
+      const appOptions = {
+        env: { AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir },
+        spawnProcess: spawnAgyWritingConversation(dir, "conv-list", [
+          { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "listed" }) }
+        ])
+      };
+
+      let sessionId: string;
+      {
+        const connection = acpClient({ name: "test-client" }).connect(createAgyAcpApp(appOptions));
+        try {
+          const session = await connection.agent.request(methods.agent.session.new, {
+            cwd: "/repo",
+            additionalDirectories: ["/extra"],
+            mcpServers: []
+          });
+          sessionId = session.sessionId;
+          await connection.agent.request(methods.agent.session.prompt, {
+            sessionId,
+            prompt: [{ type: "text", text: "hi" }]
+          });
+        } finally {
+          connection.close();
+        }
+      }
+
+      {
+        const connection = acpClient({ name: "test-client" }).connect(createAgyAcpApp(appOptions));
+        try {
+          const listed = await connection.agent.request(methods.agent.session.list, {
+            cwd: "/repo"
+          });
+          expect(listed.sessions).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                sessionId,
+                cwd: "/repo",
+                additionalDirectories: ["/extra"]
+              })
+            ])
+          );
+        } finally {
+          connection.close();
+        }
+      }
+    });
+  });
+
   it("rejects loading a session that was never persisted", async () => {
     await withConversationsDir(async (dir) => {
       const connection = acpClient({ name: "test-client" }).connect(createAgyAcpApp({

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -173,6 +173,38 @@ describe("Translator", () => {
     db.close();
   });
 
+
+  it("emits agent_thought_chunk for title-attached Think narration", () => {
+    const db = createConversationDb(dir, "conv-thought");
+    insertStep(db, {
+      idx: 1,
+      stepType: 23,
+      stepPayload: encodeStepPayload({
+        titleUpdate: "My session\n\nI will inspect the repo structure first."
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-thought")!;
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(0));
+    conn.close();
+
+    expect(updates).toEqual([
+      { sessionUpdate: "session_info_update", title: "My session" },
+      {
+        sessionUpdate: "agent_thought_chunk",
+        messageId: "title-thought-1",
+        content: { type: "text", text: "I will inspect the repo structure first." }
+      }
+    ]);
+
+    // Second poll: no duplicate thought/title.
+    const conn2 = ConversationDb.open(dir, "conv-thought")!;
+    expect(translator.translate(conn2.readAfter(0))).toHaveLength(0);
+    conn2.close();
+  });
+
   it("buffers consecutive agent-text parts into one message in replay mode", () => {
     const db = createConversationDb(dir, "conv-4");
     insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "Hello" }) });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -7,7 +7,13 @@ import { ReplayCache } from "../src/db/replay.js";
 import { conversationSnapshot, newConversationId } from "../src/db/scan.js";
 import { Translator } from "../src/db/translator.js";
 import { createConversationDb, insertStep, updateStep, updateStepPayload } from "./fixtures/conversation-db.js";
-import { encodeAgentText, encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
+import {
+  encodeAgentText,
+  encodeCommandResult,
+  encodeStepPayload,
+  encodeToolCall,
+  encodeToolRun
+} from "./fixtures/step-encoder.js";
 
 let dir: string;
 
@@ -153,7 +159,18 @@ describe("Translator", () => {
       }
     ]);
 
-    updateStep(db, 1, { status: 3 });
+    updateStep(db, 1, {
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({ call }),
+        commandResult: encodeCommandResult({
+          cwd: "/repo",
+          exitCode: 0,
+          output: "hi\n",
+          command: "echo hi"
+        })
+      })
+    });
 
     const second = translator.translate(conn.readAfter(0));
     expect(second).toMatchObject([
@@ -165,6 +182,9 @@ describe("Translator", () => {
         title: "echo hi"
       }
     ]);
+    const content = (second[0] as { content?: Array<{ content?: { text?: string } }> }).content ?? [];
+    const texts = content.map((c) => c.content?.text ?? "").join("\n");
+    expect(texts).toContain("hi");
 
     // Unchanged snapshot: no third emission.
     expect(translator.translate(conn.readAfter(0))).toHaveLength(0);
@@ -203,6 +223,50 @@ describe("Translator", () => {
     const conn2 = ConversationDb.open(dir, "conv-thought")!;
     expect(translator.translate(conn2.readAfter(0))).toHaveLength(0);
     conn2.close();
+  });
+
+
+  it("surfaces commandResult output on execute tool calls", () => {
+    const db = createConversationDb(dir, "conv-exec-out");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "c-out",
+            namePrimary: "run_command",
+            rawInputJson: '{"CommandLine":"ls","Cwd":"/repo"}'
+          })
+        }),
+        commandResult: encodeCommandResult({
+          cwd: "/repo",
+          exitCode: 0,
+          output: "README.md\n",
+          command: "ls"
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-exec-out")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as {
+      sessionUpdate: string;
+      kind: string;
+      rawOutput?: { exitCode?: number; output?: string };
+      content?: Array<{ content?: { text?: string } }>;
+    };
+    expect(update.sessionUpdate).toBe("tool_call");
+    expect(update.kind).toBe("execute");
+    expect(update.rawOutput).toMatchObject({ exitCode: 0, output: "README.md\n" });
+    const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
+    expect(body).toContain("README.md");
   });
 
   it("buffers consecutive agent-text parts into one message in replay mode", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -6,7 +6,7 @@ import { ConversationDb } from "../src/db/database.js";
 import { ReplayCache } from "../src/db/replay.js";
 import { conversationSnapshot, newConversationId } from "../src/db/scan.js";
 import { Translator } from "../src/db/translator.js";
-import { createConversationDb, insertStep, updateStepPayload } from "./fixtures/conversation-db.js";
+import { createConversationDb, insertStep, updateStep, updateStepPayload } from "./fixtures/conversation-db.js";
 import { encodeAgentText, encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 
 let dir: string;
@@ -101,11 +101,12 @@ describe("Translator", () => {
     db.close();
   });
 
-  it("dedupes tool-call steps across repeated polls in stream mode", () => {
+  it("dedupes unchanged tool-call steps across repeated polls in stream mode", () => {
     const db = createConversationDb(dir, "conv-3");
     insertStep(db, {
       idx: 1,
       stepType: 21,
+      status: 3,
       stepPayload: encodeStepPayload({
         toolRun: encodeToolRun({ call: encodeToolCall({ namePrimary: "run_command", rawInputJson: "{}" }) })
       })
@@ -116,6 +117,57 @@ describe("Translator", () => {
 
     expect(translator.translate(conn.readAfter(0))).toHaveLength(1);
     expect(translator.translate(conn.readAfter(0))).toHaveLength(0); // already emitted
+
+    conn.close();
+    db.close();
+  });
+
+
+  it("emits tool_call then tool_call_update when status progresses on the same idx", () => {
+    const db = createConversationDb(dir, "conv-tool-progress");
+    const call = encodeToolCall({
+      callId: "cmd-1",
+      namePrimary: "run_command",
+      rawInputJson: '{"CommandLine":"echo hi"}'
+    });
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 2, // in_progress
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({ call })
+      })
+    });
+
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const conn = ConversationDb.open(dir, "conv-tool-progress")!;
+
+    const first = translator.translate(conn.readAfter(0));
+    expect(first).toMatchObject([
+      {
+        sessionUpdate: "tool_call",
+        toolCallId: "cmd-1",
+        kind: "execute",
+        status: "in_progress",
+        title: "echo hi"
+      }
+    ]);
+
+    updateStep(db, 1, { status: 3 });
+
+    const second = translator.translate(conn.readAfter(0));
+    expect(second).toMatchObject([
+      {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "cmd-1",
+        kind: "execute",
+        status: "completed",
+        title: "echo hi"
+      }
+    ]);
+
+    // Unchanged snapshot: no third emission.
+    expect(translator.translate(conn.readAfter(0))).toHaveLength(0);
 
     conn.close();
     db.close();

--- a/tests/fixtures/conversation-db.ts
+++ b/tests/fixtures/conversation-db.ts
@@ -26,3 +26,24 @@ export function insertStep(
 export function updateStepPayload(db: Database.Database, idx: number, stepPayload: Uint8Array): void {
   db.prepare("UPDATE steps SET step_payload = ? WHERE idx = ?").run(Buffer.from(stepPayload), idx);
 }
+
+export function updateStepStatus(db: Database.Database, idx: number, status: number): void {
+  db.prepare("UPDATE steps SET status = ? WHERE idx = ?").run(status, idx);
+}
+
+export function updateStep(
+  db: Database.Database,
+  idx: number,
+  patch: { status?: number; stepPayload?: Uint8Array }
+): void {
+  if (patch.status !== undefined && patch.stepPayload !== undefined) {
+    db.prepare("UPDATE steps SET status = ?, step_payload = ? WHERE idx = ?").run(
+      patch.status,
+      Buffer.from(patch.stepPayload),
+      idx
+    );
+    return;
+  }
+  if (patch.status !== undefined) updateStepStatus(db, idx, patch.status);
+  if (patch.stepPayload !== undefined) updateStepPayload(db, idx, patch.stepPayload);
+}

--- a/tests/fixtures/step-encoder.ts
+++ b/tests/fixtures/step-encoder.ts
@@ -48,16 +48,35 @@ export function encodeUserPrompt(text: string): Uint8Array {
   return w.finish();
 }
 
+export function encodeCommandResult(result: {
+  cwd?: string;
+  exitCode?: number;
+  output?: string;
+  command?: string;
+}): Uint8Array {
+  const w = new BinaryWriter();
+  if (result.cwd) w.tag(2, 2).string(result.cwd);
+  if (result.exitCode !== undefined) w.tag(6, 0).int64(result.exitCode);
+  if (result.output) w.tag(21, 2).string(result.output);
+  if (result.command) {
+    w.tag(23, 2).string(result.command);
+    w.tag(25, 2).string(result.command);
+  }
+  return w.finish();
+}
+
 export function encodeStepPayload(opts: {
   toolRun?: Uint8Array;
   agentText?: string;
   titleUpdate?: string;
   userPrompt?: string;
+  commandResult?: Uint8Array;
 }): Uint8Array {
   const w = new BinaryWriter();
   if (opts.toolRun) submessage(w, 5, opts.toolRun);
-  if (opts.agentText !== undefined) submessage(w, 20, encodeAgentText(opts.agentText));
-  if (opts.titleUpdate !== undefined) submessage(w, 30, encodeTitleUpdate(opts.titleUpdate));
   if (opts.userPrompt !== undefined) submessage(w, 19, encodeUserPrompt(opts.userPrompt));
+  if (opts.agentText !== undefined) submessage(w, 20, encodeAgentText(opts.agentText));
+  if (opts.commandResult) submessage(w, 28, opts.commandResult);
+  if (opts.titleUpdate !== undefined) submessage(w, 30, encodeTitleUpdate(opts.titleUpdate));
   return w.finish();
 }


### PR DESCRIPTION
## Summary

Stable **0.2.5** release for the ACP v1 editor UX track (package version `0.2.5` → npm `latest` after tag).

- Progressive `tool_call` → `tool_call_update` when conversation steps change status/content across stream polls
- Real `agent_thought_chunk` for title-attached Think narration and think-style tools
- Decode `run_command` result payload (DB field 28) and surface stdout + `rawOutput.exitCode`
- `session/list` coverage across server restarts
- Version bump, CHANGELOG, README/roadmap updates

## Commits

1. Emit progressive tool_call updates as step status changes
2. Emit agent_thought_chunk for think narration
3. Surface run_command stdout from conversation DB field 28
4. Add session/list coverage across server restarts
5. Release 0.2.5 (+ CHANGELOG tweak)

## Test plan

- [x] `npm test` (51 tests)
- [ ] CI green on this PR
- [ ] After merge to `main`, tag `v0.2.5` and confirm GitHub Release + npm `latest` publish
- [ ] Smoke in Zed: tool cards progress in-flight → completed; think shows as thoughts; execute shows output when present