### PR TITLE
Release 0.2.7: mode config and interactive run_command permissions

### DIFF
--- a/.github/workflows/platform-smoke.yml
+++ b/.github/workflows/platform-smoke.yml
@@ -74,3 +74,21 @@ jobs:
       - name: Run ACP initialize smoke test
         shell: bash
         run: node scripts/smoke-install.mjs "$RUNNER_TEMP/install-check/node_modules/agy-acp/dist/main.js"
+
+      - name: Smoke test node-pty
+        shell: bash
+        working-directory: ${{ runner.temp }}/install-check
+        run: |
+          node --input-type=module <<'EOF'
+          import { defaultPtyFactory } from 'agy-acp/dist/cli.js';
+          const { spawn } = await defaultPtyFactory();
+          const windows = process.platform === 'win32';
+          const child = spawn(windows ? 'cmd.exe' : '/bin/sh', windows ? ['/c', 'echo node-pty-ok'] : ['-c', 'echo node-pty-ok'], {
+            cwd: process.cwd(), env: process.env, cols: 80, rows: 24
+          });
+          let output = '';
+          child.onData(data => output += data);
+          child.onExit(({ exitCode }) => {
+            if (exitCode !== 0 || !output.includes('node-pty-ok')) process.exit(1);
+          });
+          EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,40 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-07-22
+
+Session config aligned with Antigravity CLI 1.1.x, plus an experimental
+interactive permission bridge for `run_command`. Prefer **agy ≥ 1.1.5** for
+modes, stable model slugs, `--effort`, and the bridged permission menu.
+
 ### Added
 
 - ACP session `mode` config option mapped to `agy --mode`:
   `default` (omit flag), `accept-edits`, and `plan`. Persisted on load/resume,
   overridable via `AGY_ACP_MODE` or `agy-acp --mode <value>`.
+- Experimental persistent-PTY permission bridge (default path). ACP clients can
+  allow once, allow for the persistent conversation, always allow via
+  `settings.json`, or reject once. Cancellation and model/mode changes restart
+  the PTY and reset conversation-scoped grants. Only the observed four-choice
+  `run_command` menu is bridged; other status-9 interactions fail closed without
+  writing PTY menu keys. `--dangerously-skip-permissions` selects non-interactive
+  print mode; `AGY_ACP_INTERACTIVE_PERMISSIONS=0` /
+  `--no-interactive-permissions` also use print mode without auto-approval.
+- `node-pty` dependency for the interactive path, with platform smoke coverage.
 
 ### Changed
 
-- Session config option ids/names and order are now `mode`, `model`,
+- Session config option **ids** and order are now `mode`, `model`,
   `reasoningEffort` (was `model`, `effort`, and previously `fast-mode`).
+  Display **names** are `Mode`, `Model`, `Reasoning Effort`.
   `reasoningEffort` still maps to `agy --effort`.
+- Session store fields renamed to match: `model` / `reasoningEffort` (legacy
+  `modelId` / `reasoningEffect` still load).
+- Default execution path uses interactive `agy --prompt-interactive` via a
+  persistent PTY when the permission bridge is enabled; print mode remains
+  available for the bypasses above.
+- README documents Mode / allowlist / skip-permissions workarounds and the
+  interactive bridge limits.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [Unreleased]
 
+### Removed
+
+- ACP session `Fast Mode` config option (`fast-mode` / `/fast` prompt prefix).
+  Antigravity CLI removed `/fast` slash commands in `agy` 1.1.0 in favor of
+  execution mode cycling (`default` → `accept-edits` → `plan`).
+
 ## [0.2.6] - 2026-07-22
 
 Stable ACP v1 fidelity release: richer tool result bodies and better editor diffs,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [Unreleased]
 
+### Added
+
+- ACP session `mode` config option mapped to `agy --mode`:
+  `default` (omit flag), `accept-edits`, and `plan`. Persisted on load/resume,
+  overridable via `AGY_ACP_MODE` or `agy-acp --mode <value>`.
+
+### Changed
+
+- Session config option ids/names and order are now `mode`, `model`,
+  `reasoningEffort` (was `model`, `effort`, and previously `fast-mode`).
+  `reasoningEffort` still maps to `agy --effort`.
+
 ### Removed
 
 - ACP session `Fast Mode` config option (`fast-mode` / `/fast` prompt prefix).

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ACP adapter for Google Antigravity's `agy` CLI.
 
 The implementation is a TypeScript, `npx`-runnable ACP server built on
-`@agentclientprotocol/sdk` that wraps the public `agy --print` command. This
-keeps the adapter aligned with the logged-in Antigravity CLI experience and
-avoids a separate runtime startup path.
+`@agentclientprotocol/sdk` that wraps the public `agy` CLI. It uses a persistent
+interactive `agy` process by default so ACP clients can answer permission
+requests while retaining the logged-in Antigravity CLI experience.
 
 **Current package:** `0.2.7` (`latest`). Supports **ACP v1** and
 **experimental draft ACP v2** side by side via version negotiation on
@@ -20,8 +20,8 @@ Draft v2 may still change before stabilization.
 Zed / ACP client
   -> agy-acp dual protocol router (v1 or draft v2 from initialize)
   -> AgyAcpAgent (sessions, config, prompt lifecycle)
-  -> AgyCliSession (spawns agy, tracks --conversation id)
-  -> agy --print --conversation <id> --sandbox ...
+  -> AgyCliSession (keeps an interactive agy PTY, tracks --conversation id)
+  -> agy --prompt-interactive ... --conversation <id> --sandbox ...
        \-> writes to ~/.gemini/antigravity-cli/conversations/<id>.db
   -> StreamPoller polls that SQLite database while agy runs
   -> Translator decodes steps -> ACP session/update notifications
@@ -40,9 +40,10 @@ it runs, with structured (reverse-engineered, since `agy` doesn't publish a
 schema) protobuf step records — tool calls, task/permission/error details, and
 titles all included. `agy-acp` now reads that database directly instead:
 
-- one `agy --print --conversation <id>` subprocess per ACP prompt (the
-  conversation id is learned from the first turn and reused after),
-- stdout is drained but never parsed; a `StreamPoller` polls the conversation
+- one persistent interactive `agy` PTY per ACP session (the conversation id is
+  learned from the first turn and reused after),
+- PTY output is retained only as a bounded diagnostic tail and never parsed as
+  agent output; a `StreamPoller` polls the conversation
   database on an interval while the process runs, translating newly-appended
   steps into ACP updates (`agent_message_chunk`, `agent_thought_chunk`,
   progressive `tool_call` → `tool_call_update`, `session_info_update`, ...)
@@ -64,6 +65,28 @@ titles all included. `agy-acp` now reads that database directly instead:
   before exiting), then `SIGKILL` if the process does not exit,
 - `--sandbox` is enabled by default,
 - `--dangerously-skip-permissions` is opt-in only.
+
+### Interactive permission bridge
+
+The adapter runs agy in a persistent PTY by default and forwards its permission
+menu through ACP. The bridge is coupled to the observed **agy 1.1.5**
+TUI/database behavior. It offers **Yes** (once), allow for this conversation,
+always allow (writes `settings.json`), and **No** (once). “Conversation” means
+the lifetime of the same interactive agy process. Cancellation or changing
+model/mode restarts that process before the next turn, resumes the conversation
+database, and resets process-scoped grants. PTY output is retained only as a
+bounded diagnostic tail and is never sent to stdout.
+
+Passing `--dangerously-skip-permissions` (or setting its environment equivalent)
+turns off the interactive bridge and uses `agy --print` because agy auto-approves
+instead of presenting permission requests in that mode.
+For troubleshooting or compatibility with another agy version, set
+`AGY_ACP_INTERACTIVE_PERMISSIONS=0` or pass `--no-interactive-permissions` to use
+print mode without auto-approval.
+
+Only the four-choice permission menu for `run_command` is currently bridged.
+Other requested interactions, including `ask_question`, fail closed with an
+unsupported-interaction error; the bridge does not send guessed menu keys.
 
 The conversation-database wire format (`src/db/step-payload.ts`,
 `src/db/columns.ts`) was cross-referenced against the reverse-engineering
@@ -145,7 +168,11 @@ Optional environment variables:
   `accept-edits`, or `plan`). Overridden by the session Mode picker or the
   `agy-acp --mode <value>` argv flag.
 - `AGY_ACP_DANGEROUSLY_SKIP_PERMISSIONS`: when set, passes
-  `--dangerously-skip-permissions` to `agy` (auto-approve tool permissions).
+  `--dangerously-skip-permissions` to `agy` (auto-approve tool permissions) and
+  selects non-interactive print mode instead of the default permission bridge.
+- `AGY_ACP_INTERACTIVE_PERMISSIONS=0`: disables the default permission bridge
+  and uses non-interactive print mode. The equivalent argv flag is
+  `--no-interactive-permissions`.
 
 ### File writes denied in Zed?
 
@@ -159,13 +186,15 @@ Workarounds (prefer earlier ones):
 1. Set session **Mode** to **Accept Edits** (`accept-edits`), or start with
    `AGY_ACP_MODE=accept-edits` / `agy-acp --mode accept-edits`.
 2. Allowlist tools in `~/.gemini/antigravity-cli/settings.json` under
-   `permission.allow` (agy honors this in print mode as of 1.1.1–1.1.4).
-3. Opt in to `AGY_ACP_DANGEROUSLY_SKIP_PERMISSIONS=1` or
+   `permissions.allow` (agy honors this in print mode as of 1.1.1–1.1.4).
+3. As a broad auto-approve fallback, opt in to
+   `AGY_ACP_DANGEROUSLY_SKIP_PERMISSIONS=1` or
    `--dangerously-skip-permissions` (broad auto-approve).
 
-True interactive `session/request_permission` (Zed Allow/Deny dialogs feeding
-agy) is **not** implemented: agy decides permissions inside `--print` with no
-external pause/resume API. See the roadmap.
+Interactive `session/request_permission` is available experimentally for the
+observed four-choice `run_command` menu. Other agy interaction types remain
+post-hoc in print mode; interactive mode fails closed on them because their TUI
+layouts and response channels have not been verified.
 
 ## Model Picker
 
@@ -258,15 +287,16 @@ conversation database rather than driving agy as a full interactive agent.
 - [x] Decode/show fetch and web-search result bodies when present in the DB
       (search_web hit lists are not persisted by agy; query metadata only)
 - [x] Full-file write diffs with prior content when known from earlier view/write steps
