### PR TITLE
Release 0.2.6: search/fetch bodies, write diffs, permission labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-07-22
+
+Stable ACP v1 fidelity release: richer tool result bodies and better editor diffs,
+without interactive permission / terminal / MCP control-plane work (still blocked
+on wrapping `agy --print`).
+
+### Added
+
+- Decode `search_web` result metadata (step field 42): query and refined query /
+  search URL when present. Hit lists are not persisted by agy.
+- Decode `read_url_content` results (step field 40): URL, title, description, and
+  body text (truncated for display) plus optional brain `contentPath`.
+- Full-file write diffs use prior `view_file` / write content as `oldText` when
+  the same translator pass has seen that path (stream + full replay).
+
+### Changed
+
+- Permission notes label outcomes from the decision varint (`granted` / `denied`
+  instead of only “requested”).
+- Brain plan artifact writes use clearer `Plan:` titles when the filename does
+  not already contain “plan”.
+- Fetch titles prefer the URL when agy only stores the generic “Live Content”
+  label; full-file write cache ignores ranged `view_file` slices.
+
 ## [0.2.5] - 2026-07-22
 
 Stable release focused on ACP v1 editor UX. Dual-protocol draft ACP v2 support

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The implementation is a TypeScript, `npx`-runnable ACP server built on
 keeps the adapter aligned with the logged-in Antigravity CLI experience and
 avoids a separate runtime startup path.
 