-- [x] Permission notes map decision varint to granted/denied labels (still not interactive)
+- [x] Permission notes map decision varint to granted/denied labels
+- [x] Experimental four-choice `run_command` permission bridge via persistent PTY
 
 ### High priority
 
 These need more than conversation-DB polling (interactive agy control plane or
 client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
 
-- [ ] Interactive `session/request_permission` (today: post-hoc granted/denied text;
-      agy still owns allow/deny under `--print`)
+- [ ] Expand interactive `session/request_permission` beyond the verified
+      `run_command` menu (unsupported status-9 interactions currently fail closed)
 - [ ] Structured `plan` / `plan_update` / `plan_removed` (today: brain/plan files are
       prose tool content with Plan titles — not ACP plan updates)
 - [ ] Client terminals: `type: "terminal"` content + `terminal/*` (today: execute tools

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The implementation is a TypeScript, `npx`-runnable ACP server built on
 keeps the adapter aligned with the logged-in Antigravity CLI experience and
 avoids a separate runtime startup path.
 
-**Current package:** `0.2.6` (`latest`). Supports **ACP v1** and
+**Current package:** `0.2.7` (`latest`). Supports **ACP v1** and
 **experimental draft ACP v2** side by side via version negotiation on
 `initialize`. Draft ACP v2 work continues on the `alpha` dist-tag
 (`1.0.0-alpha.*`). See the [ACP v2 draft announcement](https://agentclientprotocol.com/announcements/acp-v2-draft)
@@ -96,7 +96,7 @@ node dist/main.js
 Published package / Zed:
 
 ```sh
-npx agy-acp                 # latest stable (0.2.5)
+npx agy-acp                 # latest stable (0.2.7)
 npx agy-acp@alpha           # latest alpha pre-release channel
 npx agy-acp@1.0.0-alpha.0   # pin a specific pre-release
 ```
@@ -144,18 +144,48 @@ Optional environment variables:
 - `AGY_ACP_MODE`: default execution mode for new sessions (`default`,
   `accept-edits`, or `plan`). Overridden by the session Mode picker or the
   `agy-acp --mode <value>` argv flag.
+- `AGY_ACP_DANGEROUSLY_SKIP_PERMISSIONS`: when set, passes
+  `--dangerously-skip-permissions` to `agy` (auto-approve tool permissions).
+
+### File writes denied in Zed?
+
+Under `agy --print` (agy ≥ 1.1.3), tools that need interactive confirmation are
+**soft-denied** rather than prompting a TTY. Messages like
+`User denied permission for write_file(...)` usually mean agy refused the tool —
+not that the ACP client blocked the editor filesystem.
+
+Workarounds (prefer earlier ones):
+
+1. Set session **Mode** to **Accept Edits** (`accept-edits`), or start with
+   `AGY_ACP_MODE=accept-edits` / `agy-acp --mode accept-edits`.
+2. Allowlist tools in `~/.gemini/antigravity-cli/settings.json` under
+   `permission.allow` (agy honors this in print mode as of 1.1.1–1.1.4).
+3. Opt in to `AGY_ACP_DANGEROUSLY_SKIP_PERMISSIONS=1` or
+   `--dangerously-skip-permissions` (broad auto-approve).
+
+True interactive `session/request_permission` (Zed Allow/Deny dialogs feeding
+agy) is **not** implemented: agy decides permissions inside `--print` with no
+external pause/resume API. See the roadmap.
 
 ## Model Picker
 
 When the ACP client supports session configuration options, `agy-acp` returns
-three options during `session/new` (this order):
+three options during `session/new` (this order). Wire **ids** are stable;
+**names** are human-facing labels in the client UI:
 
-- `mode` (category `mode`):
-  - `default` — agy request-review behavior (omits `--mode`; write tools may soft-deny under `--print`)
-  - `accept-edits` — `agy --mode accept-edits` (apply file edits without interactive write review)
-  - `plan` — `agy --mode plan`
-- `model` (category `model`)
-- `reasoningEffort` (category `thought_level`) — maps to `agy --effort`
+| Order | id | name | Category |
+|---|---|---|---|
+| 1 | `mode` | Mode | `mode` |
+| 2 | `model` | Model | `model` |
+| 3 | `reasoningEffort` | Reasoning Effort | `thought_level` |
+
+`mode` values:
+
+- `default` — agy request-review behavior (omits `--mode`; write tools may soft-deny under `--print`)
+- `accept-edits` — `agy --mode accept-edits` (apply file edits without interactive write review)
+- `plan` — `agy --mode plan`
+
+`reasoningEffort` maps to `agy --effort`.
 
 The adapter discovers model choices by running:
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ titles all included. `agy-acp` now reads that database directly instead:
   choice, etc.) persist to `~/.agy-acp-state/sessions.json` so list/load/resume
   survive a server restart — see `src/session-store.ts`,
 - `session/list` is advertised on both protocol versions,
-- separate ACP session `Model` and `Reasoning Effort` pickers populated from
-  `agy models` when available (effort maps to `agy --effort`),
+- ACP session config options in order: `mode`, `model`, `reasoningEffort`
+  (mode → `agy --mode`; model → `agy --model`; reasoningEffort → `agy --effort`),
 - cancellation sends `SIGINT` (giving `agy` a chance to flush its database
   before exiting), then `SIGKILL` if the process does not exit,
 - `--sandbox` is enabled by default,
@@ -141,14 +141,21 @@ Optional environment variables:
   if `agy` uses a different path on your OS.
 - `AGY_ACP_STATE_DIR`: where `agy-acp` persists session bindings (for
   `session/load`/`session/resume`), default `~/.agy-acp-state`.
+- `AGY_ACP_MODE`: default execution mode for new sessions (`default`,
+  `accept-edits`, or `plan`). Overridden by the session Mode picker or the
+  `agy-acp --mode <value>` argv flag.
 
 ## Model Picker
 
 When the ACP client supports session configuration options, `agy-acp` returns
-two options during `session/new`:
+three options during `session/new` (this order):
 
-- `Model`: a select option with ACP category `model`.
-- `Reasoning Effort`: a select option with ACP category `thought_level` (config id `effort`).
+- `mode` (category `mode`):
+  - `default` — agy request-review behavior (omits `--mode`; write tools may soft-deny under `--print`)
+  - `accept-edits` — `agy --mode accept-edits` (apply file edits without interactive write review)
+  - `plan` — `agy --mode plan`
+- `model` (category `model`)
+- `reasoningEffort` (category `thought_level`) — maps to `agy --effort`
 
 The adapter discovers model choices by running:
 
@@ -209,7 +216,7 @@ conversation database rather than driving agy as a full interactive agent.
 
 - [x] `initialize`, `session/new`, `session/prompt`, `session/cancel`, `session/close`
 - [x] `session/load` and `session/resume` with persisted bindings
-- [x] `session/set_config_option` (`model`, `effort`)
+- [x] `session/set_config_option` (`mode`, `model`, `reasoningEffort`)
 - [x] `additionalDirectories` → `agy --add-dir`
 - [x] Prompt content: text, image, embedded resource, resource link (`audio: false`)
 - [x] Streamed `session/update`: `agent_message_chunk`, `agent_thought_chunk`,
@@ -242,8 +249,8 @@ client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
 
 - [ ] Optional `session/delete` from the session store
 - [ ] `session/fork` if/when useful for clients
-- [ ] Session modes (`session/set_mode`, `modes`, `current_mode_update`) if they map
-      cleanly onto agy — today config options cover model/effort
+- [ ] Native ACP session modes (`session/set_mode`, `modes`, `current_mode_update`)
+      in addition to the `mode` config option that already maps to `agy --mode`
 - [ ] `available_commands_update` for slash-command discovery in the client UI
 - [ ] Push `config_option_update` when options change outside `set_config_option`
 - [ ] `authenticate` / `logout` / `authMethods` (today: require a pre-logged-in `agy`)

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ titles all included. `agy-acp` now reads that database directly instead:
 - `session/list` is advertised on both protocol versions,
 - separate ACP session `Model` and `Reasoning Effort` pickers populated from
   `agy models` when available (effort maps to `agy --effort`),
-- an ACP session `Fast Mode` selector that prepends `/fast` to print-mode
-  prompts without editing global Antigravity settings,
 - cancellation sends `SIGINT` (giving `agy` a chance to flush its database
   before exiting), then `SIGKILL` if the process does not exit,
 - `--sandbox` is enabled by default,
@@ -147,11 +145,10 @@ Optional environment variables:
 ## Model Picker
 
 When the ACP client supports session configuration options, `agy-acp` returns
-three options during `session/new`:
+two options during `session/new`:
 
 - `Model`: a select option with ACP category `model`.
 - `Reasoning Effort`: a select option with ACP category `thought_level` (config id `effort`).
-- `Fast Mode`: an `Off`/`On` select option with ACP category `model_config`.
 
 The adapter discovers model choices by running:
 
@@ -184,10 +181,6 @@ Legacy display-name lists (`Gemini 3.5 Flash (Medium)`) are still parsed for
 compatibility. Picker labels stay human-readable (`Gemini 3.5 Flash`,
 `Medium`, …).
 
-Enabling `Fast Mode` sends `/fast` before the user prompt in the transient
-`agy --print` session. This mirrors Antigravity CLI Fast Mode without mutating
-`~/.gemini/antigravity-cli/settings.json`.
-
 ## Session Persistence
 
 `agy-acp` advertises `loadSession: true` and the `resume`/`close`
@@ -216,7 +209,7 @@ conversation database rather than driving agy as a full interactive agent.
 
 - [x] `initialize`, `session/new`, `session/prompt`, `session/cancel`, `session/close`
 - [x] `session/load` and `session/resume` with persisted bindings
-- [x] `session/set_config_option` (`model`, `effort`, `fast-mode`)
+- [x] `session/set_config_option` (`model`, `effort`)
 - [x] `additionalDirectories` → `agy --add-dir`
 - [x] Prompt content: text, image, embedded resource, resource link (`audio: false`)
 - [x] Streamed `session/update`: `agent_message_chunk`, `agent_thought_chunk`,
@@ -250,7 +243,7 @@ client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
 - [ ] Optional `session/delete` from the session store
 - [ ] `session/fork` if/when useful for clients
 - [ ] Session modes (`session/set_mode`, `modes`, `current_mode_update`) if they map
-      cleanly onto agy — today config options cover model/effort/fast-mode
+      cleanly onto agy — today config options cover model/effort
 - [ ] `available_commands_update` for slash-command discovery in the client UI
 - [ ] Push `config_option_update` when options change outside `set_config_option`
 - [ ] `authenticate` / `logout` / `authMethods` (today: require a pre-logged-in `agy`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agy-acp",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agy-acp",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@agentclientprotocol/sdk": "^1.3.0",
         "@bufbuild/protobuf": "^2.12.1",
         "better-sqlite3": "^12.11.1",
+        "node-pty": "^1.1.0",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -1157,6 +1158,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
       }
     },
     "node_modules/obug": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agy-acp",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Agent Client Protocol adapter that wraps the Google Antigravity CLI (ACP v1 + experimental draft ACP v2)",
   "type": "module",
   "author": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@agentclientprotocol/sdk": "^1.3.0",
     "@bufbuild/protobuf": "^2.12.1",
     "better-sqlite3": "^12.11.1",
+    "node-pty": "^1.1.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -53,5 +54,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "allowScripts": {
+    "node-pty@1.1.0": true
   }
 }