-**Current package:** `0.2.5` (`latest`). Supports **ACP v1** and
+**Current package:** `0.2.6` (`latest`). Supports **ACP v1** and
 **experimental draft ACP v2** side by side via version negotiation on
 `initialize`. Draft ACP v2 work continues on the `alpha` dist-tag
 (`1.0.0-alpha.*`). See the [ACP v2 draft announcement](https://agentclientprotocol.com/announcements/acp-v2-draft)
@@ -225,13 +225,20 @@ conversation database rather than driving agy as a full interactive agent.
 - [x] Tool kinds, locations, `rawInput` / `rawOutput`, edit content type `diff`
 - [x] `session/list` from the session store
 - [x] Execute tool output when present in the conversation DB (field 28)
+- [x] Decode/show fetch and web-search result bodies when present in the DB
+      (search_web hit lists are not persisted by agy; query metadata only)
+- [x] Full-file write diffs with prior content when known from earlier view/write steps
+- [x] Permission notes map decision varint to granted/denied labels (still not interactive)
 
 ### High priority
 
-- [ ] Interactive `session/request_permission` (today: permission notes only appear as
-      post-hoc text on completed tool calls; agy still owns allow/deny)
+These need more than conversation-DB polling (interactive agy control plane or
+client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
+
+- [ ] Interactive `session/request_permission` (today: post-hoc granted/denied text;
+      agy still owns allow/deny under `--print`)
 - [ ] Structured `plan` / `plan_update` / `plan_removed` (today: brain/plan files are
-      plain tool content text)
+      prose tool content with Plan titles — not ACP plan updates)
 - [ ] Client terminals: `type: "terminal"` content + `terminal/*` (today: execute tools
       show command + captured output as content blocks, not live terminal protocol)
 - [ ] ACP elicitation for `ask_question` (today: static tool_call text options)
@@ -254,10 +261,10 @@ conversation database rather than driving agy as a full interactive agent.
 ### Fidelity improvements
 
 - [x] Surface command stdout/stderr on execute tool calls when present in the DB
-- [ ] Decode/show fetch and web-search result bodies (not just URL / title)
+- [x] Decode/show fetch and web-search result bodies (not just URL / title)
+- [x] Better diffs for full-file writes when prior content is knowable
+- [x] Map permission decisions into granted/denied labels (not interactive outcomes)
 - [ ] Agent-outbound images / richer content blocks when agy produces them
-- [ ] Better diffs for full-file writes when prior content is knowable
-- [ ] Map permission decisions into ACP permission outcomes, not only text
 
 ### Lower priority / unstable ACP
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agy-acp",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agy-acp",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agy-acp",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Agent Client Protocol adapter that wraps the Google Antigravity CLI (ACP v1 + experimental draft ACP v2)",
   "type": "module",
   "author": {

--- a/src/db/step-payload.ts
+++ b/src/db/step-payload.ts
@@ -10,6 +10,7 @@
 // than a generated client, built on the generic `readMessage` walker in
 // ./protowire.ts instead of one bespoke switch statement per message.
 
+import { BinaryReader } from "@bufbuild/protobuf/wire";
 import { readInt, readMessage, readSubmessage } from "./protowire.js";
 
 export interface ToolCall {
@@ -96,6 +97,31 @@ export interface CommandResult {
   command: string;
 }
 
+/**
+ * Step-payload field 42 — search_web result metadata.
+ * Full hit lists are not persisted by agy; only query / refined query (or
+ * search URL) appear in the conversation DB.
+ */
+export interface WebSearchResult {
+  query: string;
+  /** Refined query text, or a Google search URL, depending on the step. */
+  refinedQueryOrUrl: string;
+}
+
+/**
+ * Step-payload field 40 — read_url_content result.
+ * Body text is often huge HTML; callers should truncate for UI display.
+ */
+export interface UrlContentResult {
+  url: string;
+  title: string;
+  description: string;
+  /** Fetched document body when embedded in the payload. */
+  body: string;
+  /** Optional path to a brain artifact with the full content. */
+  contentPath: string;
+}
+
 /** The blob in the `task_details` column. */
 export interface TaskDetails {
   taskId: string;
@@ -116,6 +142,8 @@ export interface StepPayload {
   agentText: AgentText | undefined;
   titleUpdate: TitleUpdate | undefined;
   commandResult: CommandResult | undefined;
+  webSearch: WebSearchResult | undefined;
+  urlContent: UrlContentResult | undefined;
 }
 
 function decodeToolCall(bytes: Uint8Array): ToolCall {
@@ -252,6 +280,93 @@ function decodeCommandResult(bytes: Uint8Array): CommandResult {
   );
 }
 
+function decodeWebSearchResult(bytes: Uint8Array): WebSearchResult {
+  return readMessage(bytes, { query: "", refinedQueryOrUrl: "" }, {
+    1: (m, r) => (m.query = r.string()),
+    5: (m, r) => (m.refinedQueryOrUrl = r.string())
+  });
+}
+
+/** Walk nested url-content document wrappers to find the largest text body. */
+function extractLargestString(bytes: Uint8Array, depth = 0): string {
+  if (depth > 6) return "";
+  let best = "";
+  // Manual walk so every string field is considered (body field numbers vary).
+  const reader = new BinaryReader(bytes);
+  while (reader.pos < reader.len) {
+    const tag = reader.uint32();
+    const wire = tag & 7;
+    if (wire === 0) {
+      reader.int64();
+    } else if (wire === 1) {
+      reader.skip(1);
+    } else if (wire === 5) {
+      reader.skip(5);
+    } else if (wire === 2) {
+      const slice = reader.bytes();
+      let asStr: string | null = null;
+      try {
+        asStr = new TextDecoder("utf-8", { fatal: true }).decode(slice);
+      } catch {
+        asStr = null;
+      }
+      if (asStr !== null && !asStr.includes("\0") && asStr.length > best.length) {
+        // Prefer printable document bodies over tiny labels.
+        best = asStr;
+      }
+      if (slice.length > 32) {
+        const nested = extractLargestString(slice, depth + 1);
+        if (nested.length > best.length) best = nested;
+      }
+    } else {
+      break;
+    }
+  }
+  return best;
+}
+
+function decodeUrlContentDocument(bytes: Uint8Array): {
+  title: string;
+  description: string;
+  body: string;
+} {
+  const doc = readMessage(bytes, { title: "", description: "", body: "" }, {
+    4: (m, r) => (m.title = r.string()),
+    6: (m, r) => {
+      // Nested content wrapper: dig for the largest embedded string as body.
+      const nested = r.bytes();
+      const body = extractLargestString(nested);
+      if (body.length > m.body.length) m.body = body;
+    },
+    7: (m, r) => (m.description = r.string())
+  });
+  return doc;
+}
+
+function decodeUrlContentResult(bytes: Uint8Array): UrlContentResult {
+  return readMessage<UrlContentResult>(
+    bytes,
+    { url: "", title: "", description: "", body: "", contentPath: "" },
+    {
+      1: (m, r) => {
+        const url = r.string();
+        if (!m.url) m.url = url;
+      },
+      2: (m, r) => {
+        const doc = readSubmessage(r, decodeUrlContentDocument);
+        if (doc.title) m.title = doc.title;
+        if (doc.description) m.description = doc.description;
+        if (doc.body) m.body = doc.body;
+      },
+      3: (m, r) => {
+        const url = r.string();
+        if (!m.url) m.url = url;
+      },
+      6: (m, r) => (m.contentPath = r.string())
+    }
+  );
+}
+
 export function decodeTaskDetails(bytes: Uint8Array): TaskDetails {
   return readMessage(bytes, { taskId: "", logUri: "", description: "" }, {
     1: (m, r) => (m.taskId = r.string()),
@@ -273,7 +388,9 @@ export function decodeStepPayload(bytes: Uint8Array): StepPayload {
       userPrompt: undefined,
       agentText: undefined,
       titleUpdate: undefined,
-      commandResult: undefined
+      commandResult: undefined,
+      webSearch: undefined,
+      urlContent: undefined
     },
     {
       1: (m, r) => (m.validityCheck = readInt(r)),
@@ -285,7 +402,9 @@ export function decodeStepPayload(bytes: Uint8Array): StepPayload {
       19: (m, r) => (m.userPrompt = readSubmessage(r, decodeUserPrompt)),
       20: (m, r) => (m.agentText = readSubmessage(r, decodeAgentText)),
       28: (m, r) => (m.commandResult = readSubmessage(r, decodeCommandResult)),
-      30: (m, r) => (m.titleUpdate = readSubmessage(r, decodeTitleUpdate))
+      30: (m, r) => (m.titleUpdate = readSubmessage(r, decodeTitleUpdate)),
+      40: (m, r) => (m.urlContent = readSubmessage(r, decodeUrlContentResult)),
+      42: (m, r) => (m.webSearch = readSubmessage(r, decodeWebSearchResult))
     }
   );
 }

--- a/src/db/step-payload.ts
+++ b/src/db/step-payload.ts
@@ -287,11 +287,33 @@ function decodeWebSearchResult(bytes: Uint8Array): WebSearchResult {
   });
 }
 
-/** Walk nested url-content document wrappers to find the largest text body. */
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+/**
+ * Extract the fetched document body from the nested url-content wrapper.
+ * Observed layout: field 6 → field 3 → field 2 (string body). Falls back to
+ * the largest nested UTF-8 string when field numbers differ.
+ */
+function extractUrlContentBody(bytes: Uint8Array): string {
+  let body = "";
+  readMessage(bytes, {}, {
+    3: (_m, r) => {
+      const inner = r.bytes();
+      readMessage(inner, {}, {
+        2: (_m2, r2) => {
+          body = r2.string();
+        }
+      });
+    }
+  });
+  if (body) return body;
+  return extractLargestString(bytes);
+}
+
+/** Fallback walker: largest nested UTF-8 string (does not re-parse text as protobuf). */
 function extractLargestString(bytes: Uint8Array, depth = 0): string {
   if (depth > 6) return "";
   let best = "";
-  // Manual walk so every string field is considered (body field numbers vary).
   const reader = new BinaryReader(bytes);
   while (reader.pos < reader.len) {
     const tag = reader.uint32();
@@ -306,13 +328,15 @@ function extractLargestString(bytes: Uint8Array, depth = 0): string {
       const slice = reader.bytes();
       let asStr: string | null = null;
       try {
-        asStr = new TextDecoder("utf-8", { fatal: true }).decode(slice);
+        asStr = utf8Decoder.decode(slice);
       } catch {
         asStr = null;
       }
-      if (asStr !== null && !asStr.includes("\0") && asStr.length > best.length) {
-        // Prefer printable document bodies over tiny labels.
-        best = asStr;
+      if (asStr !== null && !asStr.includes("\0")) {
+        // Valid UTF-8 text: take it if longest, but do not re-walk as a message
+        // (re-parsing HTML/JSON as protobuf is expensive and meaningless).
+        if (asStr.length > best.length) best = asStr;
+        continue;
       }
       if (slice.length > 32) {
         const nested = extractLargestString(slice, depth + 1);
@@ -333,9 +357,8 @@ function decodeUrlContentDocument(bytes: Uint8Array): {
   const doc = readMessage(bytes, { title: "", description: "", body: "" }, {
     4: (m, r) => (m.title = r.string()),
     6: (m, r) => {
-      // Nested content wrapper: dig for the largest embedded string as body.
       const nested = r.bytes();
-      const body = extractLargestString(nested);
+      const body = extractUrlContentBody(nested);
       if (body.length > m.body.length) m.body = body;
     },
     7: (m, r) => (m.description = r.string())

--- a/src/db/tool-call-updates.ts
+++ b/src/db/tool-call-updates.ts
@@ -8,6 +8,19 @@ import type { ErrorDetails, PermissionInfo, TaskDetails } from "./columns.js";
 import type { SearchHit } from "./step-payload.js";
 import type { StepRow } from "./types.js";
 
+/** Absolute path -> last known file body from prior view_file / write steps. */
+export type FileContentCache = Map<string, string>;
+
+/** Options shared by tool builders that need project context. */
+export interface UpdateContext {
+  cwd?: string;
+  /** Prior file contents for full-file write diffs. */
+  fileContents?: FileContentCache;
+}
+
+/** Cap on fetched URL / large tool bodies surfaced in session updates. */
+export const MAX_TOOL_BODY_CHARS = 32_000;
+
 // --- shared helpers ----------------------------------------------------------
 
 /** Parse the JSON-encoded tool arguments (`toolRun.call.rawInputJson`), tolerating
@@ -69,6 +82,12 @@ function errorBlock(e: ErrorDetails): Record<string, unknown> {
 function permissionBlock(p: PermissionInfo): Record<string, unknown> {
   const target = p.value.trim() ? ` (${p.value.trim()})` : "";
   return textBlock(`Permission requested: ${p.kind || "unknown"}${target}`);
+}
+
+/** Truncate a large tool body for editor-friendly display. */
+export function truncateToolBody(text: string, max = MAX_TOOL_BODY_CHARS): { text: string; truncated: boolean } {
+  if (text.length <= max) return { text, truncated: false };
+  return { text: `${text.slice(0, max)}\n… (truncated, ${text.length - max} more chars)`, truncated: true };
 }
 
 function taskBlock(t: TaskDetails): Record<string, unknown> {
@@ -203,7 +222,8 @@ function fsPath(p: string | null | undefined): string | null {
 // versions (`TargetFile` vs `targetFile`), so every lookup below tries both.
 
 /** Step types 8/9/17(view_file|list_dir): a file read or directory listing. */
-export function readUpdate(stepRow: StepRow, cwd?: string): SessionUpdate {
+export function readUpdate(stepRow: StepRow, ctx?: UpdateContext | string): SessionUpdate {
+  const cwd = typeof ctx === "string" ? ctx : ctx?.cwd;
   const { stepPayload, stepType } = stepRow;
   const toolRun = stepPayload.toolRun;
   const rawInput = parseRawInput(stepRow);
@@ -254,7 +274,8 @@ function renderHits(hits: SearchHit[] | undefined): string {
 }
 
 /** Step types 7/33(grep_search|search_web): a filesystem or web search. */
-export function searchUpdate(stepRow: StepRow, cwd?: string): SessionUpdate {
+export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext | string): SessionUpdate {
+  const cwd = typeof ctx === "string" ? ctx : ctx?.cwd;
   const { stepPayload, stepType } = stepRow;
   const name = stepPayload.toolRun?.call?.namePrimary ?? "";
   const rawInput = parseRawInput(stepRow);
@@ -275,9 +296,19 @@ export function searchUpdate(stepRow: StepRow, cwd?: string): SessionUpdate {
     const body = asStr(grep?.textOutput)?.trim() || renderHits(grep?.hits) || asStr(grep?.shellCommand)?.trim();
     if (body) content.push(codeBlock(body));
   } else {
-    // search_web is call-only (no result body decoded into the payload).
-    const query = asStr(pick(rawInput, "query", "Query"))?.trim() ?? "";
+    // search_web: field 42 carries query metadata; hit lists are not persisted.
+    const web = stepPayload.webSearch;
+    const query =
+      asStr(web?.query)?.trim() || asStr(pick(rawInput, "query", "Query"))?.trim() || "";
     title = query ? `Web search ${query}` : "Web search";
+
+    const lines: string[] = [];
+    if (query) lines.push(`Query: ${query}`);
+    const secondary = asStr(web?.refinedQueryOrUrl)?.trim() ?? "";
+    if (secondary && secondary !== query) {
+      lines.push(secondary.startsWith("http") ? `URL: ${secondary}` : `Refined: ${secondary}`);
+    }
+    if (lines.length > 0) content.push(codeBlock(lines.join("\n")));
   }
 
   return toolCallUpdate({ stepRow, title, kind: "search", content, locations });
@@ -326,20 +357,57 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
   return update;
 }
 
-/** Step type 31 (read_url_content): a call-only step; the fetched body isn't decoded. */
+/** Step type 31 (read_url_content): fetch URL + optional decoded body (field 40). */
 export function fetchUpdate(stepRow: StepRow): SessionUpdate {
   const toolRun = stepRow.stepPayload.toolRun;
   const rawInput = parseRawInput(stepRow);
-  const url = asStr(pick(rawInput, "Url", "url"))?.trim();
+  const urlContent = stepRow.stepPayload.urlContent;
+  const url =
+    asStr(urlContent?.url)?.trim() || asStr(pick(rawInput, "Url", "url"))?.trim() || "";
 
+  const docTitle = asStr(urlContent?.title)?.trim() || "";
   const title =
+    (docTitle ? `Fetch ${docTitle}` : null) ||
     (url ? `Fetch ${url}` : null) ||
     asStr(toolRun?.titlePrimary)?.trim() ||
     asStr(toolRun?.titleSecondary)?.trim() ||
     "Fetch URL";
 
-  return toolCallUpdate({ stepRow, title, kind: "fetch", content: url ? [textBlock(url)] : [] });
+  const content: Record<string, unknown>[] = [];
+  if (url) content.push(textBlock(url));
+  const description = asStr(urlContent?.description)?.trim() || "";
+  if (docTitle || description) {
+    const meta = [docTitle && `Title: ${docTitle}`, description && `Description: ${description}`]
+      .filter(Boolean)
+      .join("\n");
+    if (meta) content.push(textBlock(meta));
+  }
+
+  const body = asStr(urlContent?.body) ?? "";
+  let truncated = false;
+  if (body.trim()) {
+    const sliced = truncateToolBody(body);
+    truncated = sliced.truncated;
+    content.push(codeBlock(sliced.text));
+  }
+
+  const update = toolCallUpdate({ stepRow, title, kind: "fetch", content }) as SessionUpdate & {
+    rawOutput?: unknown;
+  };
+
+  if (urlContent && !stepRow.error) {
+    update.rawOutput = {
+      url: url || undefined,
+      title: docTitle || undefined,
+      description: description || undefined,
+      contentPath: urlContent.contentPath || undefined,
+      bodyChars: body.length || undefined,
+      truncated: truncated || undefined
+    };
+  }
+  return update;
 }
+
 
 function isPlanFile(targetFile: string): boolean {
   return (
@@ -352,7 +420,8 @@ function isPlanFile(targetFile: string): boolean {
 
 /** Step type 5 (write_to_file|replace_file_content|multi_replace_file_content),
  *  and step 17 artifact writes (e.g. a generated `plan.md` for user review). */
-export function editUpdate(stepRow: StepRow, cwd?: string): SessionUpdate | SessionUpdate[] {
+export function editUpdate(stepRow: StepRow, ctx?: UpdateContext | string): SessionUpdate | SessionUpdate[] {
+  const cwd = typeof ctx === "string" ? ctx : ctx?.cwd;
   const rawInput = parseRawInput(stepRow);
   const displayCwd = fsPath(cwd) ?? undefined;
 

--- a/src/db/tool-call-updates.ts
+++ b/src/db/tool-call-updates.ts
@@ -224,6 +224,7 @@ function fsPath(p: string | null | undefined): string | null {
 /** Step types 8/9/17(view_file|list_dir): a file read or directory listing. */
 export function readUpdate(stepRow: StepRow, ctx?: UpdateContext | string): SessionUpdate {
   const cwd = typeof ctx === "string" ? ctx : ctx?.cwd;
+  const fileContents = typeof ctx === "string" ? undefined : ctx?.fileContents;
   const { stepPayload, stepType } = stepRow;
   const toolRun = stepPayload.toolRun;
   const rawInput = parseRawInput(stepRow);
@@ -258,7 +259,13 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext | string): Sess
     if (filePath) locations.push({ path: filePath, line: startLine });
 
     const body = asStr(view?.content);
-    if (body) content.push(codeBlock(body));
+    if (body) {
+      content.push(codeBlock(body));
+      // Remember full-file (or ranged) view content for later write diffs.
+      if (filePath && fileContents) {
+        fileContents.set(path.resolve(filePath), body);
+      }
+    }
   }
 
   return toolCallUpdate({ stepRow, title, kind: "read", content, locations });
@@ -422,13 +429,21 @@ function isPlanFile(targetFile: string): boolean {
  *  and step 17 artifact writes (e.g. a generated `plan.md` for user review). */
 export function editUpdate(stepRow: StepRow, ctx?: UpdateContext | string): SessionUpdate | SessionUpdate[] {
   const cwd = typeof ctx === "string" ? ctx : ctx?.cwd;
+  const fileContents = typeof ctx === "string" ? undefined : ctx?.fileContents;
   const rawInput = parseRawInput(stepRow);
   const displayCwd = fsPath(cwd) ?? undefined;
 
   const targetFile = fsPath(asStr(pick(rawInput, "TargetFile", "targetFile"))) ?? "";
   const isPlan = isPlanFile(targetFile);
   const shown = targetFile ? toDisplayPath(targetFile, displayCwd) : "";
-  const title = isPlan ? (shown.split("/").pop() ?? "Implementation Plan") : shown ? `Edit ${shown}` : "Edit";
+  const planName = shown.split("/").pop() ?? "plan.md";
+  const title = isPlan
+    ? planName.toLowerCase().includes("plan")
+      ? planName
+      : `Plan: ${planName}`
+    : shown
+      ? `Edit ${shown}`
+      : "Edit";
 
   const content: Record<string, unknown>[] = [];
   const locations: Record<string, unknown>[] = [];
@@ -437,9 +452,15 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext | string): Sess
   if (fullContent !== null) {
     // write_to_file: the whole file content is the new text.
     if (isPlan) {
-      content.push(textBlock(fullContent)); // plans are user-facing prose, not a code diff
+      // Plans are user-facing prose (brain artifacts), not code diffs.
+      content.push(textBlock(fullContent));
     } else if (targetFile) {
-      content.push({ type: "diff", path: targetFile, oldText: null, newText: fullContent });
+      // Prefer prior view_file/write content as oldText when known; otherwise null
+      // (new file or prior content never observed in this translator pass).
+      const cacheKey = path.resolve(targetFile);
+      const prior = fileContents?.get(cacheKey) ?? null;
+      content.push({ type: "diff", path: targetFile, oldText: prior, newText: fullContent });
+      fileContents?.set(cacheKey, fullContent);
     }
     if (targetFile) locations.push({ path: targetFile });
   } else if (!isPlan) {

--- a/src/db/tool-call-updates.ts
+++ b/src/db/tool-call-updates.ts
@@ -79,9 +79,25 @@ function errorBlock(e: ErrorDetails): Record<string, unknown> {
   return codeBlock(`Error: ${message}${detail}`);
 }
 
+/** Map agy permission decision varint to a short outcome label.
+ *  Observed values: 0 = denied, 1 = granted. */
+export function permissionOutcome(decision: number): "denied" | "granted" | "unknown" {
+  if (decision === 0) return "denied";
+  if (decision === 1) return "granted";
+  return "unknown";
+}
+
 function permissionBlock(p: PermissionInfo): Record<string, unknown> {
   const target = p.value.trim() ? ` (${p.value.trim()})` : "";
-  return textBlock(`Permission requested: ${p.kind || "unknown"}${target}`);
+  const kind = p.kind || "unknown";
+  const outcome = permissionOutcome(p.decision);
+  const label =
+    outcome === "denied"
+      ? `Permission denied: ${kind}${target}`
+      : outcome === "granted"
+        ? `Permission granted: ${kind}${target}`
+        : `Permission requested: ${kind}${target}`;
+  return textBlock(label);
 }
 
 /** Truncate a large tool body for editor-friendly display. */
@@ -414,7 +430,6 @@ export function fetchUpdate(stepRow: StepRow): SessionUpdate {
   }
   return update;
 }
-
 
 function isPlanFile(targetFile: string): boolean {
   return (

--- a/src/db/tool-call-updates.ts
+++ b/src/db/tool-call-updates.ts
@@ -237,10 +237,31 @@ function fsPath(p: string | null | undefined): string | null {
 // agy's rawInputJson keys are inconsistently PascalCase/camelCase across tool
 // versions (`TargetFile` vs `targetFile`), so every lookup below tries both.
 
+/**
+ * True when a view_file step looks safe to cache as the full file body for
+ * later write diffs. Reject mid-file slices; accept start-at-beginning reads
+ * that either omit an end bound or reach the file's reported total.
+ */
+function isFullFileView(opts: {
+  startLine: number;
+  endLine: number | null;
+  nextLine?: number | null;
+  fileSizeOrTotal?: number | null;
+}): boolean {
+  if (opts.startLine > 1) return false;
+  if (opts.endLine === null || opts.endLine === 0) return true;
+  // nextLine 0/undefined after a complete read; or end covers reported total lines.
+  if (opts.nextLine === 0) return true;
+  if (opts.fileSizeOrTotal != null && opts.fileSizeOrTotal > 0 && opts.endLine >= opts.fileSizeOrTotal) {
+    return true;
+  }
+  return false;
+}
+
 /** Step types 8/9/17(view_file|list_dir): a file read or directory listing. */
-export function readUpdate(stepRow: StepRow, ctx?: UpdateContext | string): SessionUpdate {
-  const cwd = typeof ctx === "string" ? ctx : ctx?.cwd;
-  const fileContents = typeof ctx === "string" ? undefined : ctx?.fileContents;
+export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate {
+  const cwd = ctx?.cwd;
+  const fileContents = ctx?.fileContents;
   const { stepPayload, stepType } = stepRow;
   const toolRun = stepPayload.toolRun;
   const rawInput = parseRawInput(stepRow);
@@ -277,8 +298,17 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext | string): Sess
     const body = asStr(view?.content);
     if (body) {
       content.push(codeBlock(body));
-      // Remember full-file (or ranged) view content for later write diffs.
-      if (filePath && fileContents) {
+      // Only cache full-file views; ranged slices would corrupt later write diffs.
+      if (
+        filePath &&
+        fileContents &&
+        isFullFileView({
+          startLine,
+          endLine,
+          nextLine: asNum(view?.nextLine),
+          fileSizeOrTotal: asNum(view?.fileSizeOrTotal)
+        })
+      ) {
         fileContents.set(path.resolve(filePath), body);
       }
     }
@@ -297,8 +327,8 @@ function renderHits(hits: SearchHit[] | undefined): string {
 }
 
 /** Step types 7/33(grep_search|search_web): a filesystem or web search. */
-export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext | string): SessionUpdate {
-  const cwd = typeof ctx === "string" ? ctx : ctx?.cwd;
+export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate {
+  const cwd = ctx?.cwd;
   const { stepPayload, stepType } = stepRow;
   const name = stepPayload.toolRun?.call?.namePrimary ?? "";
   const rawInput = parseRawInput(stepRow);
@@ -380,6 +410,18 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
   return update;
 }
 
+/** Prefer a real document title over agy's generic "Live Content" label. */
+function fetchTitle(docTitle: string, url: string, toolRun: StepRow["stepPayload"]["toolRun"]): string {
+  const generic = !docTitle || /^live content$/i.test(docTitle);
+  if (!generic) return `Fetch ${docTitle}`;
+  if (url) return `Fetch ${url}`;
+  return (
+    asStr(toolRun?.titlePrimary)?.trim() ||
+    asStr(toolRun?.titleSecondary)?.trim() ||
+    "Fetch URL"
+  );
+}
+
 /** Step type 31 (read_url_content): fetch URL + optional decoded body (field 40). */
 export function fetchUpdate(stepRow: StepRow): SessionUpdate {
   const toolRun = stepRow.stepPayload.toolRun;
@@ -389,12 +431,7 @@ export function fetchUpdate(stepRow: StepRow): SessionUpdate {
     asStr(urlContent?.url)?.trim() || asStr(pick(rawInput, "Url", "url"))?.trim() || "";
 
   const docTitle = asStr(urlContent?.title)?.trim() || "";
-  const title =
-    (docTitle ? `Fetch ${docTitle}` : null) ||
-    (url ? `Fetch ${url}` : null) ||
-    asStr(toolRun?.titlePrimary)?.trim() ||
-    asStr(toolRun?.titleSecondary)?.trim() ||
-    "Fetch URL";
+  const title = fetchTitle(docTitle, url, toolRun);
 
   const content: Record<string, unknown>[] = [];
   if (url) content.push(textBlock(url));
@@ -442,9 +479,9 @@ function isPlanFile(targetFile: string): boolean {
 
 /** Step type 5 (write_to_file|replace_file_content|multi_replace_file_content),
  *  and step 17 artifact writes (e.g. a generated `plan.md` for user review). */
-export function editUpdate(stepRow: StepRow, ctx?: UpdateContext | string): SessionUpdate | SessionUpdate[] {
-  const cwd = typeof ctx === "string" ? ctx : ctx?.cwd;
-  const fileContents = typeof ctx === "string" ? undefined : ctx?.fileContents;
+export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate | SessionUpdate[] {
+  const cwd = ctx?.cwd;
+  const fileContents = ctx?.fileContents;
   const rawInput = parseRawInput(stepRow);
   const displayCwd = fsPath(cwd) ?? undefined;
 

--- a/src/db/translator.ts
+++ b/src/db/translator.ts
@@ -16,6 +16,7 @@
 
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { filterNarration, isNarration } from "./narration.js";
+import type { FileContentCache } from "./tool-call-updates.js";
 import type { StepRow } from "./types.js";
 import { buildUpdatefromStepPayload } from "./updates.js";
 
@@ -76,6 +77,8 @@ export class Translator {
   private readonly thoughtTextLengths = new Map<string, number>();
   // Stream + replay: last emitted snapshot keyed by step idx (tool progressive lifecycle).
   private readonly toolSnapshots = new Map<number, string>();
+  // Stream + replay: last known file bodies from view_file / write_to_file (for diffs).
+  private readonly fileContents: FileContentCache = new Map();
   // Replay: buffered consecutive agent-text parts, flushed at boundaries.
   private readonly pendingAgentParts: string[] = [];
   // Replay: message id for the current buffered agent-text group.
@@ -139,7 +142,10 @@ export class Translator {
   }
 
   private pushDispatched(row: StepRow, out: SessionUpdate[]): void {
-    const update = buildUpdatefromStepPayload(row, this.opts.cwd);
+    const update = buildUpdatefromStepPayload(row, {
+      cwd: this.opts.cwd,
+      fileContents: this.fileContents
+    });
     if (Array.isArray(update)) {
       for (const item of update) this.emitProgressive(row.idx, item, out);
     } else if (update) {

--- a/src/db/updates.ts
+++ b/src/db/updates.ts
@@ -14,9 +14,12 @@ import {
   readUpdate,
   searchUpdate,
   subagentUpdate,
-  thoughtUpdate
+  thoughtUpdate,
+  type UpdateContext
 } from "./tool-call-updates.js";
 import type { StepRow } from "./types.js";
+
+export type { UpdateContext } from "./tool-call-updates.js";
 
 /**
  * Step types recorded by agy for its own bookkeeping, with no user-facing ACP
@@ -98,18 +101,18 @@ function userPromptUpdate(stepRow: StepRow): SessionUpdate[] {
  *  the fallback for any other unrecognized step type). Returns null when the
  *  step carries no actual tool call (e.g. type-17 artifact progress wrappers
  *  have a tool-run header but no `call`), so we don't emit empty tool_calls. */
-function buildByToolName(stepRow: StepRow, cwd?: string): SessionUpdate | SessionUpdate[] | null {
+function buildByToolName(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate | SessionUpdate[] | null {
   const name = stepRow.stepPayload.toolRun?.call?.namePrimary ?? "";
   if (!name) return null;
 
   if (isThoughtToolName(name)) return thoughtUpdate(stepRow);
-  if (name === "view_file" || name === "list_dir") return readUpdate(stepRow, cwd);
-  if (name === "grep_search" || name === "search_web") return searchUpdate(stepRow, cwd);
+  if (name === "view_file" || name === "list_dir") return readUpdate(stepRow, ctx);
+  if (name === "grep_search" || name === "search_web") return searchUpdate(stepRow, ctx);
   if (name === "run_command") return executeUpdate(stepRow);
   if (name === "read_url_content") return fetchUpdate(stepRow);
   if (name === "invoke_subagent") return subagentUpdate(stepRow);
   if (name === "ask_question") return questionUpdate(stepRow);
-  if (/write|replace|edit|patch/.test(name)) return editUpdate(stepRow, cwd);
+  if (/write|replace|edit|patch/.test(name)) return editUpdate(stepRow, ctx);
   return otherUpdate(stepRow);
 }
 
@@ -130,7 +133,13 @@ function buildByToolName(stepRow: StepRow, cwd?: string): SessionUpdate | Sessio
  *   90, 98, 101   lifecycle/system       -> null (skipped)
  *   default       unknown tool step      -> tool_call (generic) or null
  */
-export function buildUpdatefromStepPayload(stepRow: StepRow, cwd?: string): SessionUpdate | SessionUpdate[] | null {
+export function buildUpdatefromStepPayload(
+  stepRow: StepRow,
+  ctx?: UpdateContext | string
+): SessionUpdate | SessionUpdate[] | null {
+  const context: UpdateContext | undefined =
+    typeof ctx === "string" ? { cwd: ctx } : ctx;
+
   switch (stepRow.stepType) {
     case 14:
       return userPromptUpdate(stepRow);
@@ -139,15 +148,15 @@ export function buildUpdatefromStepPayload(stepRow: StepRow, cwd?: string): Sess
     case 23:
       return titleUpdate(stepRow);
     case 5:
-      return editUpdate(stepRow, cwd);
+      return editUpdate(stepRow, context);
     case 17:
-      return buildByToolName(stepRow, cwd);
+      return buildByToolName(stepRow, context);
     case 8:
     case 9:
-      return readUpdate(stepRow, cwd);
+      return readUpdate(stepRow, context);
     case 7:
     case 33:
-      return searchUpdate(stepRow, cwd);
+      return searchUpdate(stepRow, context);
     case 21:
       return executeUpdate(stepRow);
     case 31:
@@ -160,6 +169,6 @@ export function buildUpdatefromStepPayload(stepRow: StepRow, cwd?: string): Sess
       return otherUpdate(stepRow);
     default:
       if (LIFECYCLE_STEP_TYPES.has(stepRow.stepType)) return null;
-      return buildByToolName(stepRow, cwd);
+      return buildByToolName(stepRow, context);
   }
 }

--- a/src/db/updates.ts
+++ b/src/db/updates.ts
@@ -135,11 +135,8 @@ function buildByToolName(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate |
  */
 export function buildUpdatefromStepPayload(
   stepRow: StepRow,
-  ctx?: UpdateContext | string
+  ctx?: UpdateContext
 ): SessionUpdate | SessionUpdate[] | null {
-  const context: UpdateContext | undefined =
-    typeof ctx === "string" ? { cwd: ctx } : ctx;
-
   switch (stepRow.stepType) {
     case 14:
       return userPromptUpdate(stepRow);
@@ -148,15 +145,15 @@ export function buildUpdatefromStepPayload(
     case 23:
       return titleUpdate(stepRow);
     case 5:
-      return editUpdate(stepRow, context);
+      return editUpdate(stepRow, ctx);
     case 17:
-      return buildByToolName(stepRow, context);
+      return buildByToolName(stepRow, ctx);
     case 8:
     case 9:
-      return readUpdate(stepRow, context);
+      return readUpdate(stepRow, ctx);
     case 7:
     case 33:
-      return searchUpdate(stepRow, context);
+      return searchUpdate(stepRow, ctx);
     case 21:
       return executeUpdate(stepRow);
     case 31:
@@ -169,6 +166,6 @@ export function buildUpdatefromStepPayload(
       return otherUpdate(stepRow);
     default:
       if (LIFECYCLE_STEP_TYPES.has(stepRow.stepType)) return null;
-      return buildByToolName(stepRow, context);
+      return buildByToolName(stepRow, ctx);
   }
 }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -313,7 +313,6 @@ describe("Translator", () => {
     expect(body).toContain("https://www.google.com/search");
   });
 
-
   it("surfaces fetched URL body from field 40", () => {
     const db = createConversationDb(dir, "conv-fetch");
     insertStep(db, {
@@ -357,7 +356,6 @@ describe("Translator", () => {
     expect(body).toContain("https://example.com/doc");
     expect(body).toContain("Body from the page.");
   });
-
 
   it("uses prior view_file content as oldText on full-file writes", () => {
     const db = createConversationDb(dir, "conv-write-diff");
@@ -418,6 +416,93 @@ describe("Translator", () => {
     });
   });
 
+  it("labels permission decisions as granted or denied", () => {
+    const db = createConversationDb(dir, "conv-perm");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 7,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "cmd-deny",
+            namePrimary: "run_command",
+            rawInputJson: '{"CommandLine":"rm -rf /"}'
+          })
+        })
+      }),
+      permissions: encodePermissions({ kind: "command", value: "rm -rf /", decision: 0 })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "cmd-ok",
+            namePrimary: "run_command",
+            rawInputJson: '{"CommandLine":"ls"}'
+          })
+        })
+      }),
+      permissions: encodePermissions({ kind: "unsandboxed", value: "ls", decision: 1 })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-perm")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(2);
+    const texts = updates.map((u) =>
+      ((u as { content?: Array<{ content?: { text?: string } }> }).content ?? [])
+        .map((c) => c.content?.text ?? "")
+        .join("\n")
+    );
+    expect(texts[0]).toContain("Permission denied: command (rm -rf /)");
+    expect(texts[1]).toContain("Permission granted: unsandboxed (ls)");
+  });
+
+  it("presents brain plan writes as Plan titles with prose content", () => {
+    const planPath =
+      "/Users/me/.gemini/antigravity-cli/brain/abc/.system_generated/steps/1/implementation_plan.md";
+    const db = createConversationDb(dir, "conv-plan");
+    insertStep(db, {
+      idx: 1,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-1",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({
+              TargetFile: planPath,
+              CodeContent: "# Plan\n\n1. Do the thing\n"
+            })
+          })
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-plan")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as {
+      title: string;
+      content?: Array<{ type?: string; content?: { text?: string } }>;
+    };
+    expect(update.title).toBe("implementation_plan.md");
+    const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
+    expect(body).toContain("# Plan");
+    expect((update.content ?? []).some((c) => c.type === "diff")).toBe(false);
+  });
 
   it("buffers consecutive agent-text parts into one message in replay mode", () => {
     const db = createConversationDb(dir, "conv-4");

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -350,7 +350,7 @@ describe("Translator", () => {
       content?: Array<{ content?: { text?: string } }>;
     };
     expect(update.kind).toBe("fetch");
-    expect(update.title).toContain("Example Doc");
+    expect(update.title).toBe("Fetch Example Doc");
     expect(update.rawOutput).toMatchObject({ title: "Example Doc" });
     const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
     expect(body).toContain("https://example.com/doc");
@@ -414,6 +414,61 @@ describe("Translator", () => {
       oldText: "export const x = 1;\n",
       newText: "export const x = 2;\n"
     });
+  });
+
+  it("does not use ranged view_file slices as oldText for full-file writes", () => {
+    const db = createConversationDb(dir, "conv-write-ranged");
+    insertStep(db, {
+      idx: 1,
+      stepType: 8,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "read-range",
+            namePrimary: "view_file",
+            rawInputJson: '{"AbsolutePath":"/repo/a.ts","StartLine":10,"EndLine":20}'
+          })
+        }),
+        viewFile: encodeViewFileResult({
+          fileUri: "file:///repo/a.ts",
+          startLine: 10,
+          endLine: 20,
+          content: "partial slice\n"
+        })
+      })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "write-2",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({
+              TargetFile: "/repo/a.ts",
+              CodeContent: "full file\n"
+            })
+          })
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-write-ranged")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    const write = updates.find(
+      (u) => (u as { toolCallId?: string }).toolCallId === "write-2"
+    ) as {
+      content?: Array<{ type?: string; oldText?: string | null; newText?: string }>;
+    };
+    const diff = (write.content ?? []).find((c) => c.type === "diff");
+    expect(diff).toMatchObject({ oldText: null, newText: "full file\n" });
   });
 
   it("labels permission decisions as granted or denied", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -359,6 +359,66 @@ describe("Translator", () => {
   });
 
 
+  it("uses prior view_file content as oldText on full-file writes", () => {
+    const db = createConversationDb(dir, "conv-write-diff");
+    insertStep(db, {
+      idx: 1,
+      stepType: 8,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "read-1",
+            namePrimary: "view_file",
+            rawInputJson: '{"AbsolutePath":"/repo/a.ts"}'
+          })
+        }),
+        viewFile: encodeViewFileResult({
+          fileUri: "file:///repo/a.ts",
+          content: "export const x = 1;\n"
+        })
+      })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "write-1",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({
+              TargetFile: "/repo/a.ts",
+              CodeContent: "export const x = 2;\n"
+            })
+          })
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-write-diff")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false, cwd: "/repo" });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    const write = updates.find(
+      (u) => (u as { toolCallId?: string }).toolCallId === "write-1"
+    ) as {
+      content?: Array<{ type?: string; path?: string; oldText?: string | null; newText?: string }>;
+    };
+    expect(write).toBeTruthy();
+    const diff = (write.content ?? []).find((c) => c.type === "diff");
+    expect(diff).toMatchObject({
+      type: "diff",
+      path: "/repo/a.ts",
+      oldText: "export const x = 1;\n",
+      newText: "export const x = 2;\n"
+    });
+  });
+
+
   it("buffers consecutive agent-text parts into one message in replay mode", () => {
     const db = createConversationDb(dir, "conv-4");
     insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "Hello" }) });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -10,9 +10,13 @@ import { createConversationDb, insertStep, updateStep, updateStepPayload } from 
 import {
   encodeAgentText,
   encodeCommandResult,
+  encodePermissions,
   encodeStepPayload,
   encodeToolCall,
-  encodeToolRun
+  encodeToolRun,
+  encodeUrlContentResult,
+  encodeViewFileResult,
+  encodeWebSearchResult
 } from "./fixtures/step-encoder.js";
 
 let dir: string;
@@ -268,6 +272,92 @@ describe("Translator", () => {
     const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
     expect(body).toContain("README.md");
   });
+
+  it("surfaces web search query metadata from field 42", () => {
+    const db = createConversationDb(dir, "conv-web-search");
+    insertStep(db, {
+      idx: 1,
+      stepType: 33,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "ws-1",
+            namePrimary: "search_web",
+            rawInputJson: '{"query":"agy acp adapter"}'
+          })
+        }),
+        webSearch: encodeWebSearchResult({
+          query: "agy acp adapter",
+          refinedQueryOrUrl: "https://www.google.com/search?q=agy+acp+adapter"
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-web-search")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as {
+      kind: string;
+      title: string;
+      content?: Array<{ content?: { text?: string } }>;
+    };
+    expect(update.kind).toBe("search");
+    expect(update.title).toContain("agy acp adapter");
+    const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
+    expect(body).toContain("Query: agy acp adapter");
+    expect(body).toContain("https://www.google.com/search");
+  });
+
+
+  it("surfaces fetched URL body from field 40", () => {
+    const db = createConversationDb(dir, "conv-fetch");
+    insertStep(db, {
+      idx: 1,
+      stepType: 31,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "fetch-1",
+            namePrimary: "read_url_content",
+            rawInputJson: '{"Url":"https://example.com/doc"}'
+          })
+        }),
+        urlContent: encodeUrlContentResult({
+          url: "https://example.com/doc",
+          title: "Example Doc",
+          description: "Fetched live",
+          body: "# Hello\n\nBody from the page."
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-fetch")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as {
+      kind: string;
+      title: string;
+      rawOutput?: { title?: string; truncated?: boolean };
+      content?: Array<{ content?: { text?: string } }>;
+    };
+    expect(update.kind).toBe("fetch");
+    expect(update.title).toContain("Example Doc");
+    expect(update.rawOutput).toMatchObject({ title: "Example Doc" });
+    const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
+    expect(body).toContain("https://example.com/doc");
+    expect(body).toContain("Body from the page.");
+  });
+
 
   it("buffers consecutive agent-text parts into one message in replay mode", () => {
     const db = createConversationDb(dir, "conv-4");

--- a/tests/fixtures/conversation-db.ts
+++ b/tests/fixtures/conversation-db.ts
@@ -16,11 +16,25 @@ export function createConversationDb(dir: string, id: string): Database.Database
 
 export function insertStep(
   db: Database.Database,
-  row: { idx: number; stepType: number; status?: number; stepPayload: Uint8Array }
+  row: {
+    idx: number;
+    stepType: number;
+    status?: number;
+    stepPayload: Uint8Array;
+    permissions?: Uint8Array;
+    errorDetails?: Uint8Array;
+  }
 ): void {
   db.prepare(
-    "INSERT INTO steps (idx, step_type, status, step_payload) VALUES (?, ?, ?, ?)"
-  ).run(row.idx, row.stepType, row.status ?? 3, Buffer.from(row.stepPayload));
+    "INSERT INTO steps (idx, step_type, status, step_payload, permissions, error_details) VALUES (?, ?, ?, ?, ?, ?)"
+  ).run(
+    row.idx,
+    row.stepType,
+    row.status ?? 3,
+    Buffer.from(row.stepPayload),
+    row.permissions ? Buffer.from(row.permissions) : null,
+    row.errorDetails ? Buffer.from(row.errorDetails) : null
+  );
 }
 
 export function updateStepPayload(db: Database.Database, idx: number, stepPayload: Uint8Array): void {

--- a/tests/fixtures/step-encoder.ts
+++ b/tests/fixtures/step-encoder.ts
@@ -65,18 +65,89 @@ export function encodeCommandResult(result: {
   return w.finish();
 }
 
+export function encodeWebSearchResult(result: { query?: string; refinedQueryOrUrl?: string }): Uint8Array {
+  const w = new BinaryWriter();
+  if (result.query) w.tag(1, 2).string(result.query);
+  if (result.refinedQueryOrUrl) w.tag(5, 2).string(result.refinedQueryOrUrl);
+  return w.finish();
+}
+
+export function encodeUrlContentResult(result: {
+  url?: string;
+  title?: string;
+  description?: string;
+  body?: string;
+  contentPath?: string;
+}): Uint8Array {
+  const w = new BinaryWriter();
+  if (result.url) w.tag(1, 2).string(result.url);
+
+  // document submessage (field 2): title=4, body nested at 6.3.2, description=7
+  if (result.title || result.description || result.body) {
+    const doc = new BinaryWriter();
+    if (result.title) doc.tag(4, 2).string(result.title);
+    if (result.body) {
+      const bodyInner = new BinaryWriter();
+      bodyInner.tag(2, 2).string(result.body);
+      const bodyWrap = new BinaryWriter();
+      submessage(bodyWrap, 3, bodyInner.finish());
+      submessage(doc, 6, bodyWrap.finish());
+    }
+    if (result.description) doc.tag(7, 2).string(result.description);
+    submessage(w, 2, doc.finish());
+  }
+
+  if (result.contentPath) w.tag(6, 2).string(result.contentPath);
+  return w.finish();
+}
+
+export function encodeViewFileResult(result: {
+  fileUri?: string;
+  startLine?: number;
+  endLine?: number;
+  content?: string;
+}): Uint8Array {
+  const w = new BinaryWriter();
+  if (result.fileUri) w.tag(1, 2).string(result.fileUri);
+  if (result.startLine !== undefined) w.tag(2, 0).int64(result.startLine);
+  if (result.endLine !== undefined) w.tag(3, 0).int64(result.endLine);
+  if (result.content !== undefined) w.tag(4, 2).string(result.content);
+  return w.finish();
+}
+
+/** permissions column: { 2: { 1: { 1: kind, 2: value }, 2: decision } }. */
+export function encodePermissions(info: { kind?: string; value?: string; decision?: number }): Uint8Array {
+  const target = new BinaryWriter();
+  if (info.kind) target.tag(1, 2).string(info.kind);
+  if (info.value) target.tag(2, 2).string(info.value);
+
+  const entry = new BinaryWriter();
+  submessage(entry, 1, target.finish());
+  if (info.decision !== undefined) entry.tag(2, 0).int64(info.decision);
+
+  const w = new BinaryWriter();
+  submessage(w, 2, entry.finish());
+  return w.finish();
+}
+
 export function encodeStepPayload(opts: {
   toolRun?: Uint8Array;
   agentText?: string;
   titleUpdate?: string;
   userPrompt?: string;
   commandResult?: Uint8Array;
+  viewFile?: Uint8Array;
+  webSearch?: Uint8Array;
+  urlContent?: Uint8Array;
 }): Uint8Array {
   const w = new BinaryWriter();
   if (opts.toolRun) submessage(w, 5, opts.toolRun);
+  if (opts.viewFile) submessage(w, 14, opts.viewFile);
   if (opts.userPrompt !== undefined) submessage(w, 19, encodeUserPrompt(opts.userPrompt));
   if (opts.agentText !== undefined) submessage(w, 20, encodeAgentText(opts.agentText));
   if (opts.commandResult) submessage(w, 28, opts.commandResult);
   if (opts.titleUpdate !== undefined) submessage(w, 30, encodeTitleUpdate(opts.titleUpdate));
+  if (opts.urlContent) submessage(w, 40, opts.urlContent);
+  if (opts.webSearch) submessage(w, 42, opts.webSearch);
   return w.finish();
 }


### PR DESCRIPTION
## Summary

Stable ACP v1 fidelity release for **0.2.6**. Continues the post-0.2.5 editor UX track without interactive control-plane work (permissions/terminals/MCP still blocked under `agy --print`).

- Decode **search_web** field 42 (query / refined query or URL) and **read_url_content** field 40 (title, description, body, content path)
- Surface fetch bodies (truncated) and web-search metadata on tool calls
- Full-file write diffs use prior `view_file` / write content as `oldText` when known; ranged views are not cached
- Permission notes map decision varints to granted/denied labels; plan artifacts get clearer titles
- Hardenings: known nested body path, no re-parse of UTF-8 as protobuf, prefer URL over generic “Live Content” titles

## Test plan

- [x] `npm test` (57 tests)
- [ ] Smoke ACP initialize against a real `agy` conversation if desired
- [ ] After merge: tag `v0.2.6` for the release workflow / npm publish