--- a/src/acp-server.ts
+++ b/src/acp-server.ts
@@ -798,7 +798,7 @@ export function buildModelCatalog(entries: string[]): ModelCatalog {
 export function modeConfigOption(mode: AgyExecutionMode): V1SessionConfigOption {
   return {
     id: MODE_CONFIG_ID,
-    name: "mode",
+    name: "Mode",
     description:
       "agy execution mode (--mode). Default reviews writes; Accept Edits applies file changes; Plan focuses on planning.",
     category: "mode",
@@ -827,7 +827,7 @@ export function modeConfigOption(mode: AgyExecutionMode): V1SessionConfigOption 
 export function modelConfigOption(selectedBaseModel: string, catalog: ModelCatalog): V1SessionConfigOption {
   return {
     id: MODEL_CONFIG_ID,
-    name: "model",
+    name: "Model",
     description: "ACP model slug passed to agy --model (reasoningEffort is selected separately).",
     category: "model",
     type: "select",
@@ -846,7 +846,7 @@ export function reasoningEffectConfigOption(
 ): V1SessionConfigOption {
   return {
     id: REASONING_EFFORT_CONFIG_ID,
-    name: "reasoningEffort",
+    name: "Reasoning Effort",
     description: "Value for agy --effort (low | medium | high) for the selected model.",
     category: "thought_level",
     type: "select",

--- a/src/acp-server.ts
+++ b/src/acp-server.ts
@@ -49,8 +49,10 @@ import {
   type AgyCliConfig,
   type AgyCliSession,
   type AgyExecutionMode,
+  type PtyFactory,
   type SpawnFactory
 } from "./cli.js";
+import { permissionOptions, type AgyPermissionChoice } from "./permissions.js";
 import { promptBlocksToAgyPrompt } from "./prompt-content.js";
 import { defaultStateDir, SessionStore, type StoredSession } from "./session-store.js";
 import { sessionUpdateToV1, sessionUpdateToV2 } from "./session-updates.js";
@@ -96,11 +98,12 @@ interface ModelCatalog {
   displayName(slug: string): string;
 }
 
-interface AgyAcpOptions {
+export interface AgyAcpOptions {
   stdin?: NodeJS.ReadableStream;
   stdout?: NodeJS.WritableStream;
   env?: NodeJS.ProcessEnv;
   spawnProcess?: SpawnFactory;
+  ptyFactory?: PtyFactory;
   argv?: string[];
 }
 
@@ -129,7 +132,7 @@ export class AgyAcpAgent {
   constructor(options: AgyAcpOptions = {}) {
     this.#env = options.env ?? process.env;
     this.#argv = options.argv ?? [];
-    this.#backend = new AgyCliBackend(options.spawnProcess);
+    this.#backend = new AgyCliBackend(options.spawnProcess, options.ptyFactory);
     this.#store = new SessionStore(defaultStateDir(this.#env));
   }
 
@@ -350,6 +353,15 @@ export class AgyAcpAgent {
           sessionId: params.sessionId,
           update: sessionUpdateToV1(update)
         });
+      }, async (toolCall) => {
+        if (signal?.aborted) return "cancelled";
+        const { sessionUpdate: _discriminator, ...requestToolCall } = toolCall as unknown as Record<string, unknown>;
+        const response = await racePermissionCancellation(client.request(v1.methods.client.session.requestPermission, {
+          sessionId: params.sessionId,
+          toolCall: requestToolCall as v1.ToolCallUpdate,
+          options: permissionOptions(toolCall)
+        }), signal);
+        return selectedPermission(response, signal);
       });
       await this.persistSession(params.sessionId, session);
       return {
@@ -550,6 +562,17 @@ export class AgyAcpAgent {
       try {
         const outcome = await session.agy.prompt(promptText, async (update) => {
           await notify(sessionUpdateToV2(update));
+        }, async (toolCall) => {
+          if (signal.aborted) return "cancelled";
+          const converted = sessionUpdateToV2(toolCall) as unknown as Record<string, unknown>;
+          const { sessionUpdate: _discriminator, ...requestToolCall } = converted;
+          const response = await racePermissionCancellation(client.request(v2.methods.client.session.requestPermission, {
+            sessionId: params.sessionId,
+            title: String(requestToolCall.title ?? "Permission required"),
+            subject: { type: "tool_call", toolCall: requestToolCall as v2.ToolCallUpdate },
+            options: permissionOptions(toolCall)
+          }), signal);
+          return selectedPermission(response, signal);
         });
         await this.persistSession(params.sessionId, session);
 
@@ -723,6 +746,33 @@ export function runAcp(options: AgyAcpOptions = {}) {
 }
 
 export { promptBlocksToAgyPrompt, promptBlocksToText } from "./prompt-content.js";
+
+function selectedPermission(response: unknown, signal?: AbortSignal): AgyPermissionChoice | "cancelled" {
+  if (signal?.aborted || !response || typeof response !== "object") return "cancelled";
+  const outcome = (response as { outcome?: unknown }).outcome;
+  if (!outcome || typeof outcome !== "object" || (outcome as { outcome?: string }).outcome !== "selected") return "cancelled";
+  const id = (outcome as { optionId?: string }).optionId;
+  return id === "agy-allow-once" || id === "agy-allow-conversation" || id === "agy-allow-settings" || id === "agy-reject-once"
+    ? id : "cancelled";
+}
+
+async function racePermissionCancellation<T>(request: Promise<T>, signal?: AbortSignal): Promise<T | null> {
+  if (!signal) return request;
+  if (signal.aborted) return null;
+  // A client may eventually reject a request abandoned because the turn was
+  // cancelled. Attach a handler now so that rejection is never unhandled.
+  const guarded = request.then((value) => value, (error) => {
+    if (signal.aborted) return null;
+    throw error;
+  });
+  let abort!: () => void;
+  const cancelled = new Promise<null>((resolve) => {
+    abort = () => resolve(null);
+    signal.addEventListener("abort", abort, { once: true });
+  });
+  try { return await Promise.race([guarded, cancelled]); }
+  finally { signal.removeEventListener("abort", abort); }
+}
 
 function dedupe(values: string[]): string[] {
   return [...new Set(values)];

--- a/src/acp-server.ts
+++ b/src/acp-server.ts
@@ -57,7 +57,6 @@ const require = createRequire(import.meta.url);
 const packageJson = require("../package.json") as { version?: string };
 const MODEL_CONFIG_ID = "model";
 const REASONING_EFFORT_CONFIG_ID = "effort";
-const FAST_MODE_CONFIG_ID = "fast-mode";
 const NO_REASONING_VALUE = "none";
 /** Legacy `agy models` lines: `Gemini 3.5 Flash (Medium)`. */
 const LEGACY_EFFORT_PATTERN = /\((low|medium|high)\)\s*$/i;
@@ -475,16 +474,6 @@ export class AgyAcpAgent {
       return;
     }
 
-    if (configId === FAST_MODE_CONFIG_ID) {
-      const enabled = fastModeValueToBoolean(value);
-      if (enabled === undefined) {
-        throw new Error("Fast mode config value must be on or off");
-      }
-      session.agy.setFastMode(enabled);
-      await this.persistSession(sessionId, session);
-      return;
-    }
-
     throw new Error(`Unknown config option: ${configId}`);
   }
 
@@ -607,9 +596,6 @@ export class AgyAcpAgent {
       ? restoredModelSelection(stored, catalog)
       : initialModelSelection(config.model, catalog);
     applyModelSelection(agy, selection.baseModel, selection.reasoningEffect, catalog);
-    if (stored) {
-      agy.setFastMode(stored.fastMode);
-    }
 
     return {
       id: "", // set by the caller once the ACP session id is known
@@ -651,7 +637,6 @@ export class AgyAcpAgent {
       lastStepIdx: session.agy.lastStepIdx,
       modelId: session.selectedBaseModel,
       reasoningEffect: session.selectedReasoningEffect,
-      fastMode: session.agy.config.fastMode,
       updatedAt: new Date().toISOString()
     };
   }
@@ -818,27 +803,6 @@ export function reasoningEffectConfigOption(
   };
 }
 
-export function fastModeConfigOption(enabled: boolean): V1SessionConfigOption {
-  return {
-    id: FAST_MODE_CONFIG_ID,
-    name: "Fast Mode",
-    description: "Prepends /fast before agy --print prompts to reduce thought visualization delays.",
-    category: "model_config",
-    type: "select",
-    currentValue: enabled ? "on" : "off",
-    options: [
-      {
-        value: "off",
-        name: "Off"
-      },
-      {
-        value: "on",
-        name: "On"
-      }
-    ]
-  };
-}
-
 function sessionConfigOptionsV1(session: SessionState): V1SessionConfigOption[] {
   return [
     modelConfigOption(session.selectedBaseModel, session.catalog),
@@ -846,8 +810,7 @@ function sessionConfigOptionsV1(session: SessionState): V1SessionConfigOption[] 
       session.selectedBaseModel,
       session.selectedReasoningEffect,
       session.catalog
-    ),
-    fastModeConfigOption(session.agy.config.fastMode)
+    )
   ];
 }
 
@@ -1116,14 +1079,4 @@ function applyModelSelection(
   }
 
   agy.setEffort(selectedReasoningEffect);
-}
-
-function fastModeValueToBoolean(value: unknown): boolean | undefined {
-  if (value === true || value === "on") {
-    return true;
-  }
-  if (value === false || value === "off") {
-    return false;
-  }
-  return undefined;
 }

--- a/src/acp-server.ts
+++ b/src/acp-server.ts
@@ -41,7 +41,16 @@ import type {
 } from "@agentclientprotocol/sdk/experimental/v2";
 import { ReplayCache } from "./db/replay.js";
 import { ensureAgyInstalled } from "./installer.js";
-import { AgyCliBackend, configFromEnv, type AgyCliConfig, type AgyCliSession, type SpawnFactory } from "./cli.js";
+import {
+  AgyCliBackend,
+  AGY_EXECUTION_MODES,
+  configFromEnv,
+  isAgyExecutionMode,
+  type AgyCliConfig,
+  type AgyCliSession,
+  type AgyExecutionMode,
+  type SpawnFactory
+} from "./cli.js";
 import { promptBlocksToAgyPrompt } from "./prompt-content.js";
 import { defaultStateDir, SessionStore, type StoredSession } from "./session-store.js";
 import { sessionUpdateToV1, sessionUpdateToV2 } from "./session-updates.js";
@@ -55,8 +64,9 @@ export type AgentContext = V1AgentContext;
 
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json") as { version?: string };
+const MODE_CONFIG_ID = "mode";
 const MODEL_CONFIG_ID = "model";
-const REASONING_EFFORT_CONFIG_ID = "effort";
+const REASONING_EFFORT_CONFIG_ID = "reasoningEffort";
 const NO_REASONING_VALUE = "none";
 /** Legacy `agy models` lines: `Gemini 3.5 Flash (Medium)`. */
 const LEGACY_EFFORT_PATTERN = /\((low|medium|high)\)\s*$/i;
@@ -434,6 +444,15 @@ export class AgyAcpAgent {
 
   private async applyConfigOption(sessionId: string, configId: string, value: unknown): Promise<void> {
     const session = this.requireSession(sessionId);
+    if (configId === MODE_CONFIG_ID) {
+      if (typeof value !== "string" || !isAgyExecutionMode(value)) {
+        throw new Error(`Mode must be one of: ${AGY_EXECUTION_MODES.join(", ")}`);
+      }
+      session.agy.setMode(value);
+      await this.persistSession(sessionId, session);
+      return;
+    }
+
     if (configId === MODEL_CONFIG_ID) {
       if (typeof value !== "string") {
         throw new Error("Model config value must be a string");
@@ -456,11 +475,11 @@ export class AgyAcpAgent {
 
     if (configId === REASONING_EFFORT_CONFIG_ID) {
       if (typeof value !== "string") {
-        throw new Error("Reasoning effect config value must be a string");
+        throw new Error("reasoningEffort config value must be a string");
       }
       const allowedEffects = reasoningEffectValues(session.selectedBaseModel, session.catalog);
       if (!allowedEffects.includes(value)) {
-        throw new Error(`Unknown reasoning effect: ${value}`);
+        throw new Error(`Unknown reasoningEffort: ${value}`);
       }
 
       session.selectedReasoningEffect = value;
@@ -596,6 +615,9 @@ export class AgyAcpAgent {
       ? restoredModelSelection(stored, catalog)
       : initialModelSelection(config.model, catalog);
     applyModelSelection(agy, selection.baseModel, selection.reasoningEffect, catalog);
+    if (stored?.mode && isAgyExecutionMode(stored.mode)) {
+      agy.setMode(stored.mode);
+    }
 
     return {
       id: "", // set by the caller once the ACP session id is known
@@ -635,8 +657,9 @@ export class AgyAcpAgent {
       workspaces: session.workspaces,
       conversationId: session.agy.conversationId,
       lastStepIdx: session.agy.lastStepIdx,
-      modelId: session.selectedBaseModel,
-      reasoningEffect: session.selectedReasoningEffect,
+      model: session.selectedBaseModel,
+      reasoningEffort: session.selectedReasoningEffect,
+      mode: session.agy.config.mode,
       updatedAt: new Date().toISOString()
     };
   }
@@ -772,11 +795,40 @@ export function buildModelCatalog(entries: string[]): ModelCatalog {
   };
 }
 
+export function modeConfigOption(mode: AgyExecutionMode): V1SessionConfigOption {
+  return {
+    id: MODE_CONFIG_ID,
+    name: "mode",
+    description:
+      "agy execution mode (--mode). Default reviews writes; Accept Edits applies file changes; Plan focuses on planning.",
+    category: "mode",
+    type: "select",
+    currentValue: mode,
+    options: [
+      {
+        value: "default",
+        name: "Default",
+        description: "Request review before file writes (agy default; omits --mode)."
+      },
+      {
+        value: "accept-edits",
+        name: "Accept Edits",
+        description: "Apply file edits without interactive write review (agy --mode accept-edits)."
+      },
+      {
+        value: "plan",
+        name: "Plan",
+        description: "Plan-oriented execution (agy --mode plan)."
+      }
+    ]
+  };
+}
+
 export function modelConfigOption(selectedBaseModel: string, catalog: ModelCatalog): V1SessionConfigOption {
   return {
     id: MODEL_CONFIG_ID,
-    name: "Model",
-    description: "ACP model slug passed to agy --model (effort is selected separately).",
+    name: "model",
+    description: "ACP model slug passed to agy --model (reasoningEffort is selected separately).",
     category: "model",
     type: "select",
     currentValue: selectedBaseModel,
@@ -794,7 +846,7 @@ export function reasoningEffectConfigOption(
 ): V1SessionConfigOption {
   return {
     id: REASONING_EFFORT_CONFIG_ID,
-    name: "Reasoning Effort",
+    name: "reasoningEffort",
     description: "Value for agy --effort (low | medium | high) for the selected model.",
     category: "thought_level",
     type: "select",
@@ -805,6 +857,7 @@ export function reasoningEffectConfigOption(
 
 function sessionConfigOptionsV1(session: SessionState): V1SessionConfigOption[] {
   return [
+    modeConfigOption(session.agy.config.mode),
     modelConfigOption(session.selectedBaseModel, session.catalog),
     reasoningEffectConfigOption(
       session.selectedBaseModel,
@@ -1014,7 +1067,7 @@ function restoredModelSelection(
   stored: StoredSession,
   catalog: ModelCatalog
 ): { baseModel: string; reasoningEffect: string } {
-  const baseModel = normalizeStoredBaseModel(stored.modelId, catalog);
+  const baseModel = normalizeStoredBaseModel(stored.model, catalog);
   if (!baseModel) {
     return initialModelSelection(undefined, catalog);
   }
@@ -1024,7 +1077,7 @@ function restoredModelSelection(
   }
   return {
     baseModel,
-    reasoningEffect: normalizeStoredReasoningEffect(stored.reasoningEffect, effects)
+    reasoningEffect: normalizeStoredReasoningEffect(stored.reasoningEffort, effects)
   };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,19 @@ export type SpawnFactory = (
   options: SpawnOptions
 ) => SpawnedProcess;
 
+/** agy execution mode for `--mode` (omit flag when `default`). */
+export type AgyExecutionMode = "default" | "accept-edits" | "plan";
+
+export const AGY_EXECUTION_MODES: readonly AgyExecutionMode[] = [
+  "default",
+  "accept-edits",
+  "plan"
+] as const;
+
+export function isAgyExecutionMode(value: string): value is AgyExecutionMode {
+  return (AGY_EXECUTION_MODES as readonly string[]).includes(value);
+}
+
 export interface AgyCliConfig {
   cwd: string;
   workspaces: string[];
@@ -34,6 +47,12 @@ export interface AgyCliConfig {
   model?: string;
   /** Value for `--effort` (`low` | `medium` | `high`), when applicable. */
   effort?: string;
+  /**
+   * Agent execution mode for `agy --mode`.
+   * `default` omits the flag (request-review / write confirmation).
+   * `accept-edits` and `plan` pass `--mode <value>`.
+   */
+  mode: AgyExecutionMode;
   project?: string;
   printTimeout: string;
   sandbox: boolean;
@@ -125,6 +144,10 @@ export class AgyCliSession {
     this.config.effort = effort;
   }
 
+  setMode(mode: AgyExecutionMode): void {
+    this.config.mode = mode;
+  }
+
   commandForPrompt(prompt: string): string[] {
     const command = [
       this.config.agyPath,
@@ -142,6 +165,9 @@ export class AgyCliSession {
     }
     if (this.config.skipPermissions) {
       command.push("--dangerously-skip-permissions");
+    }
+    if (this.config.mode !== "default") {
+      command.push("--mode", this.config.mode);
     }
     if (this.config.model) {
       command.push("--model", this.config.model);
@@ -481,12 +507,26 @@ export function configFromEnv(input: AgyCliConfigInput): AgyCliConfig {
     skipPermissions = true;
   }
 
+  let mode: AgyExecutionMode = "default";
+  const modeFromEnv = optional(env.AGY_ACP_MODE);
+  if (modeFromEnv && isAgyExecutionMode(modeFromEnv)) {
+    mode = modeFromEnv;
+  }
+  const modeFlagIdx = argv.indexOf("--mode");
+  if (modeFlagIdx >= 0) {
+    const modeArg = argv[modeFlagIdx + 1];
+    if (modeArg && isAgyExecutionMode(modeArg)) {
+      mode = modeArg;
+    }
+  }
+
   return {
     cwd: input.cwd,
     workspaces: input.workspaces ?? [input.cwd],
     agyPath: "agy",
     model: undefined,
     effort: undefined,
+    mode,
     project: undefined,
     printTimeout: "5m0s",
     sandbox,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,6 @@ export interface AgyCliConfig {
   model?: string;
   /** Value for `--effort` (`low` | `medium` | `high`), when applicable. */
   effort?: string;
-  fastMode: boolean;
   project?: string;
   printTimeout: string;
   sandbox: boolean;
@@ -126,19 +125,14 @@ export class AgyCliSession {
     this.config.effort = effort;
   }
 
-  setFastMode(enabled: boolean): void {
-    this.config.fastMode = enabled;
-  }
-
   commandForPrompt(prompt: string): string[] {
-    const effectivePrompt = this.effectivePrompt(prompt);
     const command = [
       this.config.agyPath,
       "--print"
     ];
 
     if (this.config.promptInArgv) {
-      command.push(effectivePrompt);
+      command.push(prompt);
     }
 
     command.push("--print-timeout", this.config.printTimeout);
@@ -185,21 +179,16 @@ export class AgyCliSession {
    * trailing polls have drained any steps flushed right around exit.
    */
   async prompt(prompt: string, onUpdate: (update: SessionUpdate) => Promise<void>): Promise<AgyPromptOutcome> {
-    const effectivePrompt = this.effectivePrompt(prompt);
     const command = this.commandForPrompt(prompt);
     try {
-      return await this.runPromptCommand(command, effectivePrompt, onUpdate);
+      return await this.runPromptCommand(command, prompt, onUpdate);
     } catch (error) {
       if (this.shouldInstallAfterError(error)) {
         await this.installAgy();
-        return await this.runPromptCommand(this.commandForPrompt(prompt), effectivePrompt, onUpdate);
+        return await this.runPromptCommand(this.commandForPrompt(prompt), prompt, onUpdate);
       }
       throw error;
     }
-  }
-
-  private effectivePrompt(prompt: string): string {
-    return this.config.fastMode ? `/fast\n${prompt}` : prompt;
   }
 
   private async runPromptCommand(
@@ -498,7 +487,6 @@ export function configFromEnv(input: AgyCliConfigInput): AgyCliConfig {
     agyPath: "agy",
     model: undefined,
     effort: undefined,
-    fastMode: false,
     project: undefined,
     printTimeout: "5m0s",
     sandbox,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,14 @@
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { once } from "node:events";
+import { chmodSync, existsSync, statSync } from "node:fs";
 import * as os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { conversationSnapshot } from "./db/scan.js";
 import { defaultInstallBinDir, ensureAgyInstalled } from "./installer.js";
 import { StreamPoller } from "./db/streaming.js";
+import { permissionKeys, type AgyPermissionChoice } from "./permissions.js";
 export const DEFAULT_AGY_MODEL_LIST_TIMEOUT_MS = 15_000;
 export const DEFAULT_CONVERSATIONS_DIR = path.join(os.homedir(), ".gemini", "antigravity-cli", "conversations");
 const POLL_INTERVAL_MS = 200;
@@ -14,6 +17,17 @@ const TRAILING_POLL_ATTEMPTS = 3;
 const TRAILING_POLL_DELAY_MS = 100;
 
 export type SpawnedProcess = ChildProcessWithoutNullStreams;
+
+export interface PtyProcess {
+  write(data: string): void;
+  kill(signal?: string): void;
+  onData(listener: (data: string) => void): { dispose(): void };
+  onExit(listener: (event: { exitCode: number; signal?: number }) => void): { dispose(): void };
+}
+export interface PtyFactory {
+  spawn(command: string, args: string[], options: { cwd: string; env?: NodeJS.ProcessEnv; cols: number; rows: number }): PtyProcess;
+}
+export type PermissionCallback = (toolCall: SessionUpdate) => Promise<AgyPermissionChoice | "cancelled">;
 
 export interface SpawnOptions {
   cwd: string;
@@ -57,6 +71,7 @@ export interface AgyCliConfig {
   printTimeout: string;
   sandbox: boolean;
   skipPermissions: boolean;
+  interactivePermissions: boolean;
   logFile?: string;
   promptInArgv: boolean;
   autoInstall: boolean;
@@ -101,19 +116,30 @@ export class AgyCliError extends Error {
 
 export class AgyCliSession {
   #process: SpawnedProcess | undefined;
+  #pty: PtyProcess | undefined;
+  #ptyExit: Promise<{ exitCode: number }> | undefined;
+  #ptyOutput = "";
+  #ptyIdleMarkerCount = 0;
+  #ptyIdleMatchTail = "";
+  #ptyConfig = "";
   #cancelled = false;
+  #cancelTurn: (() => void) | undefined;
+  #cancelWait: Promise<void> = Promise.resolve();
   #extraPath: string | undefined;
   #conversationId: string | null = null;
   #lastStepIdx = -1;
   readonly config: AgyCliConfig;
   readonly spawnProcess: SpawnFactory;
+  readonly ptyFactory?: PtyFactory;
 
   constructor(
     config: AgyCliConfig,
-    spawnProcess: SpawnFactory = defaultSpawnFactory
+    spawnProcess: SpawnFactory = defaultSpawnFactory,
+    ptyFactory?: PtyFactory
   ) {
     this.config = config;
     this.spawnProcess = spawnProcess;
+    this.ptyFactory = ptyFactory;
   }
 
   get wasCancelled(): boolean {
@@ -198,13 +224,27 @@ export class AgyCliSession {
     return command;
   }
 
+  interactiveCommandForPrompt(prompt: string): string[] {
+    const command = this.commandForPrompt(prompt);
+    const timeout = command.indexOf("--print-timeout");
+    if (timeout >= 0) command.splice(timeout, 2);
+    const print = command.indexOf("--print");
+    if (print >= 0) command.splice(print, this.config.promptInArgv ? 2 : 1);
+    command.splice(1, 0, "--prompt-interactive", prompt);
+    return command;
+  }
+
   /**
    * Run one prompt turn: spawn agy, poll its conversation database for newly
    * appended steps while the process runs, and invoke `onUpdate` with the
    * translated ACP updates in order. Resolves once the process exits and a few
    * trailing polls have drained any steps flushed right around exit.
    */
-  async prompt(prompt: string, onUpdate: (update: SessionUpdate) => Promise<void>): Promise<AgyPromptOutcome> {
+  async prompt(prompt: string, onUpdate: (update: SessionUpdate) => Promise<void>, onPermission?: PermissionCallback): Promise<AgyPromptOutcome> {
+    if (this.config.interactivePermissions) {
+      if (!onPermission) throw new Error("interactive permissions require a permission callback");
+      return this.runInteractivePrompt(prompt, onUpdate, onPermission);
+    }
     const command = this.commandForPrompt(prompt);
     try {
       return await this.runPromptCommand(command, prompt, onUpdate);
@@ -214,6 +254,112 @@ export class AgyCliSession {
         return await this.runPromptCommand(this.commandForPrompt(prompt), prompt, onUpdate);
       }
       throw error;
+    }
+  }
+
+  private async runInteractivePrompt(prompt: string, onUpdate: (update: SessionUpdate) => Promise<void>, onPermission: PermissionCallback): Promise<AgyPromptOutcome> {
+    this.#cancelled = false;
+    this.#cancelWait = new Promise((resolve) => { this.#cancelTurn = resolve; });
+    const signature = JSON.stringify([this.config.model, this.config.effort, this.config.mode]);
+    if (this.#pty && this.#ptyConfig !== signature) await this.stopPty();
+    if (this.#cancelled) { this.#cancelTurn = undefined; return { stopReason: "cancelled" }; }
+    const snapshot = this.#conversationId === null ? conversationSnapshot(this.config.conversationsDir) : null;
+    let freshPty = false;
+    if (!this.#pty) {
+      const factory = this.ptyFactory ?? await defaultPtyFactory();
+      if (this.#cancelled) { this.#cancelTurn = undefined; return { stopReason: "cancelled" }; }
+      const [program, ...args] = this.interactiveCommandForPrompt(prompt);
+      this.#pty = factory.spawn(program, args, { ...this.spawnOptions(), cols: 120, rows: 40 });
+      freshPty = true;
+      this.#ptyConfig = signature;
+      this.#ptyOutput = "";
+      this.#ptyIdleMarkerCount = 0;
+      this.#ptyIdleMatchTail = "";
+      this.#pty.onData((data) => {
+        const marker = "for shortcuts";
+        const searchable = this.#ptyIdleMatchTail + data;
+        let offset = 0;
+        while ((offset = searchable.indexOf(marker, offset)) >= 0) {
+          this.#ptyIdleMarkerCount++;
+          offset += marker.length;
+        }
+        this.#ptyIdleMatchTail = searchable.slice(-(marker.length - 1));
+        this.#ptyOutput = (this.#ptyOutput + data).slice(-16_384);
+      });
+      this.#ptyExit = new Promise((resolve) => this.#pty!.onExit(resolve));
+    } else {
+      this.#pty.write(`\x1b[200~${prompt.replaceAll("\x1b", "")}\x1b[201~\r`);
+    }
+    const poller = new StreamPoller({ dir: this.config.conversationsDir, conversationId: this.#conversationId,
+      baseStepIdx: this.#lastStepIdx, skipNarration: false, cwd: this.config.cwd, snapshot });
+    const requested = new Set<string>();
+    const activePtyExit = this.#ptyExit!;
+    const deadline = Date.now() + parsePrintTimeoutMs(this.config.printTimeout);
+    let candidateRevision = -1;
+    let seenRevision = -1;
+    // A newly spawned TUI first draws its initial idle prompt, then draws
+    // another when the submitted turn finishes. A reused TUI only owes the
+    // latter marker.
+    let requiredIdleMarkerCount = this.#ptyIdleMarkerCount + (freshPty ? 2 : 1);
+    let failed = false;
+    try {
+      while (true) {
+        if (this.#cancelled) break;
+        if (Date.now() >= deadline) throw new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final idle marker was observed`, [this.config.agyPath], null, this.#ptyOutput);
+        const updates = poller.poll();
+        if (poller.revision !== seenRevision) {
+          seenRevision = poller.revision;
+          candidateRevision = poller.turnCompleteCandidate ? poller.revision : -1;
+        } else if (!poller.turnCompleteCandidate) candidateRevision = -1;
+        for (const update of updates) await this.raceTurnCallback(onUpdate(update), deadline);
+        if (this.#cancelled) break;
+        for (const interaction of poller.takePending()) {
+          const toolCall = interaction.update;
+          const id = String((toolCall as unknown as { toolCallId?: string }).toolCallId);
+          if (requested.has(id)) continue;
+          requested.add(id);
+          if (interaction.toolName !== "run_command") {
+            throw new AgyCliError(`Unsupported agy interaction '${interaction.toolName}' (status 9); only run_command permission menus can be bridged safely`, [this.config.agyPath], null, this.#ptyOutput);
+          }
+          const choice = await this.raceTurnCallback(onPermission(toolCall), deadline);
+          if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
+          this.#pty?.write(permissionKeys(choice));
+          // An idle marker printed before the decision cannot mean that the
+          // approved/rejected command has finished.
+          requiredIdleMarkerCount = this.#ptyIdleMarkerCount + 1;
+        }
+        if (this.#cancelled) break;
+        if (candidateRevision === poller.revision && this.#ptyIdleMarkerCount >= requiredIdleMarkerCount) break;
+        const exited = await Promise.race([activePtyExit.then(() => true), sleep(POLL_INTERVAL_MS).then(() => false)]);
+        if (exited && !this.#cancelled) throw new AgyCliError(`agy interactive PTY exited unexpectedly: ${this.#ptyOutput.trim() || "<no output>"}`, [this.config.agyPath], null, this.#ptyOutput);
+      }
+      return { stopReason: this.#cancelled ? "cancelled" : "end_turn" };
+    } catch (error) {
+      failed = true;
+      await this.stopPty();
+      throw error;
+    } finally {
+      this.#conversationId = poller.conversationId ?? this.#conversationId;
+      this.#lastStepIdx = Math.max(this.#lastStepIdx, poller.lastStepIdx);
+      poller.close();
+      if (this.#cancelled && !failed) await this.stopPty();
+      this.#cancelTurn = undefined;
+    }
+  }
+
+  private async raceTurnCallback<T>(callback: Promise<T>, deadline: number): Promise<T | "cancelled"> {
+    const guarded = callback.catch((error) => {
+      if (this.#cancelled) return "cancelled" as const;
+      throw error;
+    });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timedOut = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final idle marker was observed`, [this.config.agyPath], null, this.#ptyOutput)), Math.max(0, deadline - Date.now()));
+    });
+    try {
+      return await Promise.race([guarded, this.#cancelWait.then(() => "cancelled" as const), timedOut]);
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   }
 
@@ -383,6 +529,17 @@ export class AgyCliSession {
   }
 
   async cancel(): Promise<void> {
+    if (this.#cancelTurn) {
+      this.#cancelled = true;
+      this.#cancelTurn();
+      if (this.#pty) await this.stopPty();
+      return;
+    }
+    if (this.#pty) {
+      this.#cancelled = true;
+      await this.stopPty();
+      return;
+    }
     const child = this.#process;
     if (!child || child.exitCode !== null) {
       return;
@@ -411,6 +568,23 @@ export class AgyCliSession {
     }
   }
 
+  private async stopPty(): Promise<void> {
+    const pty = this.#pty;
+    const exit = this.#ptyExit;
+    this.#pty = undefined;
+    this.#ptyExit = undefined;
+    if (pty) {
+      try { pty.kill(); } catch {}
+      if (exit) {
+        const exited = await Promise.race([exit.then(() => true), sleep(2_000).then(() => false)]);
+        if (!exited) {
+          try { pty.kill("SIGKILL"); } catch {}
+          await Promise.race([exit, sleep(500)]);
+        }
+      }
+    }
+  }
+
   async close(): Promise<void> {
     await this.cancel();
   }
@@ -419,12 +593,14 @@ export class AgyCliSession {
 export class AgyCliBackend {
   readonly spawnProcess: SpawnFactory;
 
-  constructor(spawnProcess: SpawnFactory = defaultSpawnFactory) {
+  readonly ptyFactory?: PtyFactory;
+  constructor(spawnProcess: SpawnFactory = defaultSpawnFactory, ptyFactory?: PtyFactory) {
     this.spawnProcess = spawnProcess;
+    this.ptyFactory = ptyFactory;
   }
 
   async startSession(config: AgyCliConfig): Promise<AgyCliSession> {
-    return new AgyCliSession(config, this.spawnProcess);
+    return new AgyCliSession(config, this.spawnProcess, this.ptyFactory);
   }
 
   async listModels(config: AgyCliConfig): Promise<string[]> {
@@ -506,6 +682,12 @@ export function configFromEnv(input: AgyCliConfigInput): AgyCliConfig {
   if (env.AGY_ACP_DANGEROUSLY_SKIP_PERMISSIONS || argv.includes("--dangerously-skip-permissions")) {
     skipPermissions = true;
   }
+  // Interactive permission forwarding is the normal execution path. The
+  // explicit dangerous bypass selects print mode because there is no
+  // permission request to forward when agy auto-approves everything.
+  const interactiveSetting = env.AGY_ACP_INTERACTIVE_PERMISSIONS?.trim().toLowerCase();
+  const interactiveDisabled = interactiveSetting === "0" || interactiveSetting === "false" || argv.includes("--no-interactive-permissions");
+  const interactivePermissions = !skipPermissions && !interactiveDisabled;
 
   let mode: AgyExecutionMode = "default";
   const modeFromEnv = optional(env.AGY_ACP_MODE);
@@ -531,6 +713,7 @@ export function configFromEnv(input: AgyCliConfigInput): AgyCliConfig {
     printTimeout: "5m0s",
     sandbox,
     skipPermissions,
+    interactivePermissions,
     logFile: undefined,
     promptInArgv: true,
     autoInstall: false,
@@ -555,9 +738,48 @@ function defaultSpawnFactory(command: string, args: string[], options: SpawnOpti
   });
 }
 
+export async function defaultPtyFactory(): Promise<PtyFactory> {
+  if (process.platform !== "win32") {
+    const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.resolve("node-pty"))));
+    const nativeDirs = [
+      path.join(packageRoot, "build", "Release"),
+      path.join(packageRoot, "build", "Debug"),
+      path.join(packageRoot, "prebuilds", `${process.platform}-${process.arch}`)
+    ];
+    const nativeDir = nativeDirs.find((dir) => existsSync(path.join(dir, "pty.node")));
+    const helper = nativeDir && path.join(nativeDir, "spawn-helper");
+    const helperMode = helper && existsSync(helper) ? statSync(helper).mode : undefined;
+    if (helper && helperMode !== undefined && (helperMode & 0o111) === 0) {
+      // node-pty 1.1.0's npm tarball loses this executable bit on some npm
+      // clients. Its native addon invokes the helper directly, so repair the
+      // packaged mode before the first spawn.
+      try {
+        chmodSync(helper, helperMode | 0o111);
+      } catch (error) {
+        throw new Error(`node-pty spawn-helper is not executable and could not be repaired at ${helper}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }
+  const pty = await import("node-pty");
+  return { spawn: (command, args, options) => pty.spawn(command, args, { ...options, name: "xterm-256color" }) };
+}
+
 function optional(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+/** Parse Go duration forms used by agy (for example 5m0s and 30s). */
+function parsePrintTimeoutMs(value: string): number {
+  const source = value.trim();
+  let total = 0;
+  let consumed = "";
+  for (const match of source.matchAll(/(\d+(?:\.\d+)?)(ms|h|m|s)/g)) {
+    consumed += match[0];
+    const scale = match[2] === "h" ? 3_600_000 : match[2] === "m" ? 60_000 : match[2] === "s" ? 1_000 : 1;
+    total += Number(match[1]) * scale;
+  }
+  return consumed === source && total > 0 ? total : 5 * 60_000;
 }
 
 export function parseAgyModels(output: string): string[] {

--- a/src/db/streaming.ts
+++ b/src/db/streaming.ts
@@ -5,7 +5,15 @@
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { ConversationDb } from "./database.js";
 import { newConversationId } from "./scan.js";
+import { toolCallId } from "./tool-call-updates.js";
 import { Translator } from "./translator.js";
+import type { StepRow } from "./types.js";
+
+export interface PendingInteraction {
+  update: SessionUpdate;
+  row: StepRow;
+  toolName: string;
+}
 
 export interface StreamOptions {
   dir: string;
@@ -23,6 +31,12 @@ export class StreamPoller {
   private readonly translator: Translator;
   private db: ConversationDb | null = null;
   private boundId: string | null;
+  private _pending: PendingInteraction[] = [];
+  private _hasRows = false;
+  private _busy = false;
+  private _latestAgentComplete = false;
+  private _revision = 0;
+  private rowSnapshot = "";
 
   constructor(private readonly opts: StreamOptions) {
     this.boundId = opts.conversationId;
@@ -45,6 +59,20 @@ export class StreamPoller {
     return this.translator.hadUpdates;
   }
 
+  /** Newly observed status-9 tool calls from the most recent poll. */
+  takePending(): PendingInteraction[] {
+    const pending = this._pending;
+    this._pending = [];
+    return pending;
+  }
+
+  get turnCompleteCandidate(): boolean {
+    return this._hasRows && !this._busy && this._latestAgentComplete;
+  }
+
+  /** Increments whenever the observed rows (including growing in-place rows) change. */
+  get revision(): number { return this._revision; }
+
   /** Read steps appended since the turn began and translate the new ones. */
   poll(): SessionUpdate[] {
     if (this.boundId === null && this.opts.snapshot !== null) {
@@ -57,7 +85,20 @@ export class StreamPoller {
       if (this.db === null) return [];
     }
 
-    return this.translator.translate(this.db.readAfter(this.opts.baseStepIdx));
+    const rows = this.db.readAfter(this.opts.baseStepIdx);
+    const snapshot = rows.map((row) => `${row.idx}:${row.stepType}:${row.status}:${JSON.stringify(row.stepPayload)}`).join("|");
+    if (snapshot !== this.rowSnapshot) { this.rowSnapshot = snapshot; this._revision++; }
+    this._hasRows = rows.length > 0;
+    this._busy = rows.some((row) => row.status !== 3 && row.status !== 6 && row.status !== 7);
+    const latest = rows.at(-1);
+    this._latestAgentComplete = latest?.stepType === 15 && latest.status === 3;
+    const updates = this.translator.translate(rows);
+    for (const update of updates.filter((item) => (item as unknown as { status?: string }).status === "pending")) {
+      const id = String((update as unknown as { toolCallId?: string }).toolCallId);
+      const row = rows.find((item) => toolCallId(item) === id);
+      if (row) this._pending.push({ update, row, toolName: row.stepPayload.toolRun?.call?.namePrimary || row.stepPayload.toolRun?.call?.nameSecondary || "unknown" });
+    }
+    return updates;
   }
 
   close(): void {

--- a/src/db/tool-call-updates.ts
+++ b/src/db/tool-call-updates.ts
@@ -40,14 +40,17 @@ export function parseRawInput(stepRow: StepRow): unknown {
 /** Stable tool-call id: agy's own call id when present, else a synthetic id
  *  derived from the step's position and type. */
 export function toolCallId(stepRow: StepRow): string {
-  return stepRow.stepPayload.toolRun?.call?.callId ?? `agy-${stepRow.idx}-${stepRow.stepType}`;
+  return stepRow.stepPayload.toolRun?.call?.callId.trim() || `agy-${stepRow.idx}-${stepRow.stepType}`;
 }
 
 /** Map agy's step `status` column to an ACP tool_call status.
- *  2 = in progress, 3 = completed, 6 = cancelled/aborted, 7 = failed.
+ *  2 = in progress, 3 = completed, 6 = cancelled/aborted, 7 = failed,
+ *  9 = generic RequestedInteraction (represented as pending for inspection).
  *  `cancelled` is ACP v2; v1 clients map it to `failed` at the protocol boundary. */
-function toolCallStatus(stepRow: StepRow): "in_progress" | "completed" | "failed" | "cancelled" {
+function toolCallStatus(stepRow: StepRow): "pending" | "in_progress" | "completed" | "failed" | "cancelled" {
   switch (stepRow.status) {
+    case 9:
+      return "pending";
     case 2:
       return "in_progress";
     case 6:

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -9,8 +9,9 @@ export type StepRow = {
   stepType: number;
   /**
    * agy step status enum (from the `status` column):
-   *   2 = in progress, 3 = completed, 6 = cancelled/aborted, 7 = failed.
-   * Mapped to ACP tool_call status by `toolCallStatus` in updates/utils.
+   *   1/2 = active, 3 = completed, 6 = cancelled/aborted, 7 = failed,
+   *   9 = RequestedInteraction (generic; not necessarily a permission menu).
+   * Only status-9 run_command rows are currently bridged to ACP permissions.
    */
   status: number;
   stepPayload: StepPayload;

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,0 +1,36 @@
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+
+export type AgyPermissionChoice =
+  | "agy-allow-once"
+  | "agy-allow-conversation"
+  | "agy-allow-settings"
+  | "agy-reject-once";
+
+export interface AgyPermissionOption {
+  optionId: AgyPermissionChoice;
+  kind: "allow_once" | "allow_always" | "reject_once";
+  name: string;
+}
+
+export function permissionKeys(choice: AgyPermissionChoice): string {
+  switch (choice) {
+    case "agy-allow-once": return "\r";
+    case "agy-allow-conversation": return "\x1b[B\r";
+    case "agy-allow-settings": return "\x1b[B\x1b[B\r";
+    case "agy-reject-once": return "\x1b[B\x1b[B\x1b[B\r";
+  }
+}
+
+/** Build choices matching agy 1.1.5's run_command menu. */
+export function permissionOptions(toolCall: SessionUpdate): AgyPermissionOption[] {
+  const raw = toolCall as unknown as Record<string, unknown>;
+  const input = raw.rawInput && typeof raw.rawInput === "object" ? raw.rawInput as Record<string, unknown> : {};
+  const target = typeof input.CommandLine === "string" && input.CommandLine.trim()
+    ? input.CommandLine.trim() : String(raw.title ?? "this command");
+  return [
+    { optionId: "agy-allow-once", kind: "allow_once", name: "Yes" },
+    { optionId: "agy-allow-conversation", kind: "allow_always", name: `Yes, and always allow in this conversation for commands that start with '${target}'` },
+    { optionId: "agy-allow-settings", kind: "allow_always", name: `Yes, and always allow for commands that start with '${target}' (Persist to settings.json)` },
+    { optionId: "agy-reject-once", kind: "reject_once", name: "No" }
+  ];
+}

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -29,7 +29,6 @@ export interface StoredSession {
   lastStepIdx: number;
   modelId: string;
   reasoningEffect: string;
-  fastMode: boolean;
   updatedAt: string;
 }
 

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -27,8 +27,12 @@ export interface StoredSession {
   workspaces: string[];
   conversationId: string | null;
   lastStepIdx: number;
-  modelId: string;
-  reasoningEffect: string;
+  /** Matches ACP config option `model` (base slug for agy --model). */
+  model: string;
+  /** Matches ACP config option `reasoningEffort` (maps to agy --effort). */
+  reasoningEffort: string;
+  /** Matches ACP config option `mode` (`default` | `accept-edits` | `plan`). Absent on older store files. */
+  mode?: string;
   updatedAt: string;
 }
 
@@ -74,9 +78,13 @@ export class SessionStore {
   private async load(): Promise<DiskStore> {
     try {
       const parsed = JSON.parse(await fs.promises.readFile(this.file, "utf-8")) as {
-        sessions?: Record<string, StoredSession>;
+        sessions?: Record<string, LegacyStoredSession>;
       };
-      return { sessions: parsed.sessions ?? {} };
+      const sessions: Record<string, StoredSession> = {};
+      for (const [id, raw] of Object.entries(parsed.sessions ?? {})) {
+        sessions[id] = normalizeStoredSession(raw);
+      }
+      return { sessions };
     } catch {
       return { sessions: {} };
     }
@@ -90,6 +98,27 @@ export class SessionStore {
     await fs.promises.writeFile(tmp, JSON.stringify(store, null, 2));
     await fs.promises.rename(tmp, this.file);
   }
+}
+
+/** Legacy disk keys from older agy-acp builds. */
+type LegacyStoredSession = Partial<StoredSession> & {
+  modelId?: string;
+  reasoningEffect?: string;
+};
+
+/** Map legacy disk keys (`modelId`, `reasoningEffect`) to current field names. */
+function normalizeStoredSession(raw: LegacyStoredSession): StoredSession {
+  const { modelId, reasoningEffect, ...rest } = raw;
+  return {
+    cwd: rest.cwd ?? "",
+    workspaces: rest.workspaces ?? [],
+    conversationId: rest.conversationId ?? null,
+    lastStepIdx: rest.lastStepIdx ?? -1,
+    model: rest.model ?? modelId ?? "",
+    reasoningEffort: rest.reasoningEffort ?? reasoningEffect ?? "",
+    mode: rest.mode,
+    updatedAt: rest.updatedAt ?? new Date(0).toISOString()
+  };
 }
 
 function optional(value: string | undefined): string | undefined {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -369,7 +369,7 @@ describe("buildModelCatalog", () => {
     expect(catalog.resolve("gemini-3.5-flash", "medium")).toBe("Gemini 3.5 Flash (Medium)");
   });
 
-  it("exposes separate model and effort config options", () => {
+  it("exposes mode, model, and reasoningEffort config options", () => {
     const catalog = buildModelCatalog(["gemini-3.5-flash-medium", "gemini-3.5-flash-high"]);
     const modelConfig = modelConfigOption("gemini-3.5-flash", catalog) as SelectConfigOption;
     const reasoningConfig = reasoningEffectConfigOption(
@@ -378,6 +378,10 @@ describe("buildModelCatalog", () => {
       catalog
     ) as SelectConfigOption;
 
+    expect(modelConfig.id).toBe("model");
+    expect(modelConfig.name).toBe("model");
+    expect(reasoningConfig.id).toBe("reasoningEffort");
+    expect(reasoningConfig.name).toBe("reasoningEffort");
     expect(modelConfig.options).toEqual([
       { value: "gemini-3.5-flash", name: "Gemini 3.5 Flash" }
     ]);
@@ -411,48 +415,69 @@ describe("session model config", () => {
         mcpServers: []
       });
       const configOptions = session.configOptions ?? [];
-      const modelConfig = configOptions.find((option) => option.id === "model") as SelectConfigOption | undefined;
-      const reasoningConfig = configOptions.find((option) => option.id === "effort") as SelectConfigOption | undefined;
+      expect(configOptions.map((option) => option.id)).toEqual(["mode", "model", "reasoningEffort"]);
+      expect(configOptions.map((option) => option.name)).toEqual(["mode", "model", "reasoningEffort"]);
 
-      expect(modelConfig?.category).toBe("model");
-      expect(modelConfig?.currentValue).toBe("gemini-3.5-flash");
-      expect(modelConfig?.options).toEqual([
+      const modeConfig = configOptions[0] as SelectConfigOption;
+      const modelConfig = configOptions[1] as SelectConfigOption;
+      const reasoningConfig = configOptions[2] as SelectConfigOption;
+
+      expect(modeConfig.category).toBe("mode");
+      expect(modeConfig.currentValue).toBe("default");
+      expect(optionValues(modeConfig)).toEqual(["default", "accept-edits", "plan"]);
+
+      expect(modelConfig.category).toBe("model");
+      expect(modelConfig.currentValue).toBe("gemini-3.5-flash");
+      expect(modelConfig.options).toEqual([
         { value: "gemini-3.5-flash", name: "Gemini 3.5 Flash" },
         { value: "claude-opus-4-6-thinking", name: "Claude Opus 4.6 Thinking" },
         { value: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" }
       ]);
-      expect(reasoningConfig?.category).toBe("thought_level");
-      expect(reasoningConfig?.currentValue).toBe("medium");
-      expect(reasoningConfig?.options).toEqual([
+
+      expect(reasoningConfig.category).toBe("thought_level");
+      expect(reasoningConfig.currentValue).toBe("medium");
+      expect(reasoningConfig.options).toEqual([
         { value: "medium", name: "Medium" },
         { value: "high", name: "High" }
       ]);
-      expect(configOptions.find((option) => option.id === "fast-mode")).toBeUndefined();
+      expect(configOptions.find((option) => option.id === "effort" || option.id === "fast-mode")).toBeUndefined();
 
       const modelResponse = await connection.agent.request(methods.agent.session.setConfigOption, {
         sessionId: session.sessionId,
         configId: "model",
         value: "gemini-3.5-flash"
       });
-      expect(modelResponse.configOptions[0].currentValue).toBe("gemini-3.5-flash");
-      expect(modelResponse.configOptions[1].currentValue).toBe("medium");
-      expect(optionValues(modelResponse.configOptions[1] as SelectConfigOption)).toEqual(["medium", "high"]);
+      expect(modelResponse.configOptions.map((option) => option.id)).toEqual([
+        "mode",
+        "model",
+        "reasoningEffort"
+      ]);
+      expect(modelResponse.configOptions[1].currentValue).toBe("gemini-3.5-flash");
+      expect(modelResponse.configOptions[2].currentValue).toBe("medium");
+      expect(optionValues(modelResponse.configOptions[2] as SelectConfigOption)).toEqual(["medium", "high"]);
 
       const reasoningResponse = await connection.agent.request(methods.agent.session.setConfigOption, {
         sessionId: session.sessionId,
-        configId: "effort",
+        configId: "reasoningEffort",
         value: "high"
       });
-      expect(reasoningResponse.configOptions[1].currentValue).toBe("high");
+      expect(reasoningResponse.configOptions[2].currentValue).toBe("high");
+
+      const modeResponse = await connection.agent.request(methods.agent.session.setConfigOption, {
+        sessionId: session.sessionId,
+        configId: "mode",
+        value: "accept-edits"
+      });
+      expect(modeResponse.configOptions[0].currentValue).toBe("accept-edits");
 
       const thinkingResponse = await connection.agent.request(methods.agent.session.setConfigOption, {
         sessionId: session.sessionId,
         configId: "model",
         value: "claude-opus-4-6-thinking"
       });
-      expect(thinkingResponse.configOptions[0].currentValue).toBe("claude-opus-4-6-thinking");
-      expect(thinkingResponse.configOptions[1].currentValue).toBe("none");
-      expect(optionNames(thinkingResponse.configOptions[1] as SelectConfigOption)).toEqual(["N/A"]);
+      expect(thinkingResponse.configOptions[1].currentValue).toBe("claude-opus-4-6-thinking");
+      expect(thinkingResponse.configOptions[2].currentValue).toBe("none");
+      expect(optionNames(thinkingResponse.configOptions[2] as SelectConfigOption)).toEqual(["N/A"]);
 
       await connection.agent.request(methods.agent.session.prompt, {
         sessionId: session.sessionId,
@@ -463,6 +488,7 @@ describe("session model config", () => {
       expect(promptCall?.args[promptCall.args.indexOf("--print") + 1]).toBe("hi");
       expect(flagValue(promptCall!.args, "--model")).toBe("claude-opus-4-6-thinking");
       expect(promptCall!.args).not.toContain("--effort");
+      expect(flagValue(promptCall!.args, "--mode")).toBe("accept-edits");
     } finally {
       connection.close();
     }
@@ -488,7 +514,7 @@ describe("session model config", () => {
       });
       await connection.agent.request(methods.agent.session.setConfigOption, {
         sessionId: session.sessionId,
-        configId: "effort",
+        configId: "reasoningEffort",
         value: "high"
       });
       await connection.agent.request(methods.agent.session.prompt, {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -413,7 +413,6 @@ describe("session model config", () => {
       const configOptions = session.configOptions ?? [];
       const modelConfig = configOptions.find((option) => option.id === "model") as SelectConfigOption | undefined;
       const reasoningConfig = configOptions.find((option) => option.id === "effort") as SelectConfigOption | undefined;
-      const fastConfig = configOptions.find((option) => option.id === "fast-mode") as SelectConfigOption | undefined;
 
       expect(modelConfig?.category).toBe("model");
       expect(modelConfig?.currentValue).toBe("gemini-3.5-flash");
@@ -428,9 +427,7 @@ describe("session model config", () => {
         { value: "medium", name: "Medium" },
         { value: "high", name: "High" }
       ]);
-      expect(fastConfig?.category).toBe("model_config");
-      expect(fastConfig?.type).toBe("select");
-      expect(fastConfig?.currentValue).toBe("off");
+      expect(configOptions.find((option) => option.id === "fast-mode")).toBeUndefined();
 
       const modelResponse = await connection.agent.request(methods.agent.session.setConfigOption, {
         sessionId: session.sessionId,
@@ -448,13 +445,6 @@ describe("session model config", () => {
       });
       expect(reasoningResponse.configOptions[1].currentValue).toBe("high");
 
-      const fastResponse = await connection.agent.request(methods.agent.session.setConfigOption, {
-        sessionId: session.sessionId,
-        configId: "fast-mode",
-        value: "on"
-      });
-      expect(fastResponse.configOptions[2].currentValue).toBe("on");
-
       const thinkingResponse = await connection.agent.request(methods.agent.session.setConfigOption, {
         sessionId: session.sessionId,
         configId: "model",
@@ -470,7 +460,7 @@ describe("session model config", () => {
       });
 
       const promptCall = calls.find((call) => call.args.includes("--print"));
-      expect(promptCall?.args[promptCall.args.indexOf("--print") + 1]).toBe("/fast\nhi");
+      expect(promptCall?.args[promptCall.args.indexOf("--print") + 1]).toBe("hi");
       expect(flagValue(promptCall!.args, "--model")).toBe("claude-opus-4-6-thinking");
       expect(promptCall!.args).not.toContain("--effort");
     } finally {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -379,9 +379,9 @@ describe("buildModelCatalog", () => {
     ) as SelectConfigOption;
 
     expect(modelConfig.id).toBe("model");
-    expect(modelConfig.name).toBe("model");
+    expect(modelConfig.name).toBe("Model");
     expect(reasoningConfig.id).toBe("reasoningEffort");
-    expect(reasoningConfig.name).toBe("reasoningEffort");
+    expect(reasoningConfig.name).toBe("Reasoning Effort");
     expect(modelConfig.options).toEqual([
       { value: "gemini-3.5-flash", name: "Gemini 3.5 Flash" }
     ]);
@@ -416,7 +416,7 @@ describe("session model config", () => {
       });
       const configOptions = session.configOptions ?? [];
       expect(configOptions.map((option) => option.id)).toEqual(["mode", "model", "reasoningEffort"]);
-      expect(configOptions.map((option) => option.name)).toEqual(["mode", "model", "reasoningEffort"]);
+      expect(configOptions.map((option) => option.name)).toEqual(["Mode", "Model", "Reasoning Effort"]);
 
       const modeConfig = configOptions[0] as SelectConfigOption;
       const modelConfig = configOptions[1] as SelectConfigOption;

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -65,7 +65,7 @@ describe("session prompt", () => {
           updates.push(ctx.params.update);
         });
       const connection = client.connect(createAgyAcpApp({
-        env: { AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir },
+        env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
         spawnProcess: spawnAgyWritingConversation(dir, "conv-1", [
           { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hello" }) }
         ])
@@ -100,7 +100,7 @@ describe("session prompt", () => {
           updates.push(ctx.params.update);
         });
       const connection = client.connect(createAgyAcpApp({
-        env: { AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir },
+        env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
         spawnProcess: spawnAgyWritingConversation(dir, "conv-2", [
           {
             idx: 1,
@@ -149,7 +149,7 @@ describe("session/load and session/resume", () => {
   it("replays prior conversation history on load, but not on resume, after a simulated restart", async () => {
     await withConversationsDir(async (dir) => {
       const appOptions = {
-        env: { AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir },
+        env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
         spawnProcess: spawnAgyWritingConversation(dir, "conv-persisted", [
           { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hello from before" }) }
         ])
@@ -228,7 +228,7 @@ describe("session/load and session/resume", () => {
   it("lists persisted sessions after a restart", async () => {
     await withConversationsDir(async (dir) => {
       const appOptions = {
-        env: { AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir },
+        env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
         spawnProcess: spawnAgyWritingConversation(dir, "conv-list", [
           { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "listed" }) }
         ])
@@ -278,7 +278,7 @@ describe("session/load and session/resume", () => {
   it("rejects loading a session that was never persisted", async () => {
     await withConversationsDir(async (dir) => {
       const connection = acpClient({ name: "test-client" }).connect(createAgyAcpApp({
-        env: { AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir },
+        env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
         spawnProcess: spawnAgyWritingConversation(dir, "unused", [])
       }));
       try {
@@ -407,7 +407,7 @@ describe("session model config", () => {
       .onNotification(methods.client.session.update, (ctx) => {
         updates.push(ctx.params.update as { content: { text: string } });
       });
-    const connection = client.connect(createAgyAcpApp({ spawnProcess: spawnProcess as unknown as SpawnFactory }));
+    const connection = client.connect(createAgyAcpApp({ env: printModeEnv(), spawnProcess: spawnProcess as unknown as SpawnFactory }));
     try {
       const session = await connection.agent.request(methods.agent.session.new, {
         cwd: "/repo",
@@ -504,7 +504,7 @@ describe("session model config", () => {
       return new FakeProcess(["ok"]);
     };
     const connection = acpClient({ name: "test-client" }).connect(
-      createAgyAcpApp({ spawnProcess: spawnProcess as unknown as SpawnFactory })
+      createAgyAcpApp({ env: printModeEnv(), spawnProcess: spawnProcess as unknown as SpawnFactory })
     );
     try {
       const session = await connection.agent.request(methods.agent.session.new, {
@@ -564,7 +564,7 @@ describe("ACP v2 (experimental draft)", () => {
       );
       const connection = client.connect(
         createAgyAcpV2App({
-          env: { AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir },
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
           spawnProcess: spawnAgyWritingConversation(dir, "conv-v2-1", [
             { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hello v2" }) }
           ])
@@ -617,7 +617,7 @@ describe("ACP v2 (experimental draft)", () => {
   it("replays history on session/resume with replayFrom start", async () => {
     await withConversationsDir(async (dir) => {
       const appOptions = {
-        env: { AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir },
+        env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
         spawnProcess: spawnAgyWritingConversation(dir, "conv-v2-replay", [
           { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "prior turn" }) }
         ])
@@ -711,6 +711,10 @@ describe("ACP v2 (experimental draft)", () => {
 
 const TEST_MODELS_OUTPUT =
   "gemini-3.5-flash-medium\ngemini-3.5-flash-high\nclaude-opus-4-6-thinking\nclaude-sonnet-4-6\n";
+
+function printModeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { ...overrides, AGY_ACP_INTERACTIVE_PERMISSIONS: "0" };
+}
 
 async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
   const start = Date.now();

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -66,6 +66,23 @@ describe("commandForPrompt", () => {
     expect(flagValue(command, "--model")).toBe("gemini-3.5-flash");
     expect(flagValue(command, "--effort")).toBe("high");
   });
+
+  it("omits --mode for default and passes accept-edits or plan", () => {
+    const defaultCmd = new AgyCliSession(defaultConfig()).commandForPrompt("hello");
+    expect(defaultCmd).not.toContain("--mode");
+
+    const acceptCmd = new AgyCliSession({
+      ...defaultConfig(),
+      mode: "accept-edits"
+    }).commandForPrompt("hello");
+    expect(flagValue(acceptCmd, "--mode")).toBe("accept-edits");
+
+    const planCmd = new AgyCliSession({
+      ...defaultConfig(),
+      mode: "plan"
+    }).commandForPrompt("hello");
+    expect(flagValue(planCmd, "--mode")).toBe("plan");
+  });
 });
 
 describe("configFromEnv", () => {
@@ -83,6 +100,24 @@ describe("configFromEnv", () => {
     expect(config.skipPermissions).toBe(false);
     expect(config.promptInArgv).toBe(true);
     expect(config.autoInstall).toBe(false);
+  });
+
+  it("configures mode from argv and env", () => {
+    expect(configFromEnv({ cwd: "/repo" }).mode).toBe("default");
+    expect(configFromEnv({ cwd: "/repo", argv: ["--mode", "accept-edits"] }).mode).toBe("accept-edits");
+    expect(
+      configFromEnv({
+        cwd: "/repo",
+        env: { AGY_ACP_MODE: "plan" }
+      }).mode
+    ).toBe("plan");
+    expect(
+      configFromEnv({
+        cwd: "/repo",
+        env: { AGY_ACP_MODE: "plan" },
+        argv: ["--mode", "accept-edits"]
+      }).mode
+    ).toBe("accept-edits");
   });
 
   it("configures sandbox and skipPermissions based on argv and env", () => {
@@ -288,6 +323,7 @@ function defaultConfig(): AgyCliConfig {
     agyPath: "agy",
     printTimeout: "5m0s",
     effort: undefined,
+    mode: "default",
     sandbox: true,
     skipPermissions: false,
     promptInArgv: true,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -181,28 +181,6 @@ describe("prompt", () => {
     expect(calls[0].args[calls[0].args.indexOf("--print") + 1]).not.toBe("hello");
   });
 
-  it("prepends the transient /fast command in fast mode", async () => {
-    const fake = new FakeProcess(["ok"]);
-    const calls: SpawnCall[] = [];
-    const session = new AgyCliSession({ ...defaultConfig(), fastMode: true }, fake.spawnFactory(calls));
-
-    await collectUpdates(session, "hello");
-
-    expect(calls[0].args[calls[0].args.indexOf("--print") + 1]).toBe("/fast\nhello");
-  });
-
-  it("prefixes stdin prompts when prompt argv is disabled in fast mode", async () => {
-    const fake = new FakeProcess(["ok"]);
-    const session = new AgyCliSession(
-      { ...defaultConfig(), fastMode: true, promptInArgv: false },
-      fake.spawnFactory([])
-    );
-
-    await collectUpdates(session, "hello");
-
-    expect(fake.stdinText).toBe("/fast\nhello");
-  });
-
   it("binds the conversation id agy creates, then passes --conversation on the next turn", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-test-"));
     try {
@@ -309,7 +287,6 @@ function defaultConfig(): AgyCliConfig {
     workspaces: ["/repo"],
     agyPath: "agy",
     printTimeout: "5m0s",
-    fastMode: false,
     effort: undefined,
     sandbox: true,
     skipPermissions: false,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -14,11 +14,14 @@ import {
   configFromEnv,
   parseAgyModels,
   type AgyCliConfig,
+  type PtyFactory,
+  type PtyProcess,
   type SpawnFactory,
   type SpawnOptions
 } from "../src/cli.js";
-import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
-import { encodeStepPayload } from "./fixtures/step-encoder.js";
+import { permissionKeys, permissionOptions } from "../src/permissions.js";
+import { createConversationDb, insertStep, updateStep } from "./fixtures/conversation-db.js";
+import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 
 /** Collects updates via the `onUpdate` callback `AgyCliSession.prompt` takes. */
 async function collectUpdates(
@@ -83,6 +86,153 @@ describe("commandForPrompt", () => {
     }).commandForPrompt("hello");
     expect(flagValue(planCmd, "--mode")).toBe("plan");
   });
+
+  it("builds interactive mode without print flags", () => {
+    const session = new AgyCliSession({ ...defaultConfig(), interactivePermissions: true });
+    const command = session.interactiveCommandForPrompt("hello");
+    expect(command.slice(0, 3)).toEqual(["agy", "--prompt-interactive", "hello"]);
+    expect(command).not.toContain("--print");
+    expect(command).not.toContain("--print-timeout");
+  });
+});
+
+describe("permission bridge", () => {
+  it("maps every semantic choice to agy's menu keys", () => {
+    expect(permissionKeys("agy-allow-once")).toBe("\r");
+    expect(permissionKeys("agy-allow-conversation")).toBe("\x1b[B\r");
+    expect(permissionKeys("agy-allow-settings")).toBe("\x1b[B\x1b[B\r");
+    expect(permissionKeys("agy-reject-once")).toBe("\x1b[B\x1b[B\x1b[B\r");
+    expect(permissionOptions({ sessionUpdate: "tool_call", toolCallId: "x", title: "Run", kind: "execute", status: "pending", rawInput: { CommandLine: "whoami" } })).toEqual([
+      { optionId: "agy-allow-once", kind: "allow_once", name: "Yes" },
+      { optionId: "agy-allow-conversation", kind: "allow_always", name: "Yes, and always allow in this conversation for commands that start with 'whoami'" },
+      { optionId: "agy-allow-settings", kind: "allow_always", name: "Yes, and always allow for commands that start with 'whoami' (Persist to settings.json)" },
+      { optionId: "agy-reject-once", kind: "reject_once", name: "No" }
+    ]);
+  });
+
+  for (const [choice, keys] of [
+    ["agy-allow-once", "\r"],
+    ["agy-allow-conversation", "\x1b[B\r"],
+    ["agy-allow-settings", "\x1b[B\x1b[B\r"],
+    ["agy-reject-once", "\x1b[B\x1b[B\x1b[B\r"]
+  ] as const) {
+    it(`bridges ${choice} once and waits for the post-final idle marker`, async () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+      const pty = new FakePty(() => {
+        const db = createConversationDb(dir, "permission");
+        insertStep(db, pendingToolRow("run_command"));
+        db.close();
+      });
+      const session = interactiveSession(dir, pty);
+      let calls = 0;
+      let resolved = false;
+      const result = session.prompt("go", async () => {}, async () => {
+        calls++;
+        const db = new (await import("better-sqlite3")).default(path.join(dir, "permission.db"));
+        updateStep(db, 1, { status: 3 });
+        insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+        db.close();
+        setTimeout(() => pty.emitData("? for shortcuts"), 250);
+        return choice;
+      }).then((value) => { resolved = true; return value; });
+      await new Promise((resolve) => setTimeout(resolve, 225));
+      expect(resolved).toBe(false);
+      expect((await result).stopReason).toBe("end_turn");
+      expect(calls).toBe(1);
+      expect(pty.writes).toEqual([keys]);
+      await session.close();
+      expect(pty.killed).toBe(true);
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+  }
+
+  it("accepts an idle marker emitted after the DB write but before the next poll", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "permission-race");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const result = session.prompt("go", async () => {}, async () => {
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "permission-race.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 0);
+      return "agy-allow-once";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not mistake the fresh TUI startup marker for turn completion", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "startup-marker");
+      insertStep(db, { idx: 1, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    let resolved = false;
+    const result = session.prompt("go", async () => {}, async () => "agy-allow-once")
+      .then((value) => { resolved = true; return value; });
+
+    await new Promise((resolve) => setTimeout(resolve, 225));
+    pty.emitData("redraw without another marker");
+    await new Promise((resolve) => setTimeout(resolve, 225));
+    expect(resolved).toBe(false);
+    pty.emitData("? for shortcuts");
+    expect((await result).stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("times out while the ACP client leaves a permission request unanswered", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "permission-timeout");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty, "30ms");
+
+    await expect(session.prompt("go", async () => {}, () => new Promise(() => {}))).rejects.toThrow(/timed out after 30ms/);
+    expect(pty.killed).toBe(true);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("fails closed for ask_question without writing menu keys", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => { const db = createConversationDb(dir, "ask"); insertStep(db, pendingToolRow("ask_question")); db.close(); });
+    const session = interactiveSession(dir, pty);
+    await expect(session.prompt("go", async () => {}, async () => "agy-allow-once")).rejects.toThrow(/Unsupported agy interaction 'ask_question'/);
+    expect(pty.writes).toEqual([]);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("cancels reliably while awaiting permission", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => { const db = createConversationDb(dir, "cancel"); insertStep(db, pendingToolRow("run_command")); db.close(); });
+    const session = interactiveSession(dir, pty);
+    const pending = session.prompt("go", async () => {}, () => new Promise((resolve) => setTimeout(() => resolve("cancelled"), 300)));
+    await new Promise((resolve) => setTimeout(resolve, 220));
+    await session.cancel();
+    expect((await pending).stopReason).toBe("cancelled");
+    expect(pty.writes).toEqual([]);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("times out and stops the PTY when no conversation binds", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty();
+    const session = interactiveSession(dir, pty, "30ms");
+    await expect(session.prompt("go", async () => {}, async () => "cancelled")).rejects.toThrow(/timed out after 30ms/);
+    expect(pty.killed).toBe(true);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
 });
 
 describe("configFromEnv", () => {
@@ -100,6 +250,7 @@ describe("configFromEnv", () => {
     expect(config.skipPermissions).toBe(false);
     expect(config.promptInArgv).toBe(true);
     expect(config.autoInstall).toBe(false);
+    expect(config.interactivePermissions).toBe(true);
   });
 
   it("configures mode from argv and env", () => {
@@ -127,6 +278,7 @@ describe("configFromEnv", () => {
     });
     expect(config1.sandbox).toBe(false);
     expect(config1.skipPermissions).toBe(true);
+    expect(config1.interactivePermissions).toBe(false);
 
     const config2 = configFromEnv({
       cwd: "/repo",
@@ -137,6 +289,7 @@ describe("configFromEnv", () => {
     });
     expect(config2.sandbox).toBe(false);
     expect(config2.skipPermissions).toBe(true);
+    expect(config2.interactivePermissions).toBe(false);
 
     const config3 = configFromEnv({
       cwd: "/repo",
@@ -154,6 +307,14 @@ describe("configFromEnv", () => {
       }
     });
     expect(config4.sandbox).toBe(true);
+  });
+
+  it("enables interactive permissions by default and lets the dangerous bypass select print mode", () => {
+    expect(configFromEnv({ cwd: "/repo" }).interactivePermissions).toBe(true);
+    expect(configFromEnv({ cwd: "/repo", argv: ["--dangerously-skip-permissions"] }).interactivePermissions).toBe(false);
+    expect(configFromEnv({ cwd: "/repo", env: { AGY_ACP_DANGEROUSLY_SKIP_PERMISSIONS: "1" } }).interactivePermissions).toBe(false);
+    expect(configFromEnv({ cwd: "/repo", env: { AGY_ACP_INTERACTIVE_PERMISSIONS: "0" } }).interactivePermissions).toBe(false);
+    expect(configFromEnv({ cwd: "/repo", argv: ["--no-interactive-permissions"] }).interactivePermissions).toBe(false);
   });
 });
 
@@ -326,6 +487,7 @@ function defaultConfig(): AgyCliConfig {
     mode: "default",
     sandbox: true,
     skipPermissions: false,
+    interactivePermissions: false,
     promptInArgv: true,
     autoInstall: false,
     modelList: [],
@@ -394,4 +556,33 @@ class FakeProcess extends EventEmitter {
       return this as unknown as ReturnType<SpawnFactory>;
     };
   }
+}
+
+function pendingToolRow(name: string) {
+  return { idx: 1, stepType: 21, status: 9, stepPayload: encodeStepPayload({
+    toolRun: encodeToolRun({ call: encodeToolCall({ callId: "permission-1", namePrimary: name, rawInputJson: '{"CommandLine":"echo hi"}' }) })
+  }) };
+}
+
+function interactiveSession(dir: string, pty: FakePty, printTimeout = "3s") {
+  return new AgyCliSession({ ...defaultConfig(), conversationsDir: dir, interactivePermissions: true, printTimeout }, undefined, {
+    spawn: () => { pty.start(); return pty; }
+  } as PtyFactory);
+}
+
+class FakePty implements PtyProcess {
+  writes: string[] = [];
+  killed = false;
+  private dataListeners: Array<(data: string) => void> = [];
+  private exitListeners: Array<(event: { exitCode: number }) => void> = [];
+  constructor(private readonly onSpawn?: () => void) {}
+  start() {
+    this.onSpawn?.();
+    queueMicrotask(() => this.emitData("? for shortcuts"));
+  }
+  write(data: string) { this.writes.push(data); }
+  kill() { this.killed = true; for (const listener of this.exitListeners) listener({ exitCode: 0 }); }
+  onData(listener: (data: string) => void) { this.dataListeners.push(listener); return { dispose() {} }; }
+  onExit(listener: (event: { exitCode: number }) => void) { this.exitListeners.push(listener); return { dispose() {} }; }
+  emitData(data: string) { for (const listener of this.dataListeners) listener(data); }
 }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -197,6 +197,19 @@ describe("Translator", () => {
     db.close();
   });
 
+  it("maps permission-pending status 9 and dedupes its transition", () => {
+    const db = createConversationDb(dir, "conv-pending");
+    const payload = encodeStepPayload({ toolRun: encodeToolRun({ call: encodeToolCall({ callId: "p1", namePrimary: "run_command", rawInputJson: "{}" }) }) });
+    insertStep(db, { idx: 1, stepType: 21, status: 9, stepPayload: payload });
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const conn = ConversationDb.open(dir, "conv-pending")!;
+    expect(translator.translate(conn.readAfter(0))).toMatchObject([{ sessionUpdate: "tool_call", status: "pending" }]);
+    expect(translator.translate(conn.readAfter(0))).toEqual([]);
+    updateStep(db, 1, { status: 3, stepPayload: payload });
+    expect(translator.translate(conn.readAfter(0))).toMatchObject([{ sessionUpdate: "tool_call_update", status: "completed" }]);
+    conn.close(); db.close();
+  });
+
 
   it("emits agent_thought_chunk for title-attached Think narration", () => {
     const db = createConversationDb(dir, "conv-thought");


### PR DESCRIPTION
## Summary

- Align session config with agy 1.1.x: remove obsolete `fast-mode` (`/fast`), add `mode` (`default` / `accept-edits` / `plan`), and stabilize option ids as `mode`, `model`, `reasoningEffort` with human-facing labels Mode / Model / Reasoning Effort.
- Add an experimental default interactive permission bridge: persistent `agy --prompt-interactive` PTY, status-9 `run_command` menus via ACP `session/request_permission` (Yes / conversation allow / settings allow / No). Print mode remains for `--dangerously-skip-permissions` and `--no-interactive-permissions`.
- Ship as package **0.2.7** (changelog, version bump, node-pty dependency + platform smoke).

## Test plan

- [x] `npm test` (71 tests) on the release branch
- [ ] CI green on the PR (including platform smoke + node-pty check)
- [ ] Manual smoke in Zed: set Mode / Model / Reasoning Effort; approve a `run_command` permission once
- [ ] Confirm print-mode fallback with `AGY_ACP_INTERACTIVE_PERMISSIONS=0` or skip-permissions still works