### PR TITLE
Release 0.2.8: broader permissions, FS write-through, modes, and plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ for draft v2 may still change before ACP v2 stabilizes.
   to draft-v2 `plan_update` (`type: "markdown"` when the body is known, else
   `type: "items"`). Replaces the previous Plan-titled prose tool_call for those
   writes. No `plan_removed` and no live step status beyond checkbox markers.
+- Native ACP v1 session modes: advertise `modes` on `session/new`, `session/load`,
+  and `session/resume`, and handle `session/set_mode` for the same three ids as
+  the `mode` config option (`default` / `accept-edits` / `plan` → `agy --mode`).
+- Dual-sync mode surfaces: `session/set_mode` pushes `current_mode_update` and
+  `config_option_update`; changing `mode` via `session/set_config_option` pushes
+  `current_mode_update` so native mode UIs stay aligned.
 
 ## [0.2.7] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ for draft v2 may still change before ACP v2 stabilizes.
   embed `{ type: "terminal", terminalId }` on the tool call. v1 clients keep
   command/output content blocks. Client-executed v1 `terminal/*` is still not
   used (agy runs the shell; re-running via the editor would double-execute).
+- Structured ACP plans from agy brain markdown artifacts: emit classic v1
+  `sessionUpdate: "plan"` with entries parsed from lists/checkboxes, and map
+  to draft-v2 `plan_update` (`type: "markdown"` when the body is known, else
+  `type: "items"`). Replaces the previous Plan-titled prose tool_call for those
+  writes. No `plan_removed` and no live step status beyond checkbox markers.
 
 ## [0.2.7] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,24 @@ for draft v2 may still change before ACP v2 stabilizes.
   `config_option_update`; changing `mode` via `session/set_config_option` pushes
   `current_mode_update` so native mode UIs stay aligned.
 
+## [0.2.8] - 2026-07-22
+
+Broader interactive permission bridge: file tools and single-select
+`ask_question` can be answered through ACP clients.
+
+### Changed
+
+- Interactive permission bridge now covers file tools that share agy's
+  four-choice ToolConfirmationPanel (`write_to_file`, `replace_file_content`,
+  `multi_replace_file_content`, `view_file`, `list_dir`) in addition to
+  `run_command`.
+- Single-select, single-question `ask_question` is bridged through
+  `session/request_permission` (one option per choice + Skip). Multi-select
+  and multi-question forms still fail closed without writing PTY keys.
+- File-edit permissions use **standard ACP** option ids/kinds
+  (`allow-once` / `allow-always` / `reject-once`) so clients can map them to
+  native Keep / Reject UI, while still driving agy's TUI via PTY keys.
+
 ## [0.2.7] - 2026-07-22
 
 Session config aligned with Antigravity CLI 1.1.x, plus an experimental

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [Unreleased]
 
+### Added
+
+- Draft ACP v2 agent-owned terminals for `run_command` / execute tools: emit
+  `terminal_update` (command, cwd, base64 output snapshot, exit status) and
+  embed `{ type: "terminal", terminalId }` on the tool call. v1 clients keep
+  command/output content blocks. Client-executed v1 `terminal/*` is still not
+  used (agy runs the shell; re-running via the editor would double-execute).
+
 ## [0.2.7] - 2026-07-22
 
 Session config aligned with Antigravity CLI 1.1.x, plus an experimental

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ACP adapter for Google Antigravity's `agy` CLI. TypeScript, `npx`-runnable, buil
 `@agentclientprotocol/sdk`. Runs a persistent interactive `agy` process so ACP clients
 can answer permission requests while keeping the logged-in Antigravity CLI experience.
 
-**Package:** `0.2.7` (`latest`) — ACP v1 + experimental draft ACP v2 via `initialize`
+**Package:** `0.2.8` (`latest`) — ACP v1 + experimental draft ACP v2 via `initialize`
 negotiation. Draft v2 continues on the `alpha` dist-tag (`1.0.0-alpha.*`). See the
 [ACP v2 draft](https://agentclientprotocol.com/announcements/acp-v2-draft) and
 [migration guide](https://agentclientprotocol.com/protocol/v2/migration).
@@ -20,7 +20,7 @@ curl -fsSL https://antigravity.google/cli/install.sh | bash
 ```
 
 ```sh
-npx agy-acp                 # stable (0.2.7)
+npx agy-acp                 # stable (0.2.8)
 npx agy-acp@alpha           # draft ACP v2 channel
 npx agy-acp@1.0.0-alpha.0   # pin a pre-release
 ```
@@ -94,15 +94,6 @@ Zed / ACP client
 - Session bindings persist under `AGY_ACP_STATE_DIR` so list/load/resume survive restarts.
 - **v1:** `session/load` replays history; `session/resume` reattaches without replay.
   **v2:** only `session/resume` — pass `replayFrom: { "type": "start" }` to replay.
-
-### Permissions
-
-Default: interactive bridge (agy **1.1.5** TUI/DB behavior) for the four-choice
-`run_command` menu — Yes, allow for conversation, always allow, No. Model/mode changes
-or cancel restart the process and reset process-scoped grants.
-
-`--dangerously-skip-permissions` (or env) disables the bridge and uses `agy --print`.
-Other interactions (e.g. `ask_question`) fail closed — no guessed menu keys.
 
 Wire format decoding was cross-referenced with
 [shubzkothekar/antigravity-acp](https://github.com/shubzkothekar/antigravity-acp) (MIT);

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ node dist/main.js
 printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}' | node dist/main.js
 ```
 
+See [ROADMAP.md](./ROADMAP.md) for ACP coverage and planned work.
+
 ## Disclaimer
 
 **Unofficial community adapter.** Bridges the official

--- a/README.md
+++ b/README.md
@@ -1,130 +1,31 @@
 # agy-acp
 
-ACP adapter for Google Antigravity's `agy` CLI.
+ACP adapter for Google Antigravity's `agy` CLI. TypeScript, `npx`-runnable, built on
+`@agentclientprotocol/sdk`. Runs a persistent interactive `agy` process so ACP clients
+can answer permission requests while keeping the logged-in Antigravity CLI experience.
 
-The implementation is a TypeScript, `npx`-runnable ACP server built on
-`@agentclientprotocol/sdk` that wraps the public `agy` CLI. It uses a persistent
-interactive `agy` process by default so ACP clients can answer permission
-requests while retaining the logged-in Antigravity CLI experience.
-
-**Current package:** `0.2.7` (`latest`). Supports **ACP v1** and
-**experimental draft ACP v2** side by side via version negotiation on
-`initialize`. Draft ACP v2 work continues on the `alpha` dist-tag
-(`1.0.0-alpha.*`). See the [ACP v2 draft announcement](https://agentclientprotocol.com/announcements/acp-v2-draft)
-and [migration guide](https://agentclientprotocol.com/protocol/v2/migration).
-Draft v2 may still change before stabilization.
-
-## Architecture
-
-```text
-Zed / ACP client
-  -> agy-acp dual protocol router (v1 or draft v2 from initialize)
-  -> AgyAcpAgent (sessions, config, prompt lifecycle)
-  -> AgyCliSession (keeps an interactive agy PTY, tracks --conversation id)
-  -> agy --prompt-interactive ... --conversation <id> --sandbox ...
-       \-> writes to ~/.gemini/antigravity-cli/conversations/<id>.db
-  -> StreamPoller polls that SQLite database while agy runs
-  -> Translator decodes steps -> ACP session/update notifications
-```
-
-The ACP SDK layer owns protocol parsing, validation, JSON-RPC framing, and
-client notifications. `AgyAcpAgent` owns sessions, prompt conversion,
-cancellation, and persistence. `AgyCliSession` owns `agy` process execution and
-conversation-id tracking. Everything under `src/db/` owns turning agy's
-conversation database into ACP updates.
-
-Earlier versions of this adapter read `agy --print`'s stdout and used regex
-heuristics to guess which lines were "thinking" narration. `agy` itself
-persists every conversation turn-by-turn to an append-only SQLite database as
-it runs, with structured (reverse-engineered, since `agy` doesn't publish a
-schema) protobuf step records — tool calls, task/permission/error details, and
-titles all included. `agy-acp` now reads that database directly instead:
-
-- one persistent interactive `agy` PTY per ACP session (the conversation id is
-  learned from the first turn and reused after),
-- PTY output is retained only as a bounded diagnostic tail and never parsed as
-  agent output; a `StreamPoller` polls the conversation
-  database on an interval while the process runs, translating newly-appended
-  steps into ACP updates (`agent_message_chunk`, `agent_thought_chunk`,
-  progressive `tool_call` → `tool_call_update`, `session_info_update`, ...)
-  via `src/db/translator.ts` and `src/db/updates.ts`,
-- **ACP v1:** `session/load` replays history; `session/resume` reattaches without
-  replay. **ACP v2:** only `session/resume` — pass `replayFrom: { "type": "start" }`
-  to replay (replaces v1 load). Replay uses an incremental cache keyed on file
-  `(mtime, size)` — see `src/db/replay.ts`,
-- **ACP v2 prompt lifecycle:** `session/prompt` returns `{}` on acceptance;
-  foreground progress uses `state_update` (`running` / `idle` with `stopReason`);
-  the user message is acknowledged with a required `messageId`,
-- session bindings (which agy conversation a session is bound to, last model
-  choice, etc.) persist to `~/.agy-acp-state/sessions.json` so list/load/resume
-  survive a server restart — see `src/session-store.ts`,
-- `session/list` is advertised on both protocol versions,
-- ACP session config options in order: `mode`, `model`, `reasoningEffort`
-  (mode → `agy --mode`; model → `agy --model`; reasoningEffort → `agy --effort`),
-- cancellation sends `SIGINT` (giving `agy` a chance to flush its database
-  before exiting), then `SIGKILL` if the process does not exit,
-- `--sandbox` is enabled by default,
-- `--dangerously-skip-permissions` is opt-in only.
-
-### Interactive permission bridge
-
-The adapter runs agy in a persistent PTY by default and forwards its permission
-menu through ACP. The bridge is coupled to the observed **agy 1.1.5**
-TUI/database behavior. It offers **Yes** (once), allow for this conversation,
-always allow (writes `settings.json`), and **No** (once). “Conversation” means
-the lifetime of the same interactive agy process. Cancellation or changing
-model/mode restarts that process before the next turn, resumes the conversation
-database, and resets process-scoped grants. PTY output is retained only as a
-bounded diagnostic tail and is never sent to stdout.
-
-Passing `--dangerously-skip-permissions` (or setting its environment equivalent)
-turns off the interactive bridge and uses `agy --print` because agy auto-approves
-instead of presenting permission requests in that mode.
-For troubleshooting or compatibility with another agy version, set
-`AGY_ACP_INTERACTIVE_PERMISSIONS=0` or pass `--no-interactive-permissions` to use
-print mode without auto-approval.
-
-Only the four-choice permission menu for `run_command` is currently bridged.
-Other requested interactions, including `ask_question`, fail closed with an
-unsupported-interaction error; the bridge does not send guessed menu keys.
-
-The conversation-database wire format (`src/db/step-payload.ts`,
-`src/db/columns.ts`) was cross-referenced against the reverse-engineering
-done by the [shubzkothekar/antigravity-acp](https://github.com/shubzkothekar/antigravity-acp)
-project (MIT); the decoding code itself is our own, built on a shared generic
-wire-walker rather than a generated client.
+**Package:** `0.2.7` (`latest`) — ACP v1 + experimental draft ACP v2 via `initialize`
+negotiation. Draft v2 continues on the `alpha` dist-tag (`1.0.0-alpha.*`). See the
+[ACP v2 draft](https://agentclientprotocol.com/announcements/acp-v2-draft) and
+[migration guide](https://agentclientprotocol.com/protocol/v2/migration).
 
 ## Run
 
-`agy-acp` installs the Antigravity CLI automatically during `initialize` when
-`agy` is not already on `PATH`.
-The adapter downloads the latest release asset from
+If `agy` is missing from `PATH`, `agy-acp` installs it during `initialize` from
 [google-antigravity/antigravity-cli](https://github.com/google-antigravity/antigravity-cli/releases/latest)
-into `~/.local/bin/agy` (checksum-verified when GitHub publishes a digest), and
-prepends that directory to `PATH` for the adapter process.
-
-You can still install `agy` yourself if you prefer:
+into `~/.local/bin/agy` (checksum-verified when GitHub publishes a digest). Or install yourself:
 
 ```sh
 curl -fsSL https://antigravity.google/cli/install.sh | bash
 ```
 
-Local development:
-
 ```sh
-npm run build
-node dist/main.js
+npx agy-acp                 # stable (0.2.7)
+npx agy-acp@alpha           # draft ACP v2 channel
+npx agy-acp@1.0.0-alpha.0   # pin a pre-release
 ```
 
-Published package / Zed:
-
-```sh
-npx agy-acp                 # latest stable (0.2.7)
-npx agy-acp@alpha           # latest alpha pre-release channel
-npx agy-acp@1.0.0-alpha.0   # pin a specific pre-release
-```
-
-Example Zed custom agent shape (stable):
+Zed custom agent (stable):
 
 ```json
 {
@@ -133,14 +34,14 @@ Example Zed custom agent shape (stable):
       "command": "npx",
       "args": ["-y", "agy-acp"],
       "env": {
-        "PATH": "/path/to/agy/bin" // Optional
+        "PATH": "/path/to/agy/bin"
       }
     }
   }
 }
 ```
 
-Alpha pre-release channel (draft ACP v2 iteration):
+Alpha (draft ACP v2):
 
 ```json
 {
@@ -153,218 +54,94 @@ Alpha pre-release channel (draft ACP v2 iteration):
 }
 ```
 
-Optional environment variables:
+### Environment
 
-- `PATH`: include the directory that contains `agy` when the agent process does
-  not inherit your shell `PATH` (common in editor-launched agents). When `agy`
-  is missing, `agy-acp` installs it to `~/.local/bin` from GitHub Releases and
-  prepends that directory to `PATH` for the adapter process.
-- `AGY_ACP_CONVERSATIONS_DIR`: where `agy` writes its per-conversation SQLite
-  databases, default `~/.gemini/antigravity-cli/conversations`. Override this
-  if `agy` uses a different path on your OS.
-- `AGY_ACP_STATE_DIR`: where `agy-acp` persists session bindings (for
-  `session/load`/`session/resume`), default `~/.agy-acp-state`.
-- `AGY_ACP_MODE`: default execution mode for new sessions (`default`,
-  `accept-edits`, or `plan`). Overridden by the session Mode picker or the
-  `agy-acp --mode <value>` argv flag.
-- `AGY_ACP_DANGEROUSLY_SKIP_PERMISSIONS`: when set, passes
-  `--dangerously-skip-permissions` to `agy` (auto-approve tool permissions) and
-  selects non-interactive print mode instead of the default permission bridge.
-- `AGY_ACP_INTERACTIVE_PERMISSIONS=0`: disables the default permission bridge
-  and uses non-interactive print mode. The equivalent argv flag is
-  `--no-interactive-permissions`.
+| Variable | Default / notes |
+|---|---|
+| `PATH` | Must include `agy` if the editor doesn't inherit your shell `PATH` |
+| `AGY_ACP_CONVERSATIONS_DIR` | `~/.gemini/antigravity-cli/conversations` |
+| `AGY_ACP_STATE_DIR` | `~/.agy-acp-state` (session bindings for load/resume) |
+| `AGY_ACP_MODE` | `default` · `accept-edits` · `plan` |
+| `AGY_ACP_DANGEROUSLY_SKIP_PERMISSIONS` | Auto-approve tools; switches to non-interactive print mode |
+| `AGY_ACP_INTERACTIVE_PERMISSIONS=0` | Disable permission bridge (print mode, no auto-approve). Flag: `--no-interactive-permissions` |
 
 ### File writes denied in Zed?
 
-Under `agy --print` (agy ≥ 1.1.3), tools that need interactive confirmation are
-**soft-denied** rather than prompting a TTY. Messages like
-`User denied permission for write_file(...)` usually mean agy refused the tool —
-not that the ACP client blocked the editor filesystem.
+Under `agy --print` (agy ≥ 1.1.3), tools that need confirmation are soft-denied — messages
+like `User denied permission for write_file(...)` come from **agy**, not the editor.
 
-Workarounds (prefer earlier ones):
+1. Set session **Mode** to **Accept Edits**, or `AGY_ACP_MODE=accept-edits` / `--mode accept-edits`
+2. Allowlist tools in `~/.gemini/antigravity-cli/settings.json` under `permissions.allow`
+3. Last resort: `AGY_ACP_DANGEROUSLY_SKIP_PERMISSIONS=1` / `--dangerously-skip-permissions`
 
-1. Set session **Mode** to **Accept Edits** (`accept-edits`), or start with
-   `AGY_ACP_MODE=accept-edits` / `agy-acp --mode accept-edits`.
-2. Allowlist tools in `~/.gemini/antigravity-cli/settings.json` under
-   `permissions.allow` (agy honors this in print mode as of 1.1.1–1.1.4).
-3. As a broad auto-approve fallback, opt in to
-   `AGY_ACP_DANGEROUSLY_SKIP_PERMISSIONS=1` or
-   `--dangerously-skip-permissions` (broad auto-approve).
+## Architecture
 
-Interactive `session/request_permission` is available experimentally for the
-observed four-choice `run_command` menu. Other agy interaction types remain
-post-hoc in print mode; interactive mode fails closed on them because their TUI
-layouts and response channels have not been verified.
-
-## Model Picker
-
-When the ACP client supports session configuration options, `agy-acp` returns
-three options during `session/new` (this order). Wire **ids** are stable;
-**names** are human-facing labels in the client UI:
-
-| Order | id | name | Category |
-|---|---|---|---|
-| 1 | `mode` | Mode | `mode` |
-| 2 | `model` | Model | `model` |
-| 3 | `reasoningEffort` | Reasoning Effort | `thought_level` |
-
-`mode` values:
-
-- `default` — agy request-review behavior (omits `--mode`; write tools may soft-deny under `--print`)
-- `accept-edits` — `agy --mode accept-edits` (apply file edits without interactive write review)
-- `plan` — `agy --mode plan`
-
-`reasoningEffort` maps to `agy --effort`.
-
-The adapter discovers model choices by running:
-
-```sh
-agy models
+```text
+Zed / ACP client
+  -> agy-acp (v1 or draft v2 from initialize)
+  -> AgyAcpAgent (sessions, config, prompt lifecycle)
+  -> AgyCliSession (interactive agy PTY, --conversation id)
+  -> agy --prompt-interactive ... --conversation <id> --sandbox ...
+       \-> ~/.gemini/antigravity-cli/conversations/<id>.db
+  -> StreamPoller + Translator -> ACP session/update notifications
 ```
 
-On current Antigravity CLI releases (`agy` ≥ 1.1.5), that command lists stable
-slugs such as `gemini-3.5-flash-medium` and `claude-opus-4-6-thinking`. The
-adapter groups those into a base model plus optional effort:
+- One interactive `agy` PTY per ACP session; conversation id is learned on the first turn
+  and reused. PTY output is a diagnostic tail only — never parsed as agent text.
+- Steps come from agy's conversation SQLite DB (structured protobuf records), not stdout.
+- Config options: `mode` → `--mode`, `model` → `--model`, `reasoningEffort` → `--effort`
+- Cancel: `SIGINT` then `SIGKILL`. `--sandbox` on by default; skip-permissions is opt-in.
+- Session bindings persist under `AGY_ACP_STATE_DIR` so list/load/resume survive restarts.
+- **v1:** `session/load` replays history; `session/resume` reattaches without replay.
+  **v2:** only `session/resume` — pass `replayFrom: { "type": "start" }` to replay.
 
-| `agy models` line | Model picker | Effort picker |
+### Permissions
+
+Default: interactive bridge (agy **1.1.5** TUI/DB behavior) for the four-choice
+`run_command` menu — Yes, allow for conversation, always allow, No. Model/mode changes
+or cancel restart the process and reset process-scoped grants.
+
+`--dangerously-skip-permissions` (or env) disables the bridge and uses `agy --print`.
+Other interactions (e.g. `ask_question`) fail closed — no guessed menu keys.
+
+Wire format decoding was cross-referenced with
+[shubzkothekar/antigravity-acp](https://github.com/shubzkothekar/antigravity-acp) (MIT);
+decoding code is our own.
+
+## Model picker
+
+Session config options (stable wire ids):
+
+| id | name | Category |
 |---|---|---|
-| `gemini-3.5-flash-medium` | `gemini-3.5-flash` | `medium` |
-| `gemini-3.5-flash-high` | `gemini-3.5-flash` | `high` |
-| `claude-opus-4-6-thinking` | `claude-opus-4-6-thinking` | N/A |
-| `claude-sonnet-4-6` | `claude-sonnet-4-6` | N/A |
+| `mode` | Mode | `mode` |
+| `model` | Model | `model` |
+| `reasoningEffort` | Reasoning Effort | `thought_level` |
 
-Selecting a model and effort sends `session/set_config_option`; later prompts
-include:
+Modes: `default` (request-review), `accept-edits`, `plan`.
 
-```sh
-agy --print "..." --model gemini-3.5-flash --effort high
-```
-
-Models without effort variants only pass `--model`. Thinking models keep
-`-thinking` as part of the model identity (not as an `--effort` value).
-
-Legacy display-name lists (`Gemini 3.5 Flash (Medium)`) are still parsed for
-compatibility. Picker labels stay human-readable (`Gemini 3.5 Flash`,
-`Medium`, …).
-
-## Session Persistence
-
-`agy-acp` advertises `loadSession: true` and the `resume`/`close`
-`sessionCapabilities`:
-
-- `session/load` restores a session's working directory, model/mode
-  selection, and agy conversation binding, then replays the conversation's
-  full history as ACP updates before returning — useful when an ACP client
-  reconnects to a fresh `agy-acp` process (e.g. after an editor restart).
-- `session/resume` restores the same binding without replaying history, for
-  clients that only need to continue prompting.
-
-Both work by reading the session binding persisted after every prompt/config
-change (see `AGY_ACP_STATE_DIR` above) and, for `session/load`, replaying the
-bound agy conversation database from `AGY_ACP_CONVERSATIONS_DIR`.
-
-## ACP v1 roadmap
-
-`agy-acp` covers the core ACP prompt loop (sessions, config options, streamed
-tool calls, edit diffs, load/resume). Gaps below are relative to ACP v1 as
-exposed by `@agentclientprotocol/sdk` and are ordered by practical editor UX.
-Several items are constrained by wrapping `agy --print` and polling its
-conversation database rather than driving agy as a full interactive agent.
-
-### Done
-
-- [x] `initialize`, `session/new`, `session/prompt`, `session/cancel`, `session/close`
-- [x] `session/load` and `session/resume` with persisted bindings
-- [x] `session/set_config_option` (`mode`, `model`, `reasoningEffort`)
-- [x] `additionalDirectories` → `agy --add-dir`
-- [x] Prompt content: text, image, embedded resource, resource link (`audio: false`)
-- [x] Streamed `session/update`: `agent_message_chunk`, `agent_thought_chunk`,
-      `user_message_chunk` (replay), progressive `tool_call` / `tool_call_update`,
-      `session_info_update`
-- [x] Tool kinds, locations, `rawInput` / `rawOutput`, edit content type `diff`
-- [x] `session/list` from the session store
-- [x] Execute tool output when present in the conversation DB (field 28)
-- [x] Decode/show fetch and web-search result bodies when present in the DB
-      (search_web hit lists are not persisted by agy; query metadata only)
-- [x] Full-file write diffs with prior content when known from earlier view/write steps
-- [x] Permission notes map decision varint to granted/denied labels
-- [x] Experimental four-choice `run_command` permission bridge via persistent PTY
-
-### High priority
-
-These need more than conversation-DB polling (interactive agy control plane or
-client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
-
-- [ ] Expand interactive `session/request_permission` beyond the verified
-      `run_command` menu (unsupported status-9 interactions currently fail closed)
-- [ ] Structured `plan` / `plan_update` / `plan_removed` (today: brain/plan files are
-      prose tool content with Plan titles — not ACP plan updates)
-- [ ] Client terminals: `type: "terminal"` content + `terminal/*` (today: execute tools
-      show command + captured output as content blocks, not live terminal protocol)
-- [ ] ACP elicitation for `ask_question` (today: static tool_call text options)
-- [ ] MCP: honor `session/new` `mcpServers` and advertise real `mcpCapabilities`
-      (today: all MCP caps are `false` and servers are ignored)
-
-### Medium priority
-
-- [ ] Optional `session/delete` from the session store
-- [ ] `session/fork` if/when useful for clients
-- [ ] Native ACP session modes (`session/set_mode`, `modes`, `current_mode_update`)
-      in addition to the `mode` config option that already maps to `agy --mode`
-- [ ] `available_commands_update` for slash-command discovery in the client UI
-- [ ] Push `config_option_update` when options change outside `set_config_option`
-- [ ] `authenticate` / `logout` / `authMethods` (today: require a pre-logged-in `agy`)
-- [ ] `usage_update` and prompt-response `usage` when token data is available
-- [ ] Richer `stopReason` values (`max_tokens`, `refusal`, `max_turn_requests`) when
-      agy exposes them (today: `end_turn` or `cancelled`)
-
-### Fidelity improvements
-
-- [x] Surface command stdout/stderr on execute tool calls when present in the DB
-- [x] Decode/show fetch and web-search result bodies (not just URL / title)
-- [x] Better diffs for full-file writes when prior content is knowable
-- [x] Map permission decisions into granted/denied labels (not interactive outcomes)
-- [ ] Agent-outbound images / richer content blocks when agy produces them
-
-### Lower priority / unstable ACP
-
-Usually skip unless a client needs them for this wrapper:
-
-- [ ] `providers/*` (LLM provider routing UI)
-- [ ] `nes/*` (next-edit suggestions)
-- [ ] `document/*` (editor document sync)
-- [ ] Agent-driven client `fs/read_text_file` / `fs/write_text_file` (agy does FS itself)
-- [ ] Non-stdio transports (HTTP / WebSocket) — stdio NDJSON is intentional for Zed
+Models come from `agy models`. Effort suffixes (e.g. `gemini-3.5-flash-medium`) split into
+base model + `reasoningEffort`. Thinking models keep `-thinking` in the model id.
 
 ## Development
 
-Run the TypeScript tests:
-
 ```sh
-npm test
-```
+npm run build && npm test
+node dist/main.js
 
-Smoke-test the ACP initialize handshake:
-
-```sh
+# smoke initialize
 printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}' | node dist/main.js
 ```
 
-## Important Disclaimer & Legal Notice
+## Disclaimer
 
-**This project is an unofficial community adapter** that bridges the official [Google Antigravity CLI (`agy`)](https://antigravity.google/product/antigravity-cli) with the [Agent Client Protocol (ACP)](https://agentclientprotocol.com).
+**Unofficial community adapter.** Bridges the official
+[Google Antigravity CLI](https://antigravity.google/product/antigravity-cli) with
+[ACP](https://agentclientprotocol.com). **Use at your own risk.**
 
-**Use at your own risk.**
+Google's FAQ states that third-party tools to access Antigravity violate their
+[Terms of Service](https://antigravity.google/terms) and may lead to account suspension.
+Prefer Vertex / AI Studio API keys for lower-risk use. Use this only on test/secondary
+accounts.
 
-Google explicitly discourages third-party tools like this one. From their FAQ:
-
-> Using third party software, tools, or services to access Antigravity is a violation of our [Terms of Service](https://antigravity.google/terms), and severely degrades the experience for legitimate product users. Such actions may be grounds for suspension or termination of your account. If you would like to use a third party coding agent with Gemini, we recommend using a Vertex or AI Studio API key.
-
-### Recommendations
-- Use this adapter **only on test / secondary Google accounts**.
-- For lower-risk or production use, prefer official Google Vertex AI / AI Studio API keys with native ACP-compatible agents.
-- Monitor your account health and stop usage immediately if you notice any warnings.
-
-This project is provided **as-is** with no warranty. The maintainer(s) are not responsible for any account actions, restrictions, or consequences from using this software.
-
-By using `agy-acp`, you acknowledge that you have read and agree to both this disclaimer and Google's Terms of Service.
+Provided as-is, no warranty. By using `agy-acp` you accept this notice and Google's ToS.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,10 @@ Gaps relative to ACP v1 as exposed by `@agentclientprotocol/sdk`.
       four-choice menu (`run_command` + file tools sharing ToolConfirmationPanel)
 - [x] Execute tools surface command + captured output as content blocks (v1) and
       draft-v2 agent-owned `terminal_update` + `type: "terminal"` embeds
+- [x] Structured plan from brain markdown artifacts: classic v1 `plan` entries
+      (list/checkbox parse) and draft-v2 `plan_update` (`markdown` when body is
+      known, else `items`). Status only reflects checkbox markers in the file —
+      no live task progress from agy. `plan_removed` not emitted.
 
 ### High priority
 
@@ -47,8 +51,6 @@ client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
 
 - [ ] Expand interactive `session/request_permission` beyond verified menu
       shapes (unsupported status-9 interactions currently fail closed)
-- [ ] Structured `plan` / `plan_update` / `plan_removed` (today: brain/plan files are
-      prose tool content with Plan titles — not ACP plan updates)
 - [ ] v1 client-executed `terminal/*` (`terminal/create` runs a command in the
       editor). Blocked while agy owns the shell — re-running would double-execute.
       v1 keeps content blocks; draft v2 uses agent-owned terminals (see below).
@@ -124,6 +126,8 @@ differs or is incomplete.
       snapshot / exitStatus) plus `type: "terminal"` tool content embed.
       Output is DB field-28 snapshots (and progressive tool updates), not a
       live client PTY byte stream.
+- [x] `plan_update` for brain plan artifacts (`type: "markdown"` preferred;
+      `type: "items"` fallback). No `plan_removed` (agy does not delete plans).
 
 ### High priority
 
@@ -134,7 +138,6 @@ v2-aware clients):
       stabilizes incremental replay
 - [ ] Map `ask_question` / status-9 interactions to client `elicitation/create`
       (today: fail closed; static tool_call text only)
-- [ ] Native `plan_update` / `plan_removed` updates (not prose tool content)
 - [ ] Incremental `terminal_output_chunk` while a command is still running, if
       agy ever persists partial stdout before completion (today: full
       `terminal_update.output` snapshot when field 28 is present)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,72 @@
+# ACP v1 roadmap
+
+`agy-acp` covers the core ACP prompt loop (sessions, config options, streamed
+tool calls, edit diffs, load/resume). Gaps below are relative to ACP v1 as
+exposed by `@agentclientprotocol/sdk` and are ordered by practical editor UX.
+Several items are constrained by wrapping `agy` and polling its conversation
+database rather than driving agy as a full interactive agent.
+
+## Done
+
+- [x] `initialize`, `session/new`, `session/prompt`, `session/cancel`, `session/close`
+- [x] `session/load` and `session/resume` with persisted bindings
+- [x] `session/set_config_option` (`mode`, `model`, `reasoningEffort`)
+- [x] `additionalDirectories` → `agy --add-dir`
+- [x] Prompt content: text, image, embedded resource, resource link (`audio: false`)
+- [x] Streamed `session/update`: `agent_message_chunk`, `agent_thought_chunk`,
+      `user_message_chunk` (replay), progressive `tool_call` / `tool_call_update`,
+      `session_info_update`
+- [x] Tool kinds, locations, `rawInput` / `rawOutput`, edit content type `diff`
+- [x] `session/list` from the session store
+- [x] Execute tool output when present in the conversation DB (field 28)
+- [x] Decode/show fetch and web-search result bodies when present in the DB
+      (search_web hit lists are not persisted by agy; query metadata only)
+- [x] Full-file write diffs with prior content when known from earlier view/write steps
+- [x] Permission notes map decision varint to granted/denied labels
+- [x] Experimental four-choice `run_command` permission bridge via persistent PTY
+
+## High priority
+
+These need more than conversation-DB polling (interactive agy control plane or
+client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
+
+- [ ] Expand interactive `session/request_permission` beyond the verified
+      `run_command` menu (unsupported status-9 interactions currently fail closed)
+- [ ] Structured `plan` / `plan_update` / `plan_removed` (today: brain/plan files are
+      prose tool content with Plan titles — not ACP plan updates)
+- [ ] Client terminals: `type: "terminal"` content + `terminal/*` (today: execute tools
+      show command + captured output as content blocks, not live terminal protocol)
+- [ ] ACP elicitation for `ask_question` (today: static tool_call text options)
+- [ ] MCP: honor `session/new` `mcpServers` and advertise real `mcpCapabilities`
+      (today: all MCP caps are `false` and servers are ignored)
+
+## Medium priority
+
+- [ ] Optional `session/delete` from the session store
+- [ ] `session/fork` if/when useful for clients
+- [ ] Native ACP session modes (`session/set_mode`, `modes`, `current_mode_update`)
+      in addition to the `mode` config option that already maps to `agy --mode`
+- [ ] `available_commands_update` for slash-command discovery in the client UI
+- [ ] Push `config_option_update` when options change outside `set_config_option`
+- [ ] `authenticate` / `logout` / `authMethods` (today: require a pre-logged-in `agy`)
+- [ ] `usage_update` and prompt-response `usage` when token data is available
+- [ ] Richer `stopReason` values (`max_tokens`, `refusal`, `max_turn_requests`) when
+      agy exposes them (today: `end_turn` or `cancelled`)
+
+## Fidelity improvements
+
+- [x] Surface command stdout/stderr on execute tool calls when present in the DB
+- [x] Decode/show fetch and web-search result bodies (not just URL / title)
+- [x] Better diffs for full-file writes when prior content is knowable
+- [x] Map permission decisions into granted/denied labels (not interactive outcomes)
+- [ ] Agent-outbound images / richer content blocks when agy produces them
+
+## Lower priority / unstable ACP
+
+Usually skip unless a client needs them for this wrapper:
+
+- [ ] `providers/*` (LLM provider routing UI)
+- [ ] `nes/*` (next-edit suggestions)
+- [ ] `document/*` (editor document sync)
+- [ ] Agent-driven client `fs/read_text_file` / `fs/write_text_file` (agy does FS itself)
+- [ ] Non-stdio transports (HTTP / WebSocket) — stdio NDJSON is intentional for Zed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,24 @@
-# ACP v1 roadmap
+# Roadmap
 
 `agy-acp` covers the core ACP prompt loop (sessions, config options, streamed
-tool calls, edit diffs, load/resume). Gaps below are relative to ACP v1 as
-exposed by `@agentclientprotocol/sdk` and are ordered by practical editor UX.
-Several items are constrained by wrapping `agy` and polling its conversation
-database rather than driving agy as a full interactive agent.
+tool calls, edit diffs, load/resume). It serves **ACP v1** and **experimental
+draft ACP v2** side by side via `initialize` version negotiation
+(`agentProtocolRouter`). Gaps are ordered by practical editor UX and constrained
+by wrapping `agy` and polling its conversation database rather than driving agy
+as a full interactive agent.
 
-## Done
+Draft ACP v2 tracks the `alpha` dist-tag (`1.0.0-alpha.*`). The wire protocol may
+still change before stabilization — see the
+[ACP v2 draft](https://agentclientprotocol.com/announcements/acp-v2-draft) and
+[migration guide](https://agentclientprotocol.com/protocol/v2/migration).
+
+---
+
+## ACP v1
+
+Gaps relative to ACP v1 as exposed by `@agentclientprotocol/sdk`.
+
+### Done
 
 - [x] `initialize`, `session/new`, `session/prompt`, `session/cancel`, `session/close`
 - [x] `session/load` and `session/resume` with persisted bindings
@@ -23,15 +35,16 @@ database rather than driving agy as a full interactive agent.
       (search_web hit lists are not persisted by agy; query metadata only)
 - [x] Full-file write diffs with prior content when known from earlier view/write steps
 - [x] Permission notes map decision varint to granted/denied labels
-- [x] Experimental four-choice `run_command` permission bridge via persistent PTY
+- [x] Experimental interactive permission bridge via persistent PTY for the
+      four-choice menu (`run_command` + file tools sharing ToolConfirmationPanel)
 
-## High priority
+### High priority
 
 These need more than conversation-DB polling (interactive agy control plane or
 client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
 
-- [ ] Expand interactive `session/request_permission` beyond the verified
-      `run_command` menu (unsupported status-9 interactions currently fail closed)
+- [ ] Expand interactive `session/request_permission` beyond verified menu
+      shapes (unsupported status-9 interactions currently fail closed)
 - [ ] Structured `plan` / `plan_update` / `plan_removed` (today: brain/plan files are
       prose tool content with Plan titles — not ACP plan updates)
 - [ ] Client terminals: `type: "terminal"` content + `terminal/*` (today: execute tools
@@ -40,7 +53,7 @@ client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
 - [ ] MCP: honor `session/new` `mcpServers` and advertise real `mcpCapabilities`
       (today: all MCP caps are `false` and servers are ignored)
 
-## Medium priority
+### Medium priority
 
 - [ ] Optional `session/delete` from the session store
 - [ ] `session/fork` if/when useful for clients
@@ -53,7 +66,7 @@ client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
 - [ ] Richer `stopReason` values (`max_tokens`, `refusal`, `max_turn_requests`) when
       agy exposes them (today: `end_turn` or `cancelled`)
 
-## Fidelity improvements
+### Fidelity improvements
 
 - [x] Surface command stdout/stderr on execute tool calls when present in the DB
 - [x] Decode/show fetch and web-search result bodies (not just URL / title)
@@ -61,7 +74,7 @@ client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
 - [x] Map permission decisions into granted/denied labels (not interactive outcomes)
 - [ ] Agent-outbound images / richer content blocks when agy produces them
 
-## Lower priority / unstable ACP
+### Lower priority / unstable ACP
 
 Usually skip unless a client needs them for this wrapper:
 
@@ -70,3 +83,84 @@ Usually skip unless a client needs them for this wrapper:
 - [ ] `document/*` (editor document sync)
 - [ ] Agent-driven client `fs/read_text_file` / `fs/write_text_file` (agy does FS itself)
 - [ ] Non-stdio transports (HTTP / WebSocket) — stdio NDJSON is intentional for Zed
+
+---
+
+## ACP v2 (experimental draft)
+
+Implemented via `@agentclientprotocol/sdk/experimental/v2`. The db/translator
+layer still emits v1-shaped updates; `sessionUpdateToV2` maps them at the
+protocol boundary. Shared backend gaps (permissions, MCP, plans, terminals)
+apply to both protocol versions — listed here only when the **v2 wire shape**
+differs or is incomplete.
+
+### Done
+
+- [x] Dual-protocol router: negotiate v1 vs draft v2 from `initialize.protocolVersion`
+- [x] Role-agnostic `info` / `capabilities` on `initialize` (no `agentInfo` /
+      `agentCapabilities` split)
+- [x] Baseline session methods: `session/new`, `session/list`, `session/resume`,
+      `session/close`, `session/prompt`, `session/cancel`, `session/update`
+- [x] `session/set_config_option` with `configId` (v1 still uses `id`) for
+      `mode`, `model`, `reasoningEffort`
+- [x] Prompt lifecycle: accept with `{}` immediately; progress via
+      `state_update` (`running` / `idle` + `stopReason`)
+- [x] User-message ack: `user_message` update with agent-owned `messageId`
+- [x] Required `messageId` on `agent_message_chunk` / `agent_thought_chunk` /
+      `user_message_chunk`
+- [x] `session/resume` with optional `replayFrom: { "type": "start" }` (replaces
+      v1 `session/load`; omit `replayFrom` to reattach without replay)
+- [x] Collapse first-sight `tool_call` → v2 `tool_call_update` (upsert shape)
+- [x] Structured diff content: `changes[]` + optional `git_patch` patch block
+- [x] Tool status `cancelled` preserved for v2 (mapped to `failed` for v1)
+- [x] `session/request_permission` with v2 `subject: { type: "tool_call", … }`
+      + `title` (same interactive bridge as v1)
+- [x] Prompt caps advertised: `image`, `embeddedContext`;
+      `additionalDirectories` capability
+
+### High priority
+
+Wire-shape and lifecycle work specific to draft v2 (or required for parity with
+v2-aware clients):
+
+- [ ] Richer `replayFrom` cursors beyond `{ "type": "start" }` when the draft
+      stabilizes incremental replay
+- [ ] Map `ask_question` / status-9 interactions to client `elicitation/create`
+      (today: fail closed; static tool_call text only)
+- [ ] Native `plan_update` / `plan_removed` updates (not prose tool content)
+- [ ] `terminal_update` / `terminal_output_chunk` for execute tools when clients
+      support live terminals (today: text content blocks from DB field 28)
+- [ ] MCP: honor session `mcpServers`, advertise `capabilities.session.mcp`, and
+      route `mcp/*` if/when agy can consume external MCP servers
+- [ ] Expand interactive permission bridge to any remaining agy menus once their
+      TUI/response channels are verified
+
+### Medium priority
+
+- [ ] Advertise and implement `session/delete` / `session/fork` when useful
+- [ ] Push `config_option_update` when catalog/options change outside
+      `set_config_option`
+- [ ] `available_commands_update` for slash-command discovery
+- [ ] `auth/login` / `auth/logout` + non-empty `authMethods` (today: empty list;
+      require pre-logged-in `agy`)
+- [ ] `usage_update` when token/usage data is available from agy
+- [ ] Richer `stopReason` on idle `state_update` (`max_tokens`, `refusal`,
+      `max_turn_requests`) when agy exposes them
+- [ ] Optional full-message updates (`agent_message` / `agent_thought`) in
+      addition to chunk streaming, if clients prefer them
+
+### Draft tracking
+
+- [ ] Keep pace with `@agentclientprotocol/sdk` experimental/v2 breaking changes
+      until ACP v2 stabilizes; pin and re-test on each SDK bump
+- [ ] Promote dual-protocol support off the `alpha` track when the draft freezes
+- [ ] Drop or narrow v1-shaped internal builders if a stable v2-native update
+      model becomes the default path
+
+### Out of scope (unless a client requires them)
+
+Same as v1 lower-priority surface; not advertised in `initialize` capabilities:
+
+- [ ] `providers/*`, `nes/*`, `document/*`
+- [ ] Agent-driven client filesystem methods (agy owns FS)
+- [ ] Non-stdio transports (HTTP / WebSocket / SSE)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,6 +40,13 @@ Gaps relative to ACP v1 as exposed by `@agentclientprotocol/sdk`.
 - [x] Permission notes map decision varint to granted/denied labels
 - [x] Experimental interactive permission bridge via persistent PTY for the
       four-choice menu (`run_command` + file tools sharing ToolConfirmationPanel)
+- [x] Agent-driven client `fs/read_text_file` / `fs/write_text_file`: when the
+      client advertises both, every completed edit is routed through them —
+      whether it landed on disk without a live agy gate (accept-edits) or
+      just passed one (default mode, after the live permission prompt) —
+      so the client's own diff/review UI (e.g. Zed's Review Changes panel)
+      tracks it in either mode. Falls back to the local permission bridge
+      if the client lacks the capability or rejects the write-through.
 - [x] Execute tools surface command + captured output as content blocks (v1) and
       draft-v2 agent-owned `terminal_update` + `type: "terminal"` embeds
 - [x] Structured plan from brain markdown artifacts: classic v1 `plan` entries
@@ -52,12 +59,14 @@ Gaps relative to ACP v1 as exposed by `@agentclientprotocol/sdk`.
 These need more than conversation-DB polling (interactive agy control plane or
 client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
 
-- [ ] Expand interactive `session/request_permission` beyond verified menu
-      shapes (unsupported status-9 interactions currently fail closed)
+- [ ] Expand interactive `session/request_permission` (multi-select /
+      multi-question `ask_question`, remaining status-9 tools;
+      unsupported status-9 interactions currently fail closed)
 - [ ] v1 client-executed `terminal/*` (`terminal/create` runs a command in the
       editor). Blocked while agy owns the shell — re-running would double-execute.
       v1 keeps content blocks; draft v2 uses agent-owned terminals (see below).
-- [ ] ACP elicitation for `ask_question` (today: static tool_call text options)
+- [ ] ACP elicitation for free-text / multi-select `ask_question` (single-select
+      MCQ already uses `session/request_permission`)
 - [ ] MCP: honor `session/new` `mcpServers` and advertise real `mcpCapabilities`
       (today: all MCP caps are `false` and servers are ignored)
 
@@ -93,7 +102,6 @@ Usually skip unless a client needs them for this wrapper:
 - [ ] `providers/*` (LLM provider routing UI)
 - [ ] `nes/*` (next-edit suggestions)
 - [ ] `document/*` (editor document sync)
-- [ ] Agent-driven client `fs/read_text_file` / `fs/write_text_file` (agy does FS itself)
 - [ ] Non-stdio transports (HTTP / WebSocket) — stdio NDJSON is intentional for Zed
 
 ---
@@ -143,7 +151,7 @@ v2-aware clients):
 
 - [ ] Richer `replayFrom` cursors beyond `{ "type": "start" }` when the draft
       stabilizes incremental replay
-- [ ] Map `ask_question` / status-9 interactions to client `elicitation/create`
+- [ ] Map multi-select / free-text `ask_question` to client `elicitation/create`
       (today: fail closed; static tool_call text only)
 - [ ] Incremental `terminal_output_chunk` while a command is still running, if
       agy ever persists partial stdout before completion (today: full
@@ -183,3 +191,7 @@ Same as v1 lower-priority surface; not advertised in `initialize` capabilities:
 - [ ] `providers/*`, `nes/*`, `document/*`
 - [ ] Agent-driven client filesystem methods (agy owns FS)
 - [ ] Non-stdio transports (HTTP / WebSocket / SSE)
+
+
+
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,8 @@ Gaps relative to ACP v1 as exposed by `@agentclientprotocol/sdk`.
 - [x] Permission notes map decision varint to granted/denied labels
 - [x] Experimental interactive permission bridge via persistent PTY for the
       four-choice menu (`run_command` + file tools sharing ToolConfirmationPanel)
+- [x] Execute tools surface command + captured output as content blocks (v1) and
+      draft-v2 agent-owned `terminal_update` + `type: "terminal"` embeds
 
 ### High priority
 
@@ -47,8 +49,9 @@ client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
       shapes (unsupported status-9 interactions currently fail closed)
 - [ ] Structured `plan` / `plan_update` / `plan_removed` (today: brain/plan files are
       prose tool content with Plan titles — not ACP plan updates)
-- [ ] Client terminals: `type: "terminal"` content + `terminal/*` (today: execute tools
-      show command + captured output as content blocks, not live terminal protocol)
+- [ ] v1 client-executed `terminal/*` (`terminal/create` runs a command in the
+      editor). Blocked while agy owns the shell — re-running would double-execute.
+      v1 keeps content blocks; draft v2 uses agent-owned terminals (see below).
 - [ ] ACP elicitation for `ask_question` (today: static tool_call text options)
 - [ ] MCP: honor `session/new` `mcpServers` and advertise real `mcpCapabilities`
       (today: all MCP caps are `false` and servers are ignored)
@@ -117,6 +120,10 @@ differs or is incomplete.
       + `title` (same interactive bridge as v1)
 - [x] Prompt caps advertised: `image`, `embeddedContext`;
       `additionalDirectories` capability
+- [x] Agent-owned `terminal_update` for execute tools (command / cwd / output
+      snapshot / exitStatus) plus `type: "terminal"` tool content embed.
+      Output is DB field-28 snapshots (and progressive tool updates), not a
+      live client PTY byte stream.
 
 ### High priority
 
@@ -128,8 +135,9 @@ v2-aware clients):
 - [ ] Map `ask_question` / status-9 interactions to client `elicitation/create`
       (today: fail closed; static tool_call text only)
 - [ ] Native `plan_update` / `plan_removed` updates (not prose tool content)
-- [ ] `terminal_update` / `terminal_output_chunk` for execute tools when clients
-      support live terminals (today: text content blocks from DB field 28)
+- [ ] Incremental `terminal_output_chunk` while a command is still running, if
+      agy ever persists partial stdout before completion (today: full
+      `terminal_update.output` snapshot when field 28 is present)
 - [ ] MCP: honor session `mcpServers`, advertise `capabilities.session.mcp`, and
       route `mcp/*` if/when agy can consume external MCP servers
 - [ ] Expand interactive permission bridge to any remaining agy menus once their

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,6 +23,9 @@ Gaps relative to ACP v1 as exposed by `@agentclientprotocol/sdk`.
 - [x] `initialize`, `session/new`, `session/prompt`, `session/cancel`, `session/close`
 - [x] `session/load` and `session/resume` with persisted bindings
 - [x] `session/set_config_option` (`mode`, `model`, `reasoningEffort`)
+- [x] Native session modes: `modes` on new/load/resume, `session/set_mode`,
+      `current_mode_update` (ids match config `mode` / `agy --mode`)
+- [x] `config_option_update` when mode changes via `session/set_mode`
 - [x] `additionalDirectories` → `agy --add-dir`
 - [x] Prompt content: text, image, embedded resource, resource link (`audio: false`)
 - [x] Streamed `session/update`: `agent_message_chunk`, `agent_thought_chunk`,
@@ -62,10 +65,14 @@ client terminal protocol) and are **out of scope for 0.2.x fidelity patches**:
 
 - [ ] Optional `session/delete` from the session store
 - [ ] `session/fork` if/when useful for clients
-- [ ] Native ACP session modes (`session/set_mode`, `modes`, `current_mode_update`)
+- [x] Native ACP session modes (`session/set_mode`, `modes`, `current_mode_update`)
       in addition to the `mode` config option that already maps to `agy --mode`
+      (same three ids: `default` / `accept-edits` / `plan`). Draft v2 has no
+      `set_mode` surface — mode stays a config option there.
 - [ ] `available_commands_update` for slash-command discovery in the client UI
-- [ ] Push `config_option_update` when options change outside `set_config_option`
+- [x] Push `config_option_update` when options change outside `set_config_option`
+      (v1: after `session/set_mode`; `set_config_option` still returns the full
+      list in its response and pushes `current_mode_update` when mode changes)
 - [ ] `authenticate` / `logout` / `authMethods` (today: require a pre-logged-in `agy`)
 - [ ] `usage_update` and prompt-response `usage` when token data is available
 - [ ] Richer `stopReason` values (`max_tokens`, `refusal`, `max_turn_requests`) when
@@ -149,8 +156,9 @@ v2-aware clients):
 ### Medium priority
 
 - [ ] Advertise and implement `session/delete` / `session/fork` when useful
-- [ ] Push `config_option_update` when catalog/options change outside
-      `set_config_option`
+- [x] Push `config_option_update` when options change outside
+      `set_config_option` (v1 `set_mode` path; draft v2 has no set_mode — response
+      still returns full options on set_config_option)
 - [ ] `available_commands_update` for slash-command discovery
 - [ ] `auth/login` / `auth/logout` + non-empty `authMethods` (today: empty list;
       require pre-logged-in `agy`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agy-acp",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agy-acp",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agy-acp",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Agent Client Protocol adapter that wraps the Google Antigravity CLI (ACP v1 + experimental draft ACP v2)",
   "type": "module",
   "author": {

--- a/src/acp-server.ts
+++ b/src/acp-server.ts
@@ -318,25 +318,91 @@ export class AgyAcpAgent {
   }
 
   async setConfigOptionV1(
-    params: V1SetSessionConfigOptionRequest
+    params: V1SetSessionConfigOptionRequest,
+    client?: V1AgentContext
   ): Promise<V1SetSessionConfigOptionResponse> {
-    await this.applyConfigOption(params.sessionId, params.configId, readConfigValue(params));
-    return { configOptions: sessionConfigOptionsV1(this.requireSession(params.sessionId)) };
+    const configId = params.configId;
+    const previousMode = this.requireSession(params.sessionId).agy.config.mode;
+    await this.applyConfigOption(params.sessionId, configId, readConfigValue(params));
+    const session = this.requireSession(params.sessionId);
+
+    // Keep native modes UI in sync when mode changes via config option.
+    if (client && configId === MODE_CONFIG_ID && session.agy.config.mode !== previousMode) {
+      await this.notifyCurrentModeUpdate(client, params.sessionId, session.agy.config.mode);
+    }
+
+    return { configOptions: sessionConfigOptionsV1(session) };
   }
 
   async setConfigOptionV2(
     params: V2SetSessionConfigOptionRequest
   ): Promise<V2SetSessionConfigOptionResponse> {
     await this.applyConfigOption(params.sessionId, params.configId, readConfigValue(params));
+    // Draft v2 has no set_mode; the response carries the full option list.
+    // Out-of-band `config_option_update` is emitted on the v1 set_mode path (outside
+    // this RPC) so config UIs stay aligned with native modes.
     return { configOptions: sessionConfigOptionsV2(this.requireSession(params.sessionId)) };
   }
 
   /** @deprecated Prefer setConfigOptionV1. */
   async setConfigOption(
-    params: V1SetSessionConfigOptionRequest
+    params: V1SetSessionConfigOptionRequest,
+    client?: V1AgentContext
   ): Promise<V1SetSessionConfigOptionResponse> {
-    return this.setConfigOptionV1(params);
+    return this.setConfigOptionV1(params, client);
   }
+
+  /**
+   * v1 `session/set_mode`: mirrors the `mode` config option onto agy `--mode`.
+   * Pushes `config_option_update` so clients that only watch config options stay
+   * aligned (set_mode is outside set_config_option).
+   */
+  async setSessionMode(
+    params: SetSessionModeRequest,
+    client: V1AgentContext
+  ): Promise<SetSessionModeResponse> {
+    const previousMode = this.requireSession(params.sessionId).agy.config.mode;
+    await this.applyConfigOption(params.sessionId, MODE_CONFIG_ID, params.modeId);
+    const session = this.requireSession(params.sessionId);
+    const mode = session.agy.config.mode;
+
+    if (mode !== previousMode) {
+      await this.notifyCurrentModeUpdate(client, params.sessionId, mode);
+      await this.notifyConfigOptionUpdateV1(client, params.sessionId, session);
+    }
+
+    return {};
+  }
+
+  private async notifyCurrentModeUpdate(
+    client: V1AgentContext,
+    sessionId: string,
+    mode: AgyExecutionMode
+  ): Promise<void> {
+    await client.notify(v1.methods.client.session.update, {
+      sessionId,
+      update: {
+        sessionUpdate: "current_mode_update",
+        currentModeId: mode
+      }
+    });
+  }
+
+  private async notifyConfigOptionUpdateV1(
+    client: V1AgentContext,
+    sessionId: string,
+    session: SessionState
+  ): Promise<void> {
+    await client.notify(v1.methods.client.session.update, {
+      sessionId,
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: sessionConfigOptionsV1(session)
+      }
+    });
+  }
+
+
 
   /**
    * v1 prompt lifecycle: response carries stopReason after the full turn.
@@ -722,7 +788,10 @@ export function createAgyAcpApp(options: AgyAcpOptions = {}): V1AgentApp {
     .onRequest(v1.methods.agent.session.list, (ctx) => agy.listSessions(ctx.params))
     .onRequest(v1.methods.agent.session.load, (ctx) => agy.loadSession(ctx.params, ctx.client))
     .onRequest(v1.methods.agent.session.resume, (ctx) => agy.resumeSessionV1(ctx.params))
-    .onRequest(v1.methods.agent.session.setConfigOption, (ctx) => agy.setConfigOptionV1(ctx.params))
+    .onRequest(v1.methods.agent.session.setMode, (ctx) => agy.setSessionMode(ctx.params, ctx.client))
+    .onRequest(v1.methods.agent.session.setConfigOption, (ctx) =>
+      agy.setConfigOptionV1(ctx.params, ctx.client)
+    )
     .onRequest(v1.methods.agent.session.prompt, (ctx) => agy.promptV1(ctx.params, ctx.client, ctx.signal))
     .onRequest(v1.methods.agent.session.close, (ctx) => agy.closeSession(ctx.params))
     .onNotification(v1.methods.agent.session.cancel, (ctx) => agy.cancel(ctx.params));

--- a/src/acp-server.ts
+++ b/src/acp-server.ts
@@ -19,8 +19,11 @@ import type {
   ResumeSessionRequest as V1ResumeSessionRequest,
   ResumeSessionResponse as V1ResumeSessionResponse,
   SessionConfigOption as V1SessionConfigOption,
+  SessionModeState,
   SetSessionConfigOptionRequest as V1SetSessionConfigOptionRequest,
-  SetSessionConfigOptionResponse as V1SetSessionConfigOptionResponse
+  SetSessionConfigOptionResponse as V1SetSessionConfigOptionResponse,
+  SetSessionModeRequest,
+  SetSessionModeResponse
 } from "@agentclientprotocol/sdk";
 import type {
   AgentContext as V2AgentContext,
@@ -209,12 +212,14 @@ export class AgyAcpAgent {
     const session = await this.createSession(params.cwd, params.additionalDirectories);
     return {
       sessionId: session.id,
+      modes: sessionModeState(session.agy.config.mode),
       configOptions: sessionConfigOptionsV1(session)
     };
   }
 
   async newSessionV2(params: V2NewSessionRequest): Promise<V2NewSessionResponse> {
     const session = await this.createSession(params.cwd, params.additionalDirectories);
+    // Draft v2 has no native session/set_mode surface; mode is the config option only.
     return {
       sessionId: session.id,
       configOptions: sessionConfigOptionsV2(session)
@@ -258,13 +263,19 @@ export class AgyAcpAgent {
       });
     }
 
-    return { configOptions: sessionConfigOptionsV1(session) };
+    return {
+      modes: sessionModeState(session.agy.config.mode),
+      configOptions: sessionConfigOptionsV1(session)
+    };
   }
 
   /** v1 `session/resume`: reattach without replaying history. */
   async resumeSessionV1(params: V1ResumeSessionRequest): Promise<V1ResumeSessionResponse> {
     const { session } = await this.reloadSession(params.sessionId, params.cwd, params.additionalDirectories);
-    return { configOptions: sessionConfigOptionsV1(session) };
+    return {
+      modes: sessionModeState(session.agy.config.mode),
+      configOptions: sessionConfigOptionsV1(session)
+    };
   }
 
   /** @deprecated Prefer resumeSessionV1. */
@@ -868,6 +879,41 @@ export function buildModelCatalog(entries: string[]): ModelCatalog {
   };
 }
 
+/** Shared labels/descriptions for config option `mode` and native ACP session modes. */
+const AGY_MODE_OPTIONS: ReadonlyArray<{
+  value: AgyExecutionMode;
+  name: string;
+  description: string;
+}> = [
+  {
+    value: "default",
+    name: "Default",
+    description: "Request review before file writes (agy default; omits --mode)."
+  },
+  {
+    value: "accept-edits",
+    name: "Accept Edits",
+    description: "Apply file edits without interactive write review (agy --mode accept-edits)."
+  },
+  {
+    value: "plan",
+    name: "Plan",
+    description: "Plan-oriented execution (agy --mode plan)."
+  }
+];
+
+/** Native ACP session mode state (v1 `modes` on new/load/resume). Same ids as config `mode`. */
+export function sessionModeState(mode: AgyExecutionMode): SessionModeState {
+  return {
+    currentModeId: mode,
+    availableModes: AGY_MODE_OPTIONS.map((option) => ({
+      id: option.value,
+      name: option.name,
+      description: option.description
+    }))
+  };
+}
+
 export function modeConfigOption(mode: AgyExecutionMode): V1SessionConfigOption {
   return {
     id: MODE_CONFIG_ID,
@@ -877,23 +923,11 @@ export function modeConfigOption(mode: AgyExecutionMode): V1SessionConfigOption 
     category: "mode",
     type: "select",
     currentValue: mode,
-    options: [
-      {
-        value: "default",
-        name: "Default",
-        description: "Request review before file writes (agy default; omits --mode)."
-      },
-      {
-        value: "accept-edits",
-        name: "Accept Edits",
-        description: "Apply file edits without interactive write review (agy --mode accept-edits)."
-      },
-      {
-        value: "plan",
-        name: "Plan",
-        description: "Plan-oriented execution (agy --mode plan)."
-      }
-    ]
+    options: AGY_MODE_OPTIONS.map((option) => ({
+      value: option.value,
+      name: option.name,
+      description: option.description
+    }))
   };
 }
 

--- a/src/acp-server.ts
+++ b/src/acp-server.ts
@@ -43,6 +43,7 @@ import type {
   SetSessionConfigOptionResponse as V2SetSessionConfigOptionResponse
 } from "@agentclientprotocol/sdk/experimental/v2";
 import { ReplayCache } from "./db/replay.js";
+import type { EditFsBridge } from "./edit-fs-bridge.js";
 import { ensureAgyInstalled } from "./installer.js";
 import {
   AgyCliBackend,
@@ -131,6 +132,8 @@ export class AgyAcpAgent {
   readonly #store: SessionStore;
   readonly #replayCache = new ReplayCache(REPLAY_CACHE_CAPACITY);
   #ensureAgyPromise: Promise<string | null> | undefined;
+  /** v1 client's `fs` capability, set from `initialize`. Draft v2 has no fs/* client methods. */
+  #clientFs = { readTextFile: false, writeTextFile: false };
 
   constructor(options: AgyAcpOptions = {}) {
     this.#env = options.env ?? process.env;
@@ -141,6 +144,10 @@ export class AgyAcpAgent {
 
   async initializeV1(params: V1InitializeRequest): Promise<V1InitializeResponse> {
     await this.ensureAgyReady();
+    this.#clientFs = {
+      readTextFile: params.clientCapabilities?.fs?.readTextFile ?? false,
+      writeTextFile: params.clientCapabilities?.fs?.writeTextFile ?? false
+    };
     return {
       protocolVersion:
         params.protocolVersion === v1.PROTOCOL_VERSION ? params.protocolVersion : v1.PROTOCOL_VERSION,
@@ -206,6 +213,24 @@ export class AgyAcpAgent {
       warn: (message) => console.error(message)
     });
     return this.#ensureAgyPromise;
+  }
+
+  /**
+   * When the client advertises `fs.readTextFile` + `fs.writeTextFile`, route
+   * already-applied edits through those methods so the client's own
+   * diff/review UI (e.g. Zed's Review Changes panel) tracks them. Draft v2
+   * has no fs/* client methods, so this is v1-only.
+   */
+  private editFsBridgeV1(client: V1AgentContext, sessionId: string): EditFsBridge | undefined {
+    if (!this.#clientFs.readTextFile || !this.#clientFs.writeTextFile) return undefined;
+    return {
+      readTextFile: async (path) => {
+        await client.request(v1.methods.client.fs.readTextFile, { sessionId, path });
+      },
+      writeTextFile: async (path, content) => {
+        await client.request(v1.methods.client.fs.writeTextFile, { sessionId, path, content });
+      }
+    };
   }
 
   async newSessionV1(params: V1NewSessionRequest): Promise<V1NewSessionResponse> {
@@ -441,7 +466,7 @@ export class AgyAcpAgent {
           options: permissionOptions(toolCall, toolName)
         }), signal);
         return selectedPermission(response, signal);
-      });
+      }, this.editFsBridgeV1(client, params.sessionId));
       await this.persistSession(params.sessionId, session);
       return {
         stopReason: outcome.stopReason === "cancelled" || signal?.aborted ? "cancelled" : "end_turn"

--- a/src/acp-server.ts
+++ b/src/acp-server.ts
@@ -55,7 +55,7 @@ import {
 import { permissionOptions, type AgyPermissionChoice } from "./permissions.js";
 import { promptBlocksToAgyPrompt } from "./prompt-content.js";
 import { defaultStateDir, SessionStore, type StoredSession } from "./session-store.js";
-import { sessionUpdateToV1, sessionUpdateToV2 } from "./session-updates.js";
+import { expandSessionUpdateToV2, sessionUpdateToV1, sessionUpdateToV2 } from "./session-updates.js";
 
 /** Prefer re-exporting stable v1 symbols used by existing tests and consumers. */
 export const methods = v1.methods;
@@ -293,10 +293,12 @@ export class AgyAcpAgent {
       }
       if (stored.conversationId) {
         await this.replayConversation(params.sessionId, session, stored.conversationId, cwd, async (update) => {
-          await client.notify(v2.methods.client.session.update, {
-            sessionId: params.sessionId,
-            update: sessionUpdateToV2(update)
-          });
+          for (const v2Update of expandSessionUpdateToV2(update)) {
+            await client.notify(v2.methods.client.session.update, {
+              sessionId: params.sessionId,
+              update: v2Update
+            });
+          }
         });
       }
     }
@@ -561,10 +563,17 @@ export class AgyAcpAgent {
 
       try {
         const outcome = await session.agy.prompt(promptText, async (update) => {
-          await notify(sessionUpdateToV2(update));
+          for (const v2Update of expandSessionUpdateToV2(update)) {
+            await notify(v2Update);
+          }
         }, async (toolCall) => {
           if (signal.aborted) return "cancelled";
-          const converted = sessionUpdateToV2(toolCall) as unknown as Record<string, unknown>;
+          // Permission subject uses the tool_call_update only (skip terminal_update).
+          const expanded = expandSessionUpdateToV2(toolCall);
+          const converted = (expanded.find((item) => {
+            const kind = (item as unknown as { sessionUpdate?: string }).sessionUpdate;
+            return kind === "tool_call_update" || kind === "tool_call";
+          }) ?? sessionUpdateToV2(toolCall)) as unknown as Record<string, unknown>;
           const { sessionUpdate: _discriminator, ...requestToolCall } = converted;
           const response = await racePermissionCancellation(client.request(v2.methods.client.session.requestPermission, {
             sessionId: params.sessionId,

--- a/src/acp-server.ts
+++ b/src/acp-server.ts
@@ -355,13 +355,13 @@ export class AgyAcpAgent {
           sessionId: params.sessionId,
           update: sessionUpdateToV1(update)
         });
-      }, async (toolCall) => {
+      }, async (toolCall, { toolName }) => {
         if (signal?.aborted) return "cancelled";
         const { sessionUpdate: _discriminator, ...requestToolCall } = toolCall as unknown as Record<string, unknown>;
         const response = await racePermissionCancellation(client.request(v1.methods.client.session.requestPermission, {
           sessionId: params.sessionId,
           toolCall: requestToolCall as v1.ToolCallUpdate,
-          options: permissionOptions(toolCall)
+          options: permissionOptions(toolCall, toolName)
         }), signal);
         return selectedPermission(response, signal);
       });
@@ -566,7 +566,7 @@ export class AgyAcpAgent {
           for (const v2Update of expandSessionUpdateToV2(update)) {
             await notify(v2Update);
           }
-        }, async (toolCall) => {
+        }, async (toolCall, { toolName }) => {
           if (signal.aborted) return "cancelled";
           // Permission subject uses the tool_call_update only (skip terminal_update).
           const expanded = expandSessionUpdateToV2(toolCall);
@@ -579,7 +579,7 @@ export class AgyAcpAgent {
             sessionId: params.sessionId,
             title: String(requestToolCall.title ?? "Permission required"),
             subject: { type: "tool_call", toolCall: requestToolCall as v2.ToolCallUpdate },
-            options: permissionOptions(toolCall)
+            options: permissionOptions(toolCall, toolName)
           }), signal);
           return selectedPermission(response, signal);
         });
@@ -761,8 +761,22 @@ function selectedPermission(response: unknown, signal?: AbortSignal): AgyPermiss
   const outcome = (response as { outcome?: unknown }).outcome;
   if (!outcome || typeof outcome !== "object" || (outcome as { outcome?: string }).outcome !== "selected") return "cancelled";
   const id = (outcome as { optionId?: string }).optionId;
-  return id === "agy-allow-once" || id === "agy-allow-conversation" || id === "agy-allow-settings" || id === "agy-reject-once"
-    ? id : "cancelled";
+  if (typeof id !== "string" || !id.trim()) return "cancelled";
+  // Standard ACP ids, legacy agy-* ids, and ask_question option ids.
+  if (
+    id === "allow-once" ||
+    id === "allow-always" ||
+    id === "reject-once" ||
+    id === "agy-allow-once" ||
+    id === "agy-allow-conversation" ||
+    id === "agy-allow-settings" ||
+    id === "agy-reject-once" ||
+    id === "agy-q-skip" ||
+    /^agy-q-\d+$/.test(id)
+  ) {
+    return id;
+  }
+  return "cancelled";
 }
 
 async function racePermissionCancellation<T>(request: Promise<T>, signal?: AbortSignal): Promise<T | null> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,12 @@ import { fileURLToPath } from "node:url";
 import { conversationSnapshot } from "./db/scan.js";
 import { defaultInstallBinDir, ensureAgyInstalled } from "./installer.js";
 import { StreamPoller } from "./db/streaming.js";
-import { permissionKeys, type AgyPermissionChoice } from "./permissions.js";
+import {
+  canBridgeInteraction,
+  interactionKeys,
+  parseAskQuestion,
+  type AgyPermissionChoice
+} from "./permissions.js";
 export const DEFAULT_AGY_MODEL_LIST_TIMEOUT_MS = 15_000;
 export const DEFAULT_CONVERSATIONS_DIR = path.join(os.homedir(), ".gemini", "antigravity-cli", "conversations");
 const POLL_INTERVAL_MS = 200;
@@ -27,7 +32,10 @@ export interface PtyProcess {
 export interface PtyFactory {
   spawn(command: string, args: string[], options: { cwd: string; env?: NodeJS.ProcessEnv; cols: number; rows: number }): PtyProcess;
 }
-export type PermissionCallback = (toolCall: SessionUpdate) => Promise<AgyPermissionChoice | "cancelled">;
+export type PermissionCallback = (
+  toolCall: SessionUpdate,
+  context: { toolName: string }
+) => Promise<AgyPermissionChoice | "cancelled">;
 
 export interface SpawnOptions {
   cwd: string;
@@ -318,12 +326,30 @@ export class AgyCliSession {
           const id = String((toolCall as unknown as { toolCallId?: string }).toolCallId);
           if (requested.has(id)) continue;
           requested.add(id);
-          if (interaction.toolName !== "run_command") {
-            throw new AgyCliError(`Unsupported agy interaction '${interaction.toolName}' (status 9); only run_command permission menus can be bridged safely`, [this.config.agyPath], null, this.#ptyOutput);
+          if (!canBridgeInteraction(interaction.toolName, toolCall)) {
+            const detail = unsupportedInteractionDetail(interaction.toolName, toolCall);
+            throw new AgyCliError(
+              `Unsupported agy interaction '${interaction.toolName}' (status 9); ${detail}`,
+              [this.config.agyPath],
+              null,
+              this.#ptyOutput
+            );
           }
-          const choice = await this.raceTurnCallback(onPermission(toolCall), deadline);
+          const choice = await this.raceTurnCallback(
+            onPermission(toolCall, { toolName: interaction.toolName }),
+            deadline
+          );
           if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
-          this.#pty?.write(permissionKeys(choice));
+          const keys = interactionKeys(choice, interaction.toolName, toolCall);
+          if (keys == null) {
+            throw new AgyCliError(
+              `Unsupported permission choice '${choice}' for '${interaction.toolName}'`,
+              [this.config.agyPath],
+              null,
+              this.#ptyOutput
+            );
+          }
+          this.#pty?.write(keys);
           // An idle marker printed before the decision cannot mean that the
           // approved/rejected command has finished.
           requiredIdleMarkerCount = this.#ptyIdleMarkerCount + 1;
@@ -789,6 +815,18 @@ export function parseAgyModels(output: string): string[] {
     .filter(Boolean)
     .filter((line) => !isAgyStatusLine(line));
   return dedupe(lines);
+}
+
+function unsupportedInteractionDetail(toolName: string, toolCall: SessionUpdate): string {
+  if (toolName === "ask_question") {
+    const ask = parseAskQuestion(toolCall);
+    if (!ask) return "ask_question payload could not be parsed";
+    if (ask.questionCount !== 1) return "only single-question ask_question menus can be bridged safely";
+    if (ask.multiSelect) return "multi-select ask_question is not bridged yet";
+    if (ask.options.length === 0) return "ask_question has no selectable options";
+    return "ask_question could not be bridged";
+  }
+  return "only standard permission menus (run_command, file read/write) and single-select ask_question can be bridged safely";
 }
 
 function isAgyStatusLine(line: string): boolean {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,9 +8,18 @@ import { fileURLToPath } from "node:url";
 import { conversationSnapshot } from "./db/scan.js";
 import { defaultInstallBinDir, ensureAgyInstalled } from "./installer.js";
 import { StreamPoller } from "./db/streaming.js";
+import { revertEditToolCall } from "./edit-revert.js";
+import {
+  primeEditReadThroughClient,
+  routeEditThroughClient,
+  writeEditThroughClient,
+  type EditFsBridge
+} from "./edit-fs-bridge.js";
 import {
   canBridgeInteraction,
   interactionKeys,
+  isEditToolCall,
+  normalizePermissionChoice,
   parseAskQuestion,
   type AgyPermissionChoice
 } from "./permissions.js";
@@ -248,10 +257,15 @@ export class AgyCliSession {
    * translated ACP updates in order. Resolves once the process exits and a few
    * trailing polls have drained any steps flushed right around exit.
    */
-  async prompt(prompt: string, onUpdate: (update: SessionUpdate) => Promise<void>, onPermission?: PermissionCallback): Promise<AgyPromptOutcome> {
+  async prompt(
+    prompt: string,
+    onUpdate: (update: SessionUpdate) => Promise<void>,
+    onPermission?: PermissionCallback,
+    fsBridge?: EditFsBridge
+  ): Promise<AgyPromptOutcome> {
     if (this.config.interactivePermissions) {
       if (!onPermission) throw new Error("interactive permissions require a permission callback");
-      return this.runInteractivePrompt(prompt, onUpdate, onPermission);
+      return this.runInteractivePrompt(prompt, onUpdate, onPermission, fsBridge);
     }
     const command = this.commandForPrompt(prompt);
     try {
@@ -265,7 +279,12 @@ export class AgyCliSession {
     }
   }
 
-  private async runInteractivePrompt(prompt: string, onUpdate: (update: SessionUpdate) => Promise<void>, onPermission: PermissionCallback): Promise<AgyPromptOutcome> {
+  private async runInteractivePrompt(
+    prompt: string,
+    onUpdate: (update: SessionUpdate) => Promise<void>,
+    onPermission: PermissionCallback,
+    fsBridge?: EditFsBridge
+  ): Promise<AgyPromptOutcome> {
     this.#cancelled = false;
     this.#cancelWait = new Promise((resolve) => { this.#cancelTurn = resolve; });
     const signature = JSON.stringify([this.config.model, this.config.effort, this.config.mode]);
@@ -300,7 +319,17 @@ export class AgyCliSession {
     }
     const poller = new StreamPoller({ dir: this.config.conversationsDir, conversationId: this.#conversationId,
       baseStepIdx: this.#lastStepIdx, skipNarration: false, cwd: this.config.cwd, snapshot });
-    const requested = new Set<string>();
+    // Tracked separately: a toolCallId can legitimately go through the live
+    // gate first (status 9 -> keys sent) and later reappear as a completed
+    // edit once agy applies it, at which point it's still worth routing
+    // through the client's fs write-through so its native review UI tracks
+    // the edit — that's a second, independent decision for the same id.
+    const requestedGate = new Set<string>();
+    const requestedEditReview = new Set<string>();
+    // ids that already went through the live gate above, so a later
+    // completed-edit sighting shouldn't trigger a second (redundant) local
+    // permission prompt if the client has no fs write-through.
+    const gatedIds = new Set<string>();
     const activePtyExit = this.#ptyExit!;
     const deadline = Date.now() + parsePrintTimeoutMs(this.config.printTimeout);
     let candidateRevision = -1;
@@ -324,35 +353,90 @@ export class AgyCliSession {
         for (const interaction of poller.takePending()) {
           const toolCall = interaction.update;
           const id = String((toolCall as unknown as { toolCallId?: string }).toolCallId);
-          if (requested.has(id)) continue;
-          requested.add(id);
-          if (!canBridgeInteraction(interaction.toolName, toolCall)) {
-            const detail = unsupportedInteractionDetail(interaction.toolName, toolCall);
-            throw new AgyCliError(
-              `Unsupported agy interaction '${interaction.toolName}' (status 9); ${detail}`,
-              [this.config.agyPath],
-              null,
-              this.#ptyOutput
+          const seen = interaction.blocked ? requestedGate : requestedEditReview;
+          if (seen.has(id)) continue;
+          seen.add(id);
+
+          if (interaction.blocked) {
+            if (!canBridgeInteraction(interaction.toolName, toolCall)) {
+              const detail = unsupportedInteractionDetail(interaction.toolName, toolCall);
+              throw new AgyCliError(
+                `Unsupported agy interaction '${interaction.toolName}' (status 9); ${detail}`,
+                [this.config.agyPath],
+                null,
+                this.#ptyOutput
+              );
+            }
+            gatedIds.add(id);
+
+            if (fsBridge && isEditToolCall(toolCall)) {
+              // Prime the client's pre-edit snapshot now, while disk still
+              // genuinely holds it — agy hasn't written yet. Doing this
+              // after the fact (like the ungated path below) would mean
+              // reverting disk ourselves and racing the client's own file
+              // watcher/open-buffer state, which can silently produce an
+              // empty diff if the file is open in the client's editor.
+              try {
+                await this.raceTurnCallback(primeEditReadThroughClient(toolCall, fsBridge), deadline);
+              } catch {
+                // best effort
+              }
+            }
+
+            const choice = await this.raceTurnCallback(
+              onPermission(toolCall, { toolName: interaction.toolName }),
+              deadline
             );
+            if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
+
+            const keys = interactionKeys(choice, interaction.toolName, toolCall);
+            if (keys == null) {
+              throw new AgyCliError(
+                `Unsupported permission choice '${choice}' for '${interaction.toolName}'`,
+                [this.config.agyPath],
+                null,
+                this.#ptyOutput
+              );
+            }
+            this.#pty?.write(keys);
+            // An idle marker printed before the decision cannot mean that the
+            // approved/rejected command has finished.
+            requiredIdleMarkerCount = this.#ptyIdleMarkerCount + 1;
+            continue;
           }
+
+          // Completed edit — either it landed on disk without ever pausing
+          // (accept-edits / skip-permissions), or it just passed through the
+          // live gate above and agy applied it. Either way, if the client can
+          // take the write itself, hand it off so its native diff/review UI
+          // (e.g. Zed's Review Changes panel) tracks it.
+          if (fsBridge) {
+            const routed = gatedIds.has(id)
+              // Pre-edit state was already primed above (race-free) — just
+              // hand over the final content, no local revert needed.
+              ? await this.raceTurnCallback(writeEditThroughClient(toolCall, fsBridge), deadline)
+              // No prior gate — this is the only chance we get, so fall back
+              // to revert-then-replay (races the client's file watcher if
+              // the file happens to be open there, but it's the best we can
+              // do after the fact).
+              : await this.raceTurnCallback(routeEditThroughClient(toolCall, fsBridge), deadline);
+            if (routed === true) continue;
+          }
+          if (gatedIds.has(id)) {
+            // Already approved through the live gate above and the client
+            // has no write-through — nothing more to do here.
+            continue;
+          }
+
+          // Genuinely ungated (no live agy gate ever asked) and no client
+          // write-through available — offer local review: keep is a no-op,
+          // reject restores prior text.
           const choice = await this.raceTurnCallback(
             onPermission(toolCall, { toolName: interaction.toolName }),
             deadline
           );
           if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
-          const keys = interactionKeys(choice, interaction.toolName, toolCall);
-          if (keys == null) {
-            throw new AgyCliError(
-              `Unsupported permission choice '${choice}' for '${interaction.toolName}'`,
-              [this.config.agyPath],
-              null,
-              this.#ptyOutput
-            );
-          }
-          this.#pty?.write(keys);
-          // An idle marker printed before the decision cannot mean that the
-          // approved/rejected command has finished.
-          requiredIdleMarkerCount = this.#ptyIdleMarkerCount + 1;
+          if (normalizePermissionChoice(choice) === "agy-reject-once") revertEditToolCall(toolCall);
         }
         if (this.#cancelled) break;
         if (candidateRevision === poller.revision && this.#ptyIdleMarkerCount >= requiredIdleMarkerCount) break;

--- a/src/db/plan.ts
+++ b/src/db/plan.ts
@@ -1,0 +1,124 @@
+// Map agy brain-plan markdown artifacts onto ACP plan session updates.
+//
+// agy does not expose a structured plan control plane — only markdown files
+// under ~/.gemini/antigravity-cli/brain/**. We surface those as:
+//   - v1 classic `sessionUpdate: "plan"` with checklist-style entries
+//   - v2 `plan_update` with type "items" (mapped at the protocol boundary)
+//
+// Entry status is inferred only from checkbox markers in the markdown; there is
+// no live task-progress channel from agy, so in-progress/completed only update
+// when the plan file itself is rewritten with new markers.
+
+import type { PlanEntry, PlanEntryPriority, PlanEntryStatus, SessionUpdate } from "@agentclientprotocol/sdk";
+
+/** Stable plan id derived from the absolute brain file path. */
+export function planIdForPath(targetFile: string): string {
+  return `file:${targetFile}`;
+}
+
+/** True when a write target looks like an agy brain plan artifact. */
+export function isPlanFile(targetFile: string): boolean {
+  return (
+    targetFile.includes(".gemini") &&
+    targetFile.includes("antigravity-cli") &&
+    targetFile.includes("brain") &&
+    targetFile.endsWith("md")
+  );
+}
+
+/**
+ * Parse markdown list items into ACP plan entries.
+ *
+ * Recognizes:
+ *   - `- [ ] task` / `* [x] task` / `1. [~] task`  (checkbox → status)
+ *   - `- task` / `* task` / `1. task`               (plain list → pending)
+ *
+ * When no list items exist, falls back to a single entry from the first
+ * meaningful line (heading stripped).
+ */
+export function parsePlanEntries(markdown: string): PlanEntry[] {
+  const entries: PlanEntry[] = [];
+
+  for (const rawLine of markdown.split(/\r?\n/)) {
+    const line = rawLine.replace(/\s+$/, "");
+    if (!line.trim()) continue;
+
+    const checkbox = /^\s*(?:[-*+]|\d+[.)])\s+\[([ xX~-])\]\s+(.+)$/.exec(line);
+    if (checkbox) {
+      const content = checkbox[2].trim();
+      if (!content) continue;
+      entries.push({
+        content,
+        priority: defaultPriority(entries.length),
+        status: checkboxStatus(checkbox[1])
+      });
+      continue;
+    }
+
+    const bullet = /^\s*(?:[-*+]|\d+[.)])\s+(.+)$/.exec(line);
+    if (bullet) {
+      const content = bullet[1].trim();
+      // Skip nested bullets that are only emphasis or empty after strip.
+      if (!content || content === "-" || content === "*") continue;
+      // Ignore list markers that are really horizontal rules / separators.
+      if (/^[-*_]{3,}$/.test(content)) continue;
+      entries.push({
+        content,
+        priority: defaultPriority(entries.length),
+        status: "pending"
+      });
+    }
+  }
+
+  if (entries.length > 0) return entries;
+
+  const fallback = firstMeaningfulLine(markdown);
+  return [
+    {
+      content: fallback,
+      priority: "medium",
+      status: "pending"
+    }
+  ];
+}
+
+/** Build a classic ACP v1 `plan` session update from plan markdown. */
+export function planUpdateFromMarkdown(targetFile: string, markdown: string): SessionUpdate {
+  const entries = parsePlanEntries(markdown);
+  // Stash path for v2 planId mapping / progressive snapshot keys without
+  // inventing a non-schema field on the wire — clients ignore unknown keys? 
+  // Actually ACP forbids assumptions on unknown keys but _meta is reserved.
+  // Use _meta for agent-side mapping only; strip at boundary if needed.
+  return {
+    sessionUpdate: "plan",
+    entries,
+    _meta: {
+      "agy-acp/planId": planIdForPath(targetFile),
+      "agy-acp/planPath": targetFile,
+      "agy-acp/planMarkdown": markdown
+    }
+  } as SessionUpdate;
+}
+
+function checkboxStatus(mark: string): PlanEntryStatus {
+  const m = mark.toLowerCase();
+  if (m === "x") return "completed";
+  if (m === "~" || m === "-") return "in_progress";
+  return "pending";
+}
+
+function defaultPriority(index: number): PlanEntryPriority {
+  // First few items are typically the critical path; rest medium.
+  return index < 3 ? "high" : "medium";
+}
+
+function firstMeaningfulLine(markdown: string): string {
+  for (const raw of markdown.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    // Strip ATX headings.
+    const withoutHeading = line.replace(/^#{1,6}\s+/, "").trim();
+    if (withoutHeading) return withoutHeading.slice(0, 500);
+  }
+  return "Plan";
+}

--- a/src/db/streaming.ts
+++ b/src/db/streaming.ts
@@ -13,6 +13,14 @@ export interface PendingInteraction {
   update: SessionUpdate;
   row: StepRow;
   toolName: string;
+  /**
+   * True when agy itself is blocked awaiting this decision (status 9, the
+   * interactive confirmation menu). False for an edit that already completed
+   * without ever pausing (accept-edits / skip-permissions / any non-gated
+   * mode) — offered for review after the fact, since the write already
+   * happened.
+   */
+  blocked: boolean;
 }
 
 export interface StreamOptions {
@@ -93,10 +101,23 @@ export class StreamPoller {
     const latest = rows.at(-1);
     this._latestAgentComplete = latest?.stepType === 15 && latest.status === 3;
     const updates = this.translator.translate(rows);
-    for (const update of updates.filter((item) => (item as unknown as { status?: string }).status === "pending")) {
-      const id = String((update as unknown as { toolCallId?: string }).toolCallId);
+    for (const update of updates) {
+      const raw = update as unknown as { status?: string; kind?: string; toolCallId?: string };
+      const blocked = raw.status === "pending";
+      // Edits that complete without ever pausing (accept-edits / skip-permissions)
+      // still get offered for review — see PendingInteraction.blocked.
+      const completedEdit = raw.kind === "edit" && raw.status === "completed";
+      if (!blocked && !completedEdit) continue;
+      const id = String(raw.toolCallId);
       const row = rows.find((item) => toolCallId(item) === id);
-      if (row) this._pending.push({ update, row, toolName: row.stepPayload.toolRun?.call?.namePrimary || row.stepPayload.toolRun?.call?.nameSecondary || "unknown" });
+      if (row) {
+        this._pending.push({
+          update,
+          row,
+          toolName: row.stepPayload.toolRun?.call?.namePrimary || row.stepPayload.toolRun?.call?.nameSecondary || "unknown",
+          blocked
+        });
+      }
     }
     return updates;
   }

--- a/src/db/tool-call-updates.ts
+++ b/src/db/tool-call-updates.ts
@@ -5,6 +5,7 @@
 import path from "node:path";
 import type { SessionUpdate, ToolKind } from "@agentclientprotocol/sdk";
 import type { ErrorDetails, PermissionInfo, TaskDetails } from "./columns.js";
+import { isPlanFile, planUpdateFromMarkdown } from "./plan.js";
 import type { SearchHit } from "./step-payload.js";
 import type { StepRow } from "./types.js";
 
@@ -471,17 +472,9 @@ export function fetchUpdate(stepRow: StepRow): SessionUpdate {
   return update;
 }
 
-function isPlanFile(targetFile: string): boolean {
-  return (
-    targetFile.includes(".gemini") &&
-    targetFile.includes("antigravity-cli") &&
-    targetFile.includes("brain") &&
-    targetFile.endsWith("md")
-  );
-}
-
 /** Step type 5 (write_to_file|replace_file_content|multi_replace_file_content),
- *  and step 17 artifact writes (e.g. a generated `plan.md` for user review). */
+ *  and step 17 artifact writes (e.g. a generated `plan.md` for user review).
+ *  Brain plan markdown becomes a structured ACP `plan` update (not an edit tool). */
 export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate | SessionUpdate[] {
   const cwd = ctx?.cwd;
   const fileContents = ctx?.fileContents;
@@ -489,36 +482,32 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   const displayCwd = fsPath(cwd) ?? undefined;
 
   const targetFile = fsPath(asStr(pick(rawInput, "TargetFile", "targetFile"))) ?? "";
-  const isPlan = isPlanFile(targetFile);
+  const fullContent = asStr(pick(rawInput, "CodeContent", "codeContent"));
+
+  // Brain plan artifacts → structured plan session update (v1 `plan` / v2 plan_update).
+  if (isPlanFile(targetFile)) {
+    if (fullContent === null || fullContent.length === 0) return [];
+    return planUpdateFromMarkdown(targetFile, fullContent);
+  }
+
   const shown = targetFile ? toDisplayPath(targetFile, displayCwd) : "";
-  const planName = shown.split("/").pop() ?? "plan.md";
-  const title = isPlan
-    ? planName.toLowerCase().includes("plan")
-      ? planName
-      : `Plan: ${planName}`
-    : shown
-      ? `Edit ${shown}`
-      : "Edit";
+  const title = shown ? `Edit ${shown}` : "Edit";
 
   const content: Record<string, unknown>[] = [];
   const locations: Record<string, unknown>[] = [];
 
-  const fullContent = asStr(pick(rawInput, "CodeContent", "codeContent"));
   if (fullContent !== null) {
     // write_to_file: the whole file content is the new text.
-    if (isPlan) {
-      // Plans are user-facing prose (brain artifacts), not code diffs.
-      content.push(textBlock(fullContent));
-    } else if (targetFile) {
+    if (targetFile) {
       // Prefer prior view_file/write content as oldText when known; otherwise null
       // (new file or prior content never observed in this translator pass).
       const cacheKey = path.resolve(targetFile);
       const prior = fileContents?.get(cacheKey) ?? null;
       content.push({ type: "diff", path: targetFile, oldText: prior, newText: fullContent });
       fileContents?.set(cacheKey, fullContent);
+      locations.push({ path: targetFile });
     }
-    if (targetFile) locations.push({ path: targetFile });
-  } else if (!isPlan) {
+  } else {
     // replace_file_content (one inline chunk) or multi_replace_file_content
     // (a ReplacementChunks array) — normalize both to a list of chunks.
     const chunksRaw = pick(rawInput, "ReplacementChunks", "replacementChunks");
@@ -535,7 +524,6 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
     }
   }
 
-  if (isPlan && content.length === 0) return [];
   return toolCallUpdate({ stepRow, title, kind: "edit", content, locations });
 }
 

--- a/src/db/translator.ts
+++ b/src/db/translator.ts
@@ -45,7 +45,7 @@ function thoughtChunk(text: string, messageId: string): SessionUpdate {
   };
 }
 
-/** Stable signature of a tool/thought update for progressive re-emission. */
+/** Stable signature of a tool/plan/thought update for progressive re-emission. */
 function updateSnapshot(update: SessionUpdate): string {
   const raw = update as unknown as Record<string, unknown>;
   return JSON.stringify({
@@ -59,6 +59,10 @@ function updateSnapshot(update: SessionUpdate): string {
     rawInput: raw.rawInput,
     rawOutput: raw.rawOutput,
     messageId: raw.messageId,
+    entries: raw.entries,
+    plan: raw.plan,
+    planId: raw.planId,
+    _meta: raw._meta,
     text: raw.content && typeof raw.content === "object" ? (raw.content as { text?: string }).text : undefined
   });
 }
@@ -154,8 +158,9 @@ export class Translator {
   }
 
   /**
-   * Emit a tool/thought update, converting subsequent emissions for the same
-   * step idx into `tool_call_update` when the snapshot changes.
+   * Emit a tool/plan/thought update. Tools re-emit as `tool_call_update` when
+   * the snapshot changes; plans re-emit as a full `plan` replacement when the
+   * markdown-derived entries change. Unrelated update kinds pass through.
    */
   private emitProgressive(stepIdx: number, update: SessionUpdate, out: SessionUpdate[]): void {
     const raw = update as unknown as Record<string, unknown>;
@@ -163,6 +168,15 @@ export class Translator {
 
     if (kind === "agent_thought_chunk") {
       this.emitThought(update, out);
+      return;
+    }
+
+    if (kind === "plan" || kind === "plan_update" || kind === "plan_removed") {
+      const snapshot = updateSnapshot(update);
+      const previous = this.toolSnapshots.get(stepIdx);
+      if (previous === snapshot) return;
+      this.toolSnapshots.set(stepIdx, snapshot);
+      out.push(update);
       return;
     }
 

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -11,7 +11,7 @@ export type StepRow = {
    * agy step status enum (from the `status` column):
    *   1/2 = active, 3 = completed, 6 = cancelled/aborted, 7 = failed,
    *   9 = RequestedInteraction (generic; not necessarily a permission menu).
-   * Only status-9 run_command rows are currently bridged to ACP permissions.
+   * Status-9 run_command and file read/write rows are bridged to ACP permissions.
    */
   status: number;
   stepPayload: StepPayload;

--- a/src/edit-fs-bridge.ts
+++ b/src/edit-fs-bridge.ts
@@ -1,0 +1,105 @@
+// Route an already-applied edit (no live agy gate) through the ACP client's
+// own fs/read_text_file + fs/write_text_file so its native diff/review UI
+// (e.g. Zed's Review Changes panel, populated via its own buffer/action-log
+// tracking) owns the change instead of agy-acp's local permission-bridge
+// modal. See acp_thread.rs::write_text_file: Zed diffs the write's content
+// against the buffer snapshot it has cached (from a prior read_text_file, or
+// the buffer's live state) — so the file must still read as the pre-edit
+// text at the moment we call in, which is why we revert it locally first.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import { diffBlocks } from "./edit-revert.js";
+
+export interface EditFsBridge {
+  readTextFile(path: string): Promise<void>;
+  writeTextFile(path: string, content: string): Promise<void>;
+}
+
+/**
+ * Returns true if the edit was handed off to the client (disk ends up back
+ * at newText, written by the client itself). Returns false — leaving disk
+ * untouched at newText — if there was nothing to route or the client
+ * rejected the write-through, so the caller can fall back to the local
+ * permission-bridge review.
+ */
+export async function routeEditThroughClient(toolCall: SessionUpdate, bridge: EditFsBridge): Promise<boolean> {
+  const blocks = diffBlocks(toolCall);
+  if (blocks.length === 0) return false;
+
+  // Same matching rules as revertEditToolCall: oldText/newText may be the
+  // whole file (create/full-file write) or a snippet embedded in surrounding
+  // context (partial replace) — either way `current` is the full post-edit
+  // file content we hand to the client once it has the pre-edit state cached.
+  const reverted: { path: string; fullNewText: string }[] = [];
+  try {
+    for (const { path, oldText, newText } of blocks) {
+      const current = existsSync(path) ? readFileSync(path, "utf8") : null;
+      if (current === null) continue;
+
+      let fullOldText: string;
+      if (current === newText) {
+        fullOldText = oldText ?? "";
+      } else if (current.includes(newText)) {
+        fullOldText = current.replace(newText, oldText ?? "");
+      } else {
+        continue; // diverged since — leave this file alone
+      }
+
+      writeFileSync(path, fullOldText, "utf8");
+      reverted.push({ path, fullNewText: current });
+
+      await bridge.readTextFile(path);
+      await bridge.writeTextFile(path, current);
+    }
+    return reverted.length > 0;
+  } catch {
+    // Restore whatever we reverted before the failure, so disk still matches
+    // the content already reported via session/update.
+    for (const { path, fullNewText } of reverted) {
+      try { writeFileSync(path, fullNewText, "utf8"); } catch { /* best effort */ }
+    }
+    return false;
+  }
+}
+
+/**
+ * Prime the client's buffer snapshot for a live-gated edit *before* agy
+ * applies it, while disk still genuinely holds the pre-edit text. Used so
+ * the later write-through (see {@link writeEditThroughClient}) doesn't need
+ * to revert-then-replay disk itself — which races against the client's own
+ * file watcher if the buffer is already open there. Best effort: failures
+ * are swallowed, since a missed prime just means the later write-through
+ * won't produce a clean diff and the caller falls back silently.
+ */
+export async function primeEditReadThroughClient(toolCall: SessionUpdate, bridge: EditFsBridge): Promise<void> {
+  const paths = new Set(diffBlocks(toolCall).map((block) => block.path));
+  for (const path of paths) {
+    try {
+      await bridge.readTextFile(path);
+    } catch {
+      // best effort
+    }
+  }
+}
+
+/**
+ * Write an edit through the client after agy has already applied it *and*
+ * the pre-edit state was primed via {@link primeEditReadThroughClient} —
+ * no local revert needed, since disk was never touched by us in between.
+ */
+export async function writeEditThroughClient(toolCall: SessionUpdate, bridge: EditFsBridge): Promise<boolean> {
+  const paths = new Set(diffBlocks(toolCall).map((block) => block.path));
+  if (paths.size === 0) return false;
+  try {
+    let wrote = false;
+    for (const path of paths) {
+      if (!existsSync(path)) continue;
+      await bridge.writeTextFile(path, readFileSync(path, "utf8"));
+      wrote = true;
+    }
+    return wrote;
+  } catch {
+    return false;
+  }
+}

--- a/src/edit-revert.ts
+++ b/src/edit-revert.ts
@@ -1,0 +1,56 @@
+// Undo an edit tool call that already landed on disk without a live agy
+// confirmation gate (accept-edits / skip-permissions / any mode where agy
+// didn't block). Used so edits_pending review still offers a real reject
+// action in those cases instead of a no-op.
+
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+
+export interface DiffBlock {
+  path: string;
+  oldText: string | null;
+  newText: string;
+}
+
+export function diffBlocks(toolCall: SessionUpdate): DiffBlock[] {
+  const raw = toolCall as unknown as { content?: unknown };
+  const content = Array.isArray(raw.content) ? raw.content : [];
+  const blocks: DiffBlock[] = [];
+  for (const item of content) {
+    if (!item || typeof item !== "object") continue;
+    const block = item as Record<string, unknown>;
+    if (block.type !== "diff") continue;
+    const path = typeof block.path === "string" ? block.path : null;
+    const newText = typeof block.newText === "string" ? block.newText : null;
+    if (!path || newText === null) continue;
+    const oldText = typeof block.oldText === "string" ? block.oldText : null;
+    blocks.push({ path, oldText, newText });
+  }
+  return blocks;
+}
+
+/**
+ * Restore the pre-edit text this same translator pass recorded for each diff
+ * block. Only acts when the file's current content still matches what the
+ * edit wrote — if it has diverged further (a later edit landed on top), the
+ * block is left alone rather than guessing.
+ */
+export function revertEditToolCall(toolCall: SessionUpdate): void {
+  for (const { path, oldText, newText } of diffBlocks(toolCall)) {
+    const current = existsSync(path) ? readFileSync(path, "utf8") : null;
+    if (current === null) continue;
+
+    if (oldText === null) {
+      // This block created the file; only remove it if nothing else touched
+      // it since.
+      if (current === newText) rmSync(path);
+      continue;
+    }
+
+    if (current === newText) {
+      writeFileSync(path, oldText, "utf8");
+    } else if (current.includes(newText)) {
+      writeFileSync(path, current.replace(newText, oldText), "utf8");
+    }
+  }
+}

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,10 +1,11 @@
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 
-export type AgyPermissionChoice =
-  | "agy-allow-once"
-  | "agy-allow-conversation"
-  | "agy-allow-settings"
-  | "agy-reject-once";
+/**
+ * Option ids for permission menus and ask_question.
+ * Edit tools use standard ACP ids (`allow-once` / `reject-once` / `allow-always`)
+ * so clients can map them to native Keep / Reject UI.
+ */
+export type AgyPermissionChoice = string;
 
 export interface AgyPermissionOption {
   optionId: AgyPermissionChoice;
@@ -12,25 +13,267 @@ export interface AgyPermissionOption {
   name: string;
 }
 
-export function permissionKeys(choice: AgyPermissionChoice): string {
+export interface AskQuestionPayload {
+  question: string;
+  options: string[];
+  multiSelect: boolean;
+  questionCount: number;
+}
+
+/**
+ * Status-9 tools that can be answered through ACP `session/request_permission`
+ * and PTY key injection. `ask_question` is handled separately (MCQ, not a
+ * permission panel).
+ */
+export function isBridgeablePermissionTool(toolName: string): boolean {
+  if (!toolName || toolName === "ask_question") return false;
+  if (toolName === "run_command") return true;
+  if (toolName === "view_file" || toolName === "list_dir") return true;
+  if (isEditToolName(toolName)) return true;
+  return false;
+}
+
+export function isEditToolName(toolName: string): boolean {
+  return Boolean(toolName) && /write|replace|edit|patch/.test(toolName);
+}
+
+/** True when an ACP tool_call update is a file edit (kind or tool name). */
+export function isEditToolCall(toolCall: SessionUpdate): boolean {
+  const raw = toolCall as unknown as Record<string, unknown>;
+  if (raw.kind === "edit") return true;
+  return false;
+}
+
+/** True when this status-9 tool can be bridged (permission menu or single-select MCQ). */
+export function canBridgeInteraction(toolName: string, toolCall?: SessionUpdate): boolean {
+  if (isBridgeablePermissionTool(toolName)) return true;
+  if (toolName !== "ask_question" || !toolCall) return false;
+  const ask = parseAskQuestion(toolCall);
+  return ask != null && isBridgeableAskQuestion(ask);
+}
+
+/** Single-select, single-question ask_question is safe to map to PTY keys. */
+export function isBridgeableAskQuestion(ask: AskQuestionPayload): boolean {
+  return ask.questionCount === 1 && !ask.multiSelect && ask.options.length > 0;
+}
+
+/** Normalize client-selected option ids (standard ACP or legacy agy-*). */
+export function normalizePermissionChoice(choice: string): AgyPermissionChoice {
   switch (choice) {
+    case "allow-once":
+    case "allow_once":
+      return "agy-allow-once";
+    case "allow-always":
+    case "allow_always":
+      return "agy-allow-settings";
+    case "allow-conversation":
+      return "agy-allow-conversation";
+    case "reject-once":
+    case "reject_once":
+    case "reject":
+      return "agy-reject-once";
+    default:
+      return choice;
+  }
+}
+
+export function permissionKeys(choice: AgyPermissionChoice): string | null {
+  const id = normalizePermissionChoice(choice);
+  switch (id) {
     case "agy-allow-once": return "\r";
     case "agy-allow-conversation": return "\x1b[B\r";
     case "agy-allow-settings": return "\x1b[B\x1b[B\r";
     case "agy-reject-once": return "\x1b[B\x1b[B\x1b[B\r";
+    default: return null;
   }
 }
 
-/** Build choices matching agy 1.1.5's run_command menu. */
-export function permissionOptions(toolCall: SessionUpdate): AgyPermissionOption[] {
+/**
+ * Map an ACP option id to PTY keypresses for the given interaction.
+ * Returns null when the choice cannot be applied safely.
+ */
+export function interactionKeys(
+  choice: AgyPermissionChoice,
+  toolName: string,
+  toolCall?: SessionUpdate
+): string | null {
+  if (toolName === "ask_question") {
+    if (choice === "agy-q-skip") return "\x1b"; // Esc — cancel / skip the modal
+    const match = /^agy-q-(\d+)$/.exec(choice);
+    if (!match || !toolCall) return null;
+    const index = Number(match[1]);
+    const ask = parseAskQuestion(toolCall);
+    if (!ask || !isBridgeableAskQuestion(ask) || index < 0 || index >= ask.options.length) return null;
+    // First option is focused by default; Down N then Enter selects option N.
+    return `${"\x1b[B".repeat(index)}\r`;
+  }
+
+  // Edit tools: map standard ACP allow/reject onto agy's 4-row menu.
+  // Accept/allow-once → first row; always-allow → settings row; reject → last row.
+  if (isEditToolName(toolName)) {
+    const id = normalizePermissionChoice(choice);
+    if (id === "agy-allow-once") return "\r";
+    if (id === "agy-allow-settings") return "\x1b[B\x1b[B\r";
+    if (id === "agy-allow-conversation") return "\x1b[B\r";
+    if (id === "agy-reject-once") return "\x1b[B\x1b[B\x1b[B\r";
+    return null;
+  }
+
+  return permissionKeys(choice);
+}
+
+function pickString(input: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function toolRawInput(toolCall: SessionUpdate): Record<string, unknown> {
   const raw = toolCall as unknown as Record<string, unknown>;
-  const input = raw.rawInput && typeof raw.rawInput === "object" ? raw.rawInput as Record<string, unknown> : {};
-  const target = typeof input.CommandLine === "string" && input.CommandLine.trim()
-    ? input.CommandLine.trim() : String(raw.title ?? "this command");
+  return raw.rawInput && typeof raw.rawInput === "object" && !Array.isArray(raw.rawInput)
+    ? raw.rawInput as Record<string, unknown>
+    : {};
+}
+
+/** Parse ask_question rawInput into a stable shape for bridging. */
+export function parseAskQuestion(toolCall: SessionUpdate): AskQuestionPayload | null {
+  const input = toolRawInput(toolCall);
+  const questionsRaw = input.questions ?? input.Questions;
+  const questions = Array.isArray(questionsRaw) ? questionsRaw : [];
+  if (questions.length === 0) return null;
+
+  const first = questions[0];
+  const entry = first && typeof first === "object" && !Array.isArray(first)
+    ? first as Record<string, unknown>
+    : {};
+  const question =
+    pickString(entry, "question", "Question") ??
+    String((toolCall as unknown as { title?: unknown }).title ?? "Question");
+  const optionsRaw = entry.options ?? entry.Options;
+  const optionsList = Array.isArray(optionsRaw) ? optionsRaw : [];
+  const options = optionsList
+    .map((opt) => {
+      if (typeof opt === "string") return opt.trim();
+      if (opt && typeof opt === "object" && !Array.isArray(opt)) {
+        return pickString(opt as Record<string, unknown>, "label", "Label", "text", "Text", "id", "Id") ?? "";
+      }
+      return "";
+    })
+    .filter(Boolean);
+  const multiSelect = Boolean(entry.is_multi_select ?? entry.isMultiSelect ?? entry.IsMultiSelect);
+
+  return {
+    question,
+    options,
+    multiSelect,
+    questionCount: questions.length
+  };
+}
+
+/** Build ACP permission options for the given pending tool interaction. */
+export function permissionOptions(toolCall: SessionUpdate, toolName?: string): AgyPermissionOption[] {
+  if (toolName === "ask_question") {
+    return askQuestionOptions(toolCall);
+  }
+
+  // File edits: standard ACP option ids/kinds so clients can render native
+  // Keep / Reject (or equivalent) review UI against the tool_call diff.
+  if (isEditToolName(toolName ?? "") || (toolName == null && isEditToolCall(toolCall))) {
+    return standardEditPermissionOptions();
+  }
+
+  const raw = toolCall as unknown as Record<string, unknown>;
+  const input = toolRawInput(toolCall);
+  const command = pickString(input, "CommandLine", "commandLine", "command");
+  const filePath = pickString(
+    input,
+    "TargetFile",
+    "targetFile",
+    "AbsolutePath",
+    "absolutePath",
+    "FilePath",
+    "DirectoryPath",
+    "directoryPath"
+  );
+
+  const useCommandMenu =
+    toolName === "run_command" ||
+    ((toolName == null || toolName === "") && Boolean(command) && !filePath);
+
+  if (useCommandMenu) {
+    const target = command ?? String(raw.title ?? "this command");
+    return [
+      { optionId: "agy-allow-once", kind: "allow_once", name: "Yes" },
+      {
+        optionId: "agy-allow-conversation",
+        kind: "allow_always",
+        name: `Yes, and always allow in this conversation for commands that start with '${target}'`
+      },
+      {
+        optionId: "agy-allow-settings",
+        kind: "allow_always",
+        name: `Yes, and always allow for commands that start with '${target}' (Persist to settings.json)`
+      },
+      { optionId: "agy-reject-once", kind: "reject_once", name: "No" }
+    ];
+  }
+
+  // Generic tool menus (e.g. read_file) from agy 1.1.5 TUI strings.
+  const grant = permissionGrantLabel(toolName, filePath, raw.title);
   return [
     { optionId: "agy-allow-once", kind: "allow_once", name: "Yes" },
-    { optionId: "agy-allow-conversation", kind: "allow_always", name: `Yes, and always allow in this conversation for commands that start with '${target}'` },
-    { optionId: "agy-allow-settings", kind: "allow_always", name: `Yes, and always allow for commands that start with '${target}' (Persist to settings.json)` },
+    {
+      optionId: "agy-allow-conversation",
+      kind: "allow_always",
+      name: `Yes, and always allow '${grant}' in this conversation`
+    },
+    {
+      optionId: "agy-allow-settings",
+      kind: "allow_always",
+      name: `Yes, and always allow '${grant}' (Persist to settings.json)`
+    },
     { optionId: "agy-reject-once", kind: "reject_once", name: "No" }
   ];
+}
+
+/**
+ * Standard ACP permission options for file edits.
+ * Clients (Zed, Grok Build as ACP host, etc.) key off `kind` for Keep/Reject UI.
+ * @see https://agentclientprotocol.com/protocol/v1/tool-calls#requesting-permission
+ */
+function standardEditPermissionOptions(): AgyPermissionOption[] {
+  return [
+    { optionId: "allow-once", kind: "allow_once", name: "Allow" },
+    { optionId: "allow-always", kind: "allow_always", name: "Always allow" },
+    { optionId: "reject-once", kind: "reject_once", name: "Reject" }
+  ];
+}
+
+function askQuestionOptions(toolCall: SessionUpdate): AgyPermissionOption[] {
+  const ask = parseAskQuestion(toolCall);
+  if (!ask || !isBridgeableAskQuestion(ask)) {
+    return [{ optionId: "agy-q-skip", kind: "reject_once", name: "Skip" }];
+  }
+  const options: AgyPermissionOption[] = ask.options.map((name, index) => ({
+    optionId: `agy-q-${index}`,
+    kind: "allow_once" as const,
+    name
+  }));
+  options.push({ optionId: "agy-q-skip", kind: "reject_once", name: "Skip" });
+  return options;
+}
+
+/** Format the grant pattern shown in agy menus / settings.allow rules. */
+function permissionGrantLabel(
+  toolName: string | undefined,
+  filePath: string | undefined,
+  title: unknown
+): string {
+  const isRead = toolName === "view_file" || toolName === "list_dir";
+  const kind = isRead ? "read_file" : "write_file";
+  if (filePath) return `${kind}(${filePath})`;
+  if (typeof title === "string" && title.trim()) return title.trim();
+  return `${kind}(*)`;
 }

--- a/src/session-updates.ts
+++ b/src/session-updates.ts
@@ -245,6 +245,11 @@ export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
       status: mapToolStatusForV1(raw.status)
     } as V1SessionUpdate;
   }
+  // Drop agent-private plan _meta keys from the v1 wire (entries stay).
+  if (raw.sessionUpdate === "plan" && raw._meta && typeof raw._meta === "object") {
+    const { _meta: _drop, ...rest } = raw;
+    return rest as V1SessionUpdate;
+  }
   return update;
 }
 
@@ -289,7 +294,46 @@ export function sessionUpdateToV2(update: V1SessionUpdate): V2SessionUpdate {
     return raw as V2SessionUpdate;
   }
 
+  // Classic v1 `plan` → draft v2 `plan_update` with structured items.
+  // Prefer markdown content when the translator stashed it in _meta.
+  if (raw.sessionUpdate === "plan") {
+    return planToV2(raw);
+  }
+
   return raw as V2SessionUpdate;
+}
+
+function planToV2(raw: Record<string, unknown>): V2SessionUpdate {
+  const meta = asRecord(raw._meta);
+  const planId =
+    (typeof meta?.["agy-acp/planId"] === "string" && meta["agy-acp/planId"]) ||
+    (typeof meta?.["agy-acp/planPath"] === "string" && `file:${meta["agy-acp/planPath"]}`) ||
+    "agy-plan";
+  const markdown =
+    typeof meta?.["agy-acp/planMarkdown"] === "string" ? meta["agy-acp/planMarkdown"] : null;
+  const entries = Array.isArray(raw.entries) ? raw.entries : [];
+
+  // Prefer markdown when available (full fidelity of the brain artifact);
+  // otherwise fall back to item entries from the classic plan shape.
+  if (markdown !== null && markdown.length > 0) {
+    return {
+      sessionUpdate: "plan_update",
+      plan: {
+        type: "markdown",
+        planId,
+        content: markdown
+      }
+    } as V2SessionUpdate;
+  }
+
+  return {
+    sessionUpdate: "plan_update",
+    plan: {
+      type: "items",
+      planId,
+      entries
+    }
+  } as V2SessionUpdate;
 }
 
 /**

--- a/src/session-updates.ts
+++ b/src/session-updates.ts
@@ -2,7 +2,8 @@
 //
 // The db layer emits v1-shaped updates (with required messageIds on message
 // chunks). v1 clients receive them as-is; v2 clients get the draft-v2 mapping
-// (tool_call → tool_call_update, structured diffs, cancelled status, etc.).
+// (tool_call → tool_call_update, structured diffs, cancelled status, agent-owned
+// terminals for execute tools, etc.).
 
 import type { SessionUpdate as V1SessionUpdate } from "@agentclientprotocol/sdk";
 import type { SessionUpdate as V2SessionUpdate } from "@agentclientprotocol/sdk/experimental/v2";
@@ -39,6 +40,11 @@ export function gitPatchForFile(
     `@@ -1,${Math.max(oldLines.length, 1)} +1,${Math.max(newLines.length, 1)} @@`,
     body
   ].join("\n");
+}
+
+/** Stable agent-owned terminal id for an execute tool call. */
+export function terminalIdForToolCall(toolCallId: string): string {
+  return `agy-term-${toolCallId}`;
 }
 
 function toolContentToV2(item: Record<string, unknown>): Record<string, unknown> {
@@ -78,6 +84,158 @@ function mapToolStatusForV1(status: unknown): unknown {
   return status === "cancelled" ? "failed" : status;
 }
 
+function isToolCallUpdate(raw: Record<string, unknown>): boolean {
+  return raw.sessionUpdate === "tool_call" || raw.sessionUpdate === "tool_call_update";
+}
+
+function isExecuteToolUpdate(raw: Record<string, unknown>): boolean {
+  return isToolCallUpdate(raw) && raw.kind === "execute";
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function pickString(input: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+/** Strip markdown fences from tool content text blocks (execute builders wrap code). */
+function unfence(text: string): string {
+  const trimmed = text.replace(/^\s+|\s+$/g, "");
+  const match = /^`{3,}[^\n]*\n([\s\S]*?)\n`{3,}$/.exec(trimmed);
+  return match ? match[1] : text;
+}
+
+function contentTexts(raw: Record<string, unknown>): string[] {
+  if (!Array.isArray(raw.content)) return [];
+  const texts: string[] = [];
+  for (const item of raw.content) {
+    const block = asRecord(item);
+    if (!block || block.type !== "content") continue;
+    const content = asRecord(block.content);
+    if (content && typeof content.text === "string" && content.text.length > 0) {
+      texts.push(unfence(content.text));
+    }
+  }
+  return texts;
+}
+
+export interface ExecuteTerminalMeta {
+  terminalId: string;
+  toolCallId: string;
+  command?: string;
+  cwd?: string;
+  output?: string;
+  exitCode?: number;
+  status?: string;
+}
+
+/** Extract execute-tool terminal fields from a v1-shaped tool call update. */
+export function executeTerminalMeta(update: V1SessionUpdate): ExecuteTerminalMeta | null {
+  const raw = update as unknown as Record<string, unknown>;
+  if (!isExecuteToolUpdate(raw)) return null;
+  const toolCallId = typeof raw.toolCallId === "string" && raw.toolCallId.trim()
+    ? raw.toolCallId.trim()
+    : "";
+  if (!toolCallId) return null;
+
+  const rawInput = asRecord(raw.rawInput) ?? {};
+  const rawOutput = asRecord(raw.rawOutput) ?? {};
+  const texts = contentTexts(raw);
+
+  const command =
+    pickString(rawInput, "CommandLine", "commandLine", "command") ??
+    (texts[0]?.includes("\n") ? texts[0].split("\n")[0] : texts[0]) ??
+    (typeof raw.title === "string" && raw.title.trim() ? raw.title.trim() : undefined);
+
+  const cwd = pickString(rawInput, "Cwd", "cwd");
+
+  let output = typeof rawOutput.output === "string" ? rawOutput.output : undefined;
+  if (output == null && texts.length >= 2) {
+    // executeUpdate: content[0] = command, content[1] = output when both present.
+    output = texts[1];
+  } else if (output == null && texts.length === 1 && command && texts[0] !== command) {
+    output = texts[0];
+  }
+
+  const exitCode = typeof rawOutput.exitCode === "number" ? rawOutput.exitCode : undefined;
+  const status = typeof raw.status === "string" ? raw.status : undefined;
+
+  return {
+    terminalId: terminalIdForToolCall(toolCallId),
+    toolCallId,
+    command,
+    cwd,
+    output,
+    exitCode,
+    status
+  };
+}
+
+function utf8ToBase64(text: string): string {
+  return Buffer.from(text, "utf8").toString("base64");
+}
+
+/**
+ * Build a draft-v2 `terminal_update` for an execute tool call from DB-backed
+ * command metadata. Output is a full replacement snapshot (not live PTY bytes);
+ * mid-command streaming only appears if agy persists partial field-28 results.
+ */
+export function terminalUpdateForExecute(meta: ExecuteTerminalMeta): V2SessionUpdate {
+  const update: Record<string, unknown> = {
+    sessionUpdate: "terminal_update",
+    terminalId: meta.terminalId
+  };
+  if (meta.command) update.command = meta.command;
+  if (meta.cwd) update.cwd = meta.cwd;
+  if (meta.output != null && meta.output.length > 0) {
+    update.output = { data: utf8ToBase64(meta.output) };
+  }
+
+  const finished =
+    meta.status === "completed" ||
+    meta.status === "failed" ||
+    meta.status === "cancelled";
+  if (finished) {
+    const exitStatus: Record<string, unknown> = {};
+    if (typeof meta.exitCode === "number") exitStatus.exitCode = meta.exitCode;
+    if (meta.status === "cancelled" && meta.exitCode == null) exitStatus.signal = "SIGINT";
+    update.exitStatus = exitStatus;
+  } else if (typeof meta.exitCode === "number") {
+    // Exit code without a terminal status still marks the process as exited.
+    update.exitStatus = { exitCode: meta.exitCode };
+  }
+
+  return update as V2SessionUpdate;
+}
+
+function withTerminalContent(
+  content: unknown,
+  terminalId: string
+): Record<string, unknown>[] {
+  const terminalBlock = { type: "terminal", terminalId };
+  if (!Array.isArray(content) || content.length === 0) {
+    return [terminalBlock];
+  }
+  const mapped = content.map((item) =>
+    item && typeof item === "object"
+      ? toolContentToV2(item as Record<string, unknown>)
+      : item
+  ) as Record<string, unknown>[];
+  // Avoid duplicating the same terminal embed on progressive updates.
+  if (mapped.some((item) => item?.type === "terminal" && item.terminalId === terminalId)) {
+    return mapped;
+  }
+  return [terminalBlock, ...mapped];
+}
+
 /** Identity cast for the v1 wire format (builders already emit v1 shapes). */
 export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
   const raw = update as unknown as Record<string, unknown>;
@@ -90,7 +248,11 @@ export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
   return update;
 }
 
-/** Map a builder-emitted (v1-shaped) update onto draft ACP v2. */
+/**
+ * Map a builder-emitted (v1-shaped) update onto a single draft ACP v2 update.
+ * Prefer {@link expandSessionUpdateToV2} on the wire — execute tools also emit
+ * a sibling `terminal_update`.
+ */
 export function sessionUpdateToV2(update: V1SessionUpdate): V2SessionUpdate {
   const raw = { ...(update as unknown as Record<string, unknown>) };
 
@@ -130,10 +292,27 @@ export function sessionUpdateToV2(update: V1SessionUpdate): V2SessionUpdate {
   return raw as V2SessionUpdate;
 }
 
+/**
+ * Expand one v1-shaped update into one or more v2 session updates.
+ * Execute tools produce `terminal_update` then `tool_call_update` with a
+ * display-only `{ type: "terminal", terminalId }` content block.
+ */
+export function expandSessionUpdateToV2(update: V1SessionUpdate): V2SessionUpdate[] {
+  const meta = executeTerminalMeta(update);
+  if (!meta) {
+    return [sessionUpdateToV2(update)];
+  }
+
+  const tool = sessionUpdateToV2(update) as unknown as Record<string, unknown>;
+  tool.content = withTerminalContent(tool.content, meta.terminalId);
+
+  return [terminalUpdateForExecute(meta), tool as V2SessionUpdate];
+}
+
 export function mapUpdatesToV1(updates: readonly V1SessionUpdate[]): V1SessionUpdate[] {
   return updates.map(sessionUpdateToV1);
 }
 
 export function mapUpdatesToV2(updates: readonly V1SessionUpdate[]): V2SessionUpdate[] {
-  return updates.map(sessionUpdateToV2);
+  return updates.flatMap(expandSessionUpdateToV2);
 }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -21,6 +21,7 @@ import { createConversationDb, insertStep } from "./fixtures/conversation-db.js"
 import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 import {
   expandSessionUpdateToV2,
+  sessionUpdateToV1,
   sessionUpdateToV2,
   terminalIdForToolCall
 } from "../src/session-updates.js";
@@ -709,6 +710,52 @@ describe("ACP v2 (experimental draft)", () => {
       type: "diff",
       changes: [{ operation: "add", path: "/tmp/a.ts", fileType: "text" }],
       patch: { format: "git_patch" }
+    });
+  });
+
+  it("maps classic plan to v2 plan_update markdown when meta is present", () => {
+    const markdown = "# Plan\n\n- [ ] One\n- [x] Two\n";
+    const update = {
+      sessionUpdate: "plan",
+      entries: [
+        { content: "One", priority: "high", status: "pending" },
+        { content: "Two", priority: "high", status: "completed" }
+      ],
+      _meta: {
+        "agy-acp/planId": "file:/tmp/brain/plan.md",
+        "agy-acp/planPath": "/tmp/brain/plan.md",
+        "agy-acp/planMarkdown": markdown
+      }
+    } as SessionUpdate;
+
+    const v2Update = sessionUpdateToV2(update) as Record<string, unknown>;
+    expect(v2Update.sessionUpdate).toBe("plan_update");
+    expect(v2Update.plan).toEqual({
+      type: "markdown",
+      planId: "file:/tmp/brain/plan.md",
+      content: markdown
+    });
+
+    const v1Wire = sessionUpdateToV1(update) as Record<string, unknown>;
+    expect(v1Wire.sessionUpdate).toBe("plan");
+    expect(v1Wire.entries).toHaveLength(2);
+    expect(v1Wire._meta).toBeUndefined();
+  });
+
+  it("maps classic plan to v2 plan_update items without markdown meta", () => {
+    const update = {
+      sessionUpdate: "plan",
+      entries: [{ content: "Ship it", priority: "medium", status: "pending" }]
+    } as SessionUpdate;
+
+    const v2Update = sessionUpdateToV2(update) as Record<string, unknown>;
+    expect(v2Update).toEqual({
+      sessionUpdate: "plan_update",
+      plan: {
+        type: "items",
+        planId: "agy-plan",
+        entries: [{ content: "Ship it", priority: "medium", status: "pending" }]
+      }
     });
   });
 

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -19,7 +19,11 @@ import {
 import type { SpawnFactory } from "../src/cli.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
-import { sessionUpdateToV2 } from "../src/session-updates.js";
+import {
+  expandSessionUpdateToV2,
+  sessionUpdateToV2,
+  terminalIdForToolCall
+} from "../src/session-updates.js";
 import type { SessionConfigOption, SessionUpdate } from "@agentclientprotocol/sdk";
 
 type SelectConfigOption = Extract<SessionConfigOption, { type: "select" }>;
@@ -705,6 +709,72 @@ describe("ACP v2 (experimental draft)", () => {
       type: "diff",
       changes: [{ operation: "add", path: "/tmp/a.ts", fileType: "text" }],
       patch: { format: "git_patch" }
+    });
+  });
+
+  it("expands execute tool calls into terminal_update + tool_call_update", () => {
+    const update = {
+      sessionUpdate: "tool_call",
+      toolCallId: "cmd-1",
+      title: "ls",
+      kind: "execute",
+      status: "completed",
+      rawInput: { CommandLine: "ls", Cwd: "/repo" },
+      rawOutput: { exitCode: 0, output: "README.md\n" },
+      content: [
+        { type: "content", content: { type: "text", text: "```\nls\n```" } },
+        { type: "content", content: { type: "text", text: "```\nREADME.md\n```" } }
+      ]
+    } as SessionUpdate;
+
+    const expanded = expandSessionUpdateToV2(update) as Array<Record<string, unknown>>;
+    expect(expanded).toHaveLength(2);
+
+    const terminalId = terminalIdForToolCall("cmd-1");
+    expect(expanded[0]).toMatchObject({
+      sessionUpdate: "terminal_update",
+      terminalId,
+      command: "ls",
+      cwd: "/repo",
+      exitStatus: { exitCode: 0 }
+    });
+    expect((expanded[0].output as { data?: string })?.data).toBe(
+      Buffer.from("README.md\n", "utf8").toString("base64")
+    );
+
+    expect(expanded[1]).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "cmd-1",
+      kind: "execute",
+      status: "completed"
+    });
+    const content = expanded[1].content as Array<Record<string, unknown>>;
+    expect(content[0]).toEqual({ type: "terminal", terminalId });
+    expect(content.some((item) => item.type === "content")).toBe(true);
+  });
+
+  it("emits in-progress terminal_update without exitStatus", () => {
+    const update = {
+      sessionUpdate: "tool_call",
+      toolCallId: "cmd-2",
+      title: "sleep 1",
+      kind: "execute",
+      status: "in_progress",
+      rawInput: { CommandLine: "sleep 1" }
+    } as SessionUpdate;
+
+    const [terminal, tool] = expandSessionUpdateToV2(update) as Array<Record<string, unknown>>;
+    expect(terminal).toMatchObject({
+      sessionUpdate: "terminal_update",
+      terminalId: terminalIdForToolCall("cmd-2"),
+      command: "sleep 1"
+    });
+    expect(terminal.exitStatus).toBeUndefined();
+    expect(terminal.output).toBeUndefined();
+    expect(tool).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      status: "in_progress",
+      content: [{ type: "terminal", terminalId: terminalIdForToolCall("cmd-2") }]
     });
   });
 });

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -8,6 +8,7 @@ import * as installer from "../src/installer.js";
 import { client as acpClient, methods, PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import {
+  AgyAcpAgent,
   buildModelCatalog,
   createAgyAcpApp,
   createAgyAcpV2App,
@@ -16,7 +17,7 @@ import {
   reasoningEffectConfigOption,
   toModelSlug
 } from "../src/acp-server.js";
-import type { SpawnFactory } from "../src/cli.js";
+import type { PtyFactory, SpawnFactory } from "../src/cli.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 import {
@@ -58,6 +59,148 @@ describe("initialize", () => {
       installSpy.mockRestore();
       connection.close();
     }
+  });
+});
+
+describe("editFsBridgeV1", () => {
+  type FsBridgeAgent = {
+    editFsBridgeV1(
+      client: { request: (...args: unknown[]) => Promise<unknown> },
+      sessionId: string
+    ): { readTextFile(path: string): Promise<void>; writeTextFile(path: string, content: string): Promise<void> } | undefined;
+  };
+
+  it("is undefined when the client doesn't advertise both fs capabilities", async () => {
+    vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue(null);
+    const agent = new AgyAcpAgent();
+    await agent.initializeV1({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: { fs: { readTextFile: true } } });
+    const bridge = (agent as unknown as FsBridgeAgent).editFsBridgeV1({ request: vi.fn() }, "s1");
+    expect(bridge).toBeUndefined();
+    vi.restoreAllMocks();
+  });
+
+  it("routes read/write through client.request with fs/read_text_file and fs/write_text_file", async () => {
+    vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue(null);
+    const agent = new AgyAcpAgent();
+    await agent.initializeV1({
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } }
+    });
+    const request = vi.fn().mockResolvedValue({});
+    const bridge = (agent as unknown as FsBridgeAgent).editFsBridgeV1({ request }, "s1")!;
+    expect(bridge).toBeDefined();
+
+    await bridge.readTextFile("/repo/a.txt");
+    expect(request).toHaveBeenCalledWith(methods.client.fs.readTextFile, { sessionId: "s1", path: "/repo/a.txt" });
+
+    await bridge.writeTextFile("/repo/a.txt", "new content");
+    expect(request).toHaveBeenCalledWith(methods.client.fs.writeTextFile, {
+      sessionId: "s1",
+      path: "/repo/a.txt",
+      content: "new content"
+    });
+    vi.restoreAllMocks();
+  });
+});
+
+class FakePty {
+  writes: string[] = [];
+  killed = false;
+  private dataListeners: Array<(data: string) => void> = [];
+  private exitListeners: Array<(event: { exitCode: number }) => void> = [];
+  constructor(private readonly onSpawn?: (pty: FakePty) => void) {}
+  start() {
+    this.onSpawn?.(this);
+    queueMicrotask(() => this.emitData("? for shortcuts"));
+  }
+  write(data: string) { this.writes.push(data); }
+  kill() { this.killed = true; for (const listener of this.exitListeners) listener({ exitCode: 0 }); }
+  onData(listener: (data: string) => void) { this.dataListeners.push(listener); return { dispose() {} }; }
+  onExit(listener: (event: { exitCode: number }) => void) { this.exitListeners.push(listener); return { dispose() {} }; }
+  emitData(data: string) { for (const listener of this.dataListeners) listener(data); }
+}
+
+describe("edit fs write-through (full ACP round trip)", () => {
+  it("routes an already-applied edit through fs/read_text_file + fs/write_text_file instead of session/request_permission", async () => {
+    await withConversationsDir(async (dir) => {
+      const targetFile = path.join(dir, "target.txt");
+      fs.writeFileSync(targetFile, "before\nNEW\nafter", "utf8");
+      const rawInputJson = JSON.stringify({ TargetFile: targetFile, TargetContent: "OLD", ReplacementContent: "NEW" });
+
+      const pty = new FakePty((self) => {
+        const db = createConversationDb(dir, "fs-bridge-e2e");
+        insertStep(db, {
+          idx: 1,
+          stepType: 5,
+          status: 3,
+          stepPayload: encodeStepPayload({
+            toolRun: encodeToolRun({ call: encodeToolCall({ callId: "edit-1", namePrimary: "replace_file_content", rawInputJson }) })
+          })
+        });
+        db.close();
+        setTimeout(async () => {
+          const Database = (await import("better-sqlite3")).default;
+          const db2 = new Database(path.join(dir, "fs-bridge-e2e.db"));
+          insertStep(db2, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+          db2.close();
+          self.emitData("? for shortcuts");
+        }, 300);
+      });
+
+      const readCalls: string[] = [];
+      const writeCalls: Array<{ path: string; content: string }> = [];
+      let permissionCalls = 0;
+
+      const testClient = acpClient({ name: "test-client" })
+        .onRequest(methods.client.fs.readTextFile, (ctx) => {
+          readCalls.push(ctx.params.path);
+          return { content: fs.readFileSync(ctx.params.path, "utf8") };
+        })
+        .onRequest(methods.client.fs.writeTextFile, (ctx) => {
+          writeCalls.push({ path: ctx.params.path, content: ctx.params.content });
+          fs.writeFileSync(ctx.params.path, ctx.params.content, "utf8");
+          return {};
+        })
+        .onRequest(methods.client.session.requestPermission, () => {
+          permissionCalls++;
+          return { outcome: { outcome: "selected", optionId: "allow-once" } };
+        })
+        .onNotification(methods.client.session.update, () => {});
+
+      const connection = testClient.connect(createAgyAcpApp({
+        env: { AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir },
+        spawnProcess: ((_command: string, args: string[]) => {
+          if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+          return new FakeProcess([]);
+        }) as unknown as SpawnFactory,
+        ptyFactory: { spawn: () => { pty.start(); return pty; } } as unknown as PtyFactory
+      }));
+
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } }
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: dir,
+          additionalDirectories: [],
+          mcpServers: []
+        });
+
+        const response = await connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "edit it" }]
+        });
+
+        expect(response.stopReason).toBe("end_turn");
+        expect(permissionCalls).toBe(0);
+        expect(readCalls).toEqual([targetFile]);
+        expect(writeCalls).toEqual([{ path: targetFile, content: "before\nNEW\nafter" }]);
+        expect(fs.readFileSync(targetFile, "utf8")).toBe("before\nNEW\nafter");
+      } finally {
+        connection.close();
+      }
+    });
   });
 });
 

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -397,6 +397,129 @@ describe("buildModelCatalog", () => {
   });
 });
 
+describe("session modes and config option sync", () => {
+  it("advertises modes on session/new and keeps set_mode dual-synced with config", async () => {
+    const spawnProcess = (command: string, args: string[]) => {
+      if (args[0] === "models") {
+        return new FakeProcess([TEST_MODELS_OUTPUT]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+    const updates: Array<Record<string, unknown>> = [];
+    const client = acpClient({ name: "test-client" }).onNotification(
+      methods.client.session.update,
+      (ctx) => {
+        updates.push(ctx.params.update as Record<string, unknown>);
+      }
+    );
+    const connection = client.connect(
+      createAgyAcpApp({ env: printModeEnv(), spawnProcess: spawnProcess as unknown as SpawnFactory })
+    );
+    try {
+      const session = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/repo",
+        additionalDirectories: [],
+        mcpServers: []
+      });
+
+      expect(session.modes).toEqual({
+        currentModeId: "default",
+        availableModes: [
+          {
+            id: "default",
+            name: "Default",
+            description: "Request review before file writes (agy default; omits --mode)."
+          },
+          {
+            id: "accept-edits",
+            name: "Accept Edits",
+            description: "Apply file edits without interactive write review (agy --mode accept-edits)."
+          },
+          {
+            id: "plan",
+            name: "Plan",
+            description: "Plan-oriented execution (agy --mode plan)."
+          }
+        ]
+      });
+      expect(session.configOptions?.[0]).toMatchObject({
+        id: "mode",
+        currentValue: "default"
+      });
+
+      updates.length = 0;
+      await connection.agent.request(methods.agent.session.setMode, {
+        sessionId: session.sessionId,
+        modeId: "plan"
+      });
+
+      expect(updates).toEqual(
+        expect.arrayContaining([
+          { sessionUpdate: "current_mode_update", currentModeId: "plan" },
+          expect.objectContaining({
+            sessionUpdate: "config_option_update",
+            configOptions: expect.arrayContaining([
+              expect.objectContaining({ id: "mode", currentValue: "plan" })
+            ])
+          })
+        ])
+      );
+      expect(updates.filter((u) => u.sessionUpdate === "current_mode_update")).toHaveLength(1);
+      expect(updates.filter((u) => u.sessionUpdate === "config_option_update")).toHaveLength(1);
+
+      updates.length = 0;
+      const modeViaConfig = await connection.agent.request(methods.agent.session.setConfigOption, {
+        sessionId: session.sessionId,
+        configId: "mode",
+        value: "accept-edits"
+      });
+      expect(modeViaConfig.configOptions[0].currentValue).toBe("accept-edits");
+      expect(updates).toEqual([
+        { sessionUpdate: "current_mode_update", currentModeId: "accept-edits" }
+      ]);
+      // Config UI already received the full list in the set_config_option response.
+      expect(updates.some((u) => u.sessionUpdate === "config_option_update")).toBe(false);
+
+      updates.length = 0;
+      await connection.agent.request(methods.agent.session.setMode, {
+        sessionId: session.sessionId,
+        modeId: "accept-edits"
+      });
+      // Same mode: no redundant notifications.
+      expect(updates).toEqual([]);
+    } finally {
+      connection.close();
+    }
+  });
+
+  it("rejects unknown mode ids on session/set_mode", async () => {
+    const spawnProcess = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        return new FakeProcess([TEST_MODELS_OUTPUT]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+    const connection = acpClient({ name: "test-client" }).connect(
+      createAgyAcpApp({ env: printModeEnv(), spawnProcess: spawnProcess as unknown as SpawnFactory })
+    );
+    try {
+      const session = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/repo",
+        additionalDirectories: [],
+        mcpServers: []
+      });
+      await expect(
+        connection.agent.request(methods.agent.session.setMode, {
+          sessionId: session.sessionId,
+          modeId: "architect"
+        })
+      ).rejects.toThrow();
+    } finally {
+      connection.close();
+    }
+  });
+});
+
 describe("session model config", () => {
   it("updates agy --model and --effort for later prompts", async () => {
     const calls: Array<{ command: string; args: string[]; options: unknown }> = [];

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -327,6 +327,217 @@ describe("permission bridge", () => {
   });
 
 
+  it("offers review for an edit that already applied without a live gate, and reverts on reject", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const targetFile = path.join(dir, "target.txt");
+    fs.writeFileSync(targetFile, "before\nNEW\nafter", "utf8");
+    const rawInputJson = JSON.stringify({ TargetFile: targetFile, TargetContent: "OLD", ReplacementContent: "NEW" });
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "already-applied");
+      insertStep(db, {
+        idx: 1,
+        stepType: 5,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({ call: encodeToolCall({ callId: "edit-1", namePrimary: "replace_file_content", rawInputJson }) })
+        })
+      });
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    let sawKind: string | undefined;
+    let sawStatus: string | undefined;
+    const result = session.prompt("edit it", async () => {}, async (toolCall) => {
+      const raw = toolCall as unknown as { kind?: string; status?: string };
+      sawKind = raw.kind;
+      sawStatus = raw.status;
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "already-applied.db"));
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 0);
+      return "reject-once";
+    });
+    expect((await result).stopReason).toBe("end_turn");
+    expect(sawKind).toBe("edit");
+    expect(sawStatus).toBe("completed");
+    // No live agy gate to answer — nothing sent to the PTY.
+    expect(pty.writes).toEqual([]);
+    expect(fs.readFileSync(targetFile, "utf8")).toBe("before\nOLD\nafter");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("leaves an already-applied edit in place when the client keeps it", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const targetFile = path.join(dir, "target.txt");
+    fs.writeFileSync(targetFile, "before\nNEW\nafter", "utf8");
+    const rawInputJson = JSON.stringify({ TargetFile: targetFile, TargetContent: "OLD", ReplacementContent: "NEW" });
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "already-applied-keep");
+      insertStep(db, {
+        idx: 1,
+        stepType: 5,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({ call: encodeToolCall({ callId: "edit-1", namePrimary: "replace_file_content", rawInputJson }) })
+        })
+      });
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const result = session.prompt("edit it", async () => {}, async () => {
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "already-applied-keep.db"));
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 0);
+      return "allow-once";
+    });
+    expect((await result).stopReason).toBe("end_turn");
+    expect(pty.writes).toEqual([]);
+    expect(fs.readFileSync(targetFile, "utf8")).toBe("before\nNEW\nafter");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("routes an already-applied edit through the client's fs write-through instead of asking permission", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const targetFile = path.join(dir, "target.txt");
+    fs.writeFileSync(targetFile, "before\nNEW\nafter", "utf8");
+    const rawInputJson = JSON.stringify({ TargetFile: targetFile, TargetContent: "OLD", ReplacementContent: "NEW" });
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "fs-bridge-route");
+      insertStep(db, {
+        idx: 1,
+        stepType: 5,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({ call: encodeToolCall({ callId: "edit-1", namePrimary: "replace_file_content", rawInputJson }) })
+        })
+      });
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const reads: string[] = [];
+    const writes: Array<{ path: string; content: string }> = [];
+    let permissionCalls = 0;
+    const fsBridge = {
+      readTextFile: async (p: string) => { reads.push(p); },
+      writeTextFile: async (p: string, content: string) => {
+        writes.push({ path: p, content });
+        fs.writeFileSync(p, content, "utf8");
+      }
+    };
+    const result = session.prompt("edit it", async () => {}, async () => {
+      permissionCalls++;
+      return "allow-once";
+    }, fsBridge);
+    setTimeout(async () => {
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "fs-bridge-route.db"));
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      pty.emitData("? for shortcuts");
+    }, 50);
+    expect((await result).stopReason).toBe("end_turn");
+    expect(permissionCalls).toBe(0);
+    expect(reads).toEqual([targetFile]);
+    expect(writes).toEqual([{ path: targetFile, content: "before\nNEW\nafter" }]);
+    expect(fs.readFileSync(targetFile, "utf8")).toBe("before\nNEW\nafter");
+    expect(pty.writes).toEqual([]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("falls back to the local permission bridge if the client's fs write-through fails", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const targetFile = path.join(dir, "target.txt");
+    fs.writeFileSync(targetFile, "before\nNEW\nafter", "utf8");
+    const rawInputJson = JSON.stringify({ TargetFile: targetFile, TargetContent: "OLD", ReplacementContent: "NEW" });
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "fs-bridge-fallback");
+      insertStep(db, {
+        idx: 1,
+        stepType: 5,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({ call: encodeToolCall({ callId: "edit-1", namePrimary: "replace_file_content", rawInputJson }) })
+        })
+      });
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    let permissionCalls = 0;
+    const fsBridge = {
+      readTextFile: async () => {},
+      writeTextFile: async () => { throw new Error("client rejected the write"); }
+    };
+    const result = session.prompt("edit it", async () => {}, async () => {
+      permissionCalls++;
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "fs-bridge-fallback.db"));
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 0);
+      return "reject-once";
+    }, fsBridge);
+    expect((await result).stopReason).toBe("end_turn");
+    expect(permissionCalls).toBe(1);
+    // The failed write-through must leave disk exactly as it already reported
+    // via session/update (newText), not stuck mid-revert.
+    expect(fs.readFileSync(targetFile, "utf8")).toBe("before\nOLD\nafter");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("also routes a live-gated edit (default mode) through the client's fs write-through once agy applies it", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const targetFile = path.join(dir, "target.txt");
+    fs.writeFileSync(targetFile, "before\nOLD\nafter", "utf8");
+    const rawInputJson = JSON.stringify({ TargetFile: targetFile, TargetContent: "OLD", ReplacementContent: "NEW" });
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "fs-bridge-gated");
+      insertStep(db, {
+        idx: 1,
+        stepType: 5,
+        status: 9,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({ call: encodeToolCall({ callId: "edit-1", namePrimary: "replace_file_content", rawInputJson }) })
+        })
+      });
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const reads: string[] = [];
+    const writes: Array<{ path: string; content: string }> = [];
+    let permissionCalls = 0;
+    const fsBridge = {
+      readTextFile: async (p: string) => { reads.push(p); },
+      writeTextFile: async (p: string, content: string) => {
+        writes.push({ path: p, content });
+        fs.writeFileSync(p, content, "utf8");
+      }
+    };
+    const result = session.prompt("edit it", async () => {}, async () => {
+      permissionCalls++;
+      // Simulate agy itself performing the write after the live gate is answered.
+      fs.writeFileSync(targetFile, "before\nNEW\nafter", "utf8");
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "fs-bridge-gated.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 0);
+      return "agy-allow-once";
+    }, fsBridge);
+    expect((await result).stopReason).toBe("end_turn");
+    // Exactly one permission round trip — the live gate itself. The
+    // subsequent write-through must not trigger a second local prompt.
+    expect(permissionCalls).toBe(1);
+    expect(pty.writes).toEqual(["\r"]);
+    expect(reads).toEqual([targetFile]);
+    expect(writes).toEqual([{ path: targetFile, content: "before\nNEW\nafter" }]);
+    expect(fs.readFileSync(targetFile, "utf8")).toBe("before\nNEW\nafter");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("cancels reliably while awaiting permission", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => { const db = createConversationDb(dir, "cancel"); insertStep(db, pendingToolRow("run_command")); db.close(); });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -19,7 +19,13 @@ import {
   type SpawnFactory,
   type SpawnOptions
 } from "../src/cli.js";
-import { permissionKeys, permissionOptions } from "../src/permissions.js";
+import {
+  canBridgeInteraction,
+  interactionKeys,
+  isBridgeablePermissionTool,
+  permissionKeys,
+  permissionOptions
+} from "../src/permissions.js";
 import { createConversationDb, insertStep, updateStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 
@@ -108,6 +114,51 @@ describe("permission bridge", () => {
       { optionId: "agy-allow-settings", kind: "allow_always", name: "Yes, and always allow for commands that start with 'whoami' (Persist to settings.json)" },
       { optionId: "agy-reject-once", kind: "reject_once", name: "No" }
     ]);
+    expect(permissionOptions({
+      sessionUpdate: "tool_call",
+      toolCallId: "y",
+      title: "Edit src/cli.ts",
+      kind: "edit",
+      status: "pending",
+      rawInput: { TargetFile: "/repo/src/cli.ts" }
+    }, "replace_file_content")).toEqual([
+      { optionId: "allow-once", kind: "allow_once", name: "Allow" },
+      { optionId: "allow-always", kind: "allow_always", name: "Always allow" },
+      { optionId: "reject-once", kind: "reject_once", name: "Reject" }
+    ]);
+    expect(interactionKeys("allow-once", "replace_file_content")).toBe("\r");
+    expect(interactionKeys("reject-once", "replace_file_content")).toBe("\x1b[B\x1b[B\x1b[B\r");
+    expect(isBridgeablePermissionTool("run_command")).toBe(true);
+    expect(isBridgeablePermissionTool("replace_file_content")).toBe(true);
+    expect(isBridgeablePermissionTool("write_to_file")).toBe(true);
+    expect(isBridgeablePermissionTool("view_file")).toBe(true);
+    expect(isBridgeablePermissionTool("ask_question")).toBe(false);
+
+    const askCall = {
+      sessionUpdate: "tool_call" as const,
+      toolCallId: "q1",
+      title: "Pick one",
+      kind: "other" as const,
+      status: "pending" as const,
+      rawInput: {
+        questions: [{
+          question: "Which approach?",
+          options: ["Option A", "Option B", "Option C"],
+          is_multi_select: false
+        }]
+      }
+    };
+    expect(canBridgeInteraction("ask_question", askCall)).toBe(true);
+    expect(permissionOptions(askCall, "ask_question")).toEqual([
+      { optionId: "agy-q-0", kind: "allow_once", name: "Option A" },
+      { optionId: "agy-q-1", kind: "allow_once", name: "Option B" },
+      { optionId: "agy-q-2", kind: "allow_once", name: "Option C" },
+      { optionId: "agy-q-skip", kind: "reject_once", name: "Skip" }
+    ]);
+    expect(interactionKeys("agy-q-0", "ask_question", askCall)).toBe("\r");
+    expect(interactionKeys("agy-q-1", "ask_question", askCall)).toBe("\x1b[B\r");
+    expect(interactionKeys("agy-q-2", "ask_question", askCall)).toBe("\x1b[B\x1b[B\r");
+    expect(interactionKeys("agy-q-skip", "ask_question", askCall)).toBe("\x1b");
   });
 
   for (const [choice, keys] of [
@@ -204,14 +255,77 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("fails closed for ask_question without writing menu keys", async () => {
+  it("bridges single-select ask_question via PTY option keys", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
-    const pty = new FakePty(() => { const db = createConversationDb(dir, "ask"); insertStep(db, pendingToolRow("ask_question")); db.close(); });
+    const askInput = JSON.stringify({
+      questions: [{
+        question: "Which approach?",
+        options: ["Option A", "Option B", "Option C"],
+        is_multi_select: false
+      }]
+    });
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "ask");
+      insertStep(db, pendingToolRow("ask_question", askInput, 138));
+      db.close();
+    });
     const session = interactiveSession(dir, pty);
-    await expect(session.prompt("go", async () => {}, async () => "agy-allow-once")).rejects.toThrow(/Unsupported agy interaction 'ask_question'/);
+    const result = session.prompt("clarify", async () => {}, async () => {
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "ask.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "thanks" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 50);
+      return "agy-q-1";
+    });
+    expect((await result).stopReason).toBe("end_turn");
+    expect(pty.writes).toEqual(["\x1b[B\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("fails closed for multi-select ask_question without writing keys", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const askInput = JSON.stringify({
+      questions: [{
+        question: "Pick many",
+        options: ["A", "B"],
+        is_multi_select: true
+      }]
+    });
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "ask-multi");
+      insertStep(db, pendingToolRow("ask_question", askInput, 138));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    await expect(session.prompt("go", async () => {}, async () => "agy-q-0")).rejects.toThrow(/multi-select ask_question/);
     expect(pty.writes).toEqual([]);
     fs.rmSync(dir, { recursive: true, force: true });
   });
+
+  it("bridges replace_file_content permission menus like run_command", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "replace");
+      insertStep(db, pendingToolRow("replace_file_content", '{"TargetFile":"/repo/src/cli.ts"}', 5));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const result = session.prompt("edit it", async () => {}, async () => {
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "replace.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 50);
+      return "agy-allow-once";
+    });
+    expect((await result).stopReason).toBe("end_turn");
+    expect(pty.writes).toEqual(["\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
 
   it("cancels reliably while awaiting permission", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
@@ -558,9 +672,9 @@ class FakeProcess extends EventEmitter {
   }
 }
 
-function pendingToolRow(name: string) {
-  return { idx: 1, stepType: 21, status: 9, stepPayload: encodeStepPayload({
-    toolRun: encodeToolRun({ call: encodeToolCall({ callId: "permission-1", namePrimary: name, rawInputJson: '{"CommandLine":"echo hi"}' }) })
+function pendingToolRow(name: string, rawInputJson = '{"CommandLine":"echo hi"}', stepType = 21) {
+  return { idx: 1, stepType, status: 9, stepPayload: encodeStepPayload({
+    toolRun: encodeToolRun({ call: encodeToolCall({ callId: "permission-1", namePrimary: name, rawInputJson }) })
   }) };
 }
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -533,7 +533,7 @@ describe("Translator", () => {
     expect(texts[1]).toContain("Permission granted: unsandboxed (ls)");
   });
 
-  it("presents brain plan writes as Plan titles with prose content", () => {
+  it("presents brain plan writes as structured ACP plan entries", () => {
     const planPath =
       "/Users/me/.gemini/antigravity-cli/brain/abc/.system_generated/steps/1/implementation_plan.md";
     const db = createConversationDb(dir, "conv-plan");
@@ -548,7 +548,7 @@ describe("Translator", () => {
             namePrimary: "write_to_file",
             rawInputJson: JSON.stringify({
               TargetFile: planPath,
-              CodeContent: "# Plan\n\n1. Do the thing\n"
+              CodeContent: "# Plan\n\n1. Do the thing\n2. Ship it\n"
             })
           })
         })
@@ -563,13 +563,50 @@ describe("Translator", () => {
 
     expect(updates).toHaveLength(1);
     const update = updates[0] as {
-      title: string;
-      content?: Array<{ type?: string; content?: { text?: string } }>;
+      sessionUpdate: string;
+      entries?: Array<{ content: string; status: string; priority: string }>;
     };
-    expect(update.title).toBe("implementation_plan.md");
-    const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
-    expect(body).toContain("# Plan");
-    expect((update.content ?? []).some((c) => c.type === "diff")).toBe(false);
+    expect(update.sessionUpdate).toBe("plan");
+    expect(update.entries?.map((e) => e.content)).toEqual(["Do the thing", "Ship it"]);
+    expect(update.entries?.every((e) => e.status === "pending")).toBe(true);
+  });
+
+  it("dedups unchanged plan snapshots across stream polls", () => {
+    const planPath =
+      "/Users/me/.gemini/antigravity-cli/brain/abc/.system_generated/steps/1/implementation_plan.md";
+    const db = createConversationDb(dir, "conv-plan-dedup");
+    insertStep(db, {
+      idx: 1,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-1",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({
+              TargetFile: planPath,
+              CodeContent: "- [ ] One\n- [x] Two\n"
+            })
+          })
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-plan-dedup")!;
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const first = translator.translate(conn.readAfter(-1));
+    const second = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(0);
+    const entries = (first[0] as { entries: Array<{ content: string; status: string }> }).entries;
+    expect(entries).toEqual([
+      { content: "One", priority: "high", status: "pending" },
+      { content: "Two", priority: "high", status: "completed" }
+    ]);
   });
 
   it("buffers consecutive agent-text parts into one message in replay mode", () => {

--- a/tests/edit-fs-bridge.test.ts
+++ b/tests/edit-fs-bridge.test.ts
@@ -1,0 +1,169 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+import {
+  primeEditReadThroughClient,
+  routeEditThroughClient,
+  writeEditThroughClient,
+  type EditFsBridge
+} from "../src/edit-fs-bridge.js";
+
+function diffToolCall(blocks: Array<{ path: string; oldText: string | null; newText: string }>): SessionUpdate {
+  return {
+    sessionUpdate: "tool_call",
+    toolCallId: "x",
+    title: "Edit",
+    kind: "edit",
+    status: "completed",
+    content: blocks.map((b) => ({ type: "diff" as const, ...b }))
+  } as SessionUpdate;
+}
+
+function recordingBridge() {
+  const reads: string[] = [];
+  const writes: Array<{ path: string; content: string }> = [];
+  const bridge: EditFsBridge = {
+    readTextFile: async (p) => { reads.push(p); },
+    writeTextFile: async (p, content) => {
+      writes.push({ path: p, content });
+      fs.writeFileSync(p, content, "utf8");
+    }
+  };
+  return { bridge, reads, writes };
+}
+
+describe("routeEditThroughClient", () => {
+  it("reverts to old text, reads, then writes the full post-edit content back through the client", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before\nNEW\nafter", "utf8");
+    const { bridge, reads, writes } = recordingBridge();
+    const seenDuringRead: string[] = [];
+    const wrapped: EditFsBridge = {
+      readTextFile: async (p) => {
+        seenDuringRead.push(fs.readFileSync(p, "utf8"));
+        await bridge.readTextFile(p);
+      },
+      writeTextFile: bridge.writeTextFile
+    };
+
+    const routed = await routeEditThroughClient(
+      diffToolCall([{ path: file, oldText: "OLD", newText: "NEW" }]),
+      wrapped
+    );
+
+    expect(routed).toBe(true);
+    // Disk read as "old" during the read call (pre-edit state), so the
+    // client's diff is computed against the real before/after.
+    expect(seenDuringRead).toEqual(["before\nOLD\nafter"]);
+    expect(reads).toEqual([file]);
+    expect(writes).toEqual([{ path: file, content: "before\nNEW\nafter" }]);
+    // The client "wrote" the final content itself.
+    expect(fs.readFileSync(file, "utf8")).toBe("before\nNEW\nafter");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("handles a full-file create (oldText null) by reverting to empty before the write-through", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file = path.join(dir, "new.txt");
+    fs.writeFileSync(file, "created", "utf8");
+    const { bridge, writes } = recordingBridge();
+
+    const routed = await routeEditThroughClient(
+      diffToolCall([{ path: file, oldText: null, newText: "created" }]),
+      bridge
+    );
+
+    expect(routed).toBe(true);
+    expect(writes).toEqual([{ path: file, content: "created" }]);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("leaves the file alone and returns false when content has diverged since the edit", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "something else entirely", "utf8");
+    const { bridge, writes } = recordingBridge();
+
+    const routed = await routeEditThroughClient(
+      diffToolCall([{ path: file, oldText: "old", newText: "new" }]),
+      bridge
+    );
+
+    expect(routed).toBe(false);
+    expect(writes).toEqual([]);
+    expect(fs.readFileSync(file, "utf8")).toBe("something else entirely");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns false and restores the post-edit content when the client rejects the write", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before\nNEW\nafter", "utf8");
+    const bridge: EditFsBridge = {
+      readTextFile: async () => {},
+      writeTextFile: async () => { throw new Error("client rejected"); }
+    };
+
+    const routed = await routeEditThroughClient(
+      diffToolCall([{ path: file, oldText: "OLD", newText: "NEW" }]),
+      bridge
+    );
+
+    expect(routed).toBe(false);
+    expect(fs.readFileSync(file, "utf8")).toBe("before\nNEW\nafter");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns false when there are no diff content blocks", async () => {
+    const { bridge } = recordingBridge();
+    const routed = await routeEditThroughClient(
+      { sessionUpdate: "tool_call", toolCallId: "x", title: "Edit", kind: "edit", status: "completed", content: [] } as unknown as SessionUpdate,
+      bridge
+    );
+    expect(routed).toBe(false);
+  });
+});
+
+describe("primeEditReadThroughClient + writeEditThroughClient", () => {
+  it("reads the referenced path(s) without touching disk, deduped across blocks", async () => {
+    const { bridge, reads, writes } = recordingBridge();
+    await primeEditReadThroughClient(
+      diffToolCall([
+        { path: "/repo/a.txt", oldText: "old", newText: "new" },
+        { path: "/repo/a.txt", oldText: "old2", newText: "new2" }
+      ]),
+      bridge
+    );
+    expect(reads).toEqual(["/repo/a.txt"]);
+    expect(writes).toEqual([]);
+  });
+
+  it("writes the current on-disk content through the client without reverting or re-reading first", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before\nNEW\nafter", "utf8");
+    const { bridge, reads, writes } = recordingBridge();
+
+    const routed = await writeEditThroughClient(
+      diffToolCall([{ path: file, oldText: "OLD", newText: "NEW" }]),
+      bridge
+    );
+
+    expect(routed).toBe(true);
+    expect(reads).toEqual([]);
+    expect(writes).toEqual([{ path: file, content: "before\nNEW\nafter" }]);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writeEditThroughClient returns false when the file no longer exists", async () => {
+    const { bridge } = recordingBridge();
+    const routed = await writeEditThroughClient(
+      diffToolCall([{ path: "/nonexistent/gone.txt", oldText: "old", newText: "new" }]),
+      bridge
+    );
+    expect(routed).toBe(false);
+  });
+});

--- a/tests/edit-revert.test.ts
+++ b/tests/edit-revert.test.ts
@@ -1,0 +1,71 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+import { revertEditToolCall } from "../src/edit-revert.js";
+
+function diffToolCall(blocks: Array<{ path: string; oldText: string | null; newText: string }>): SessionUpdate {
+  return {
+    sessionUpdate: "tool_call",
+    toolCallId: "x",
+    title: "Edit",
+    kind: "edit",
+    status: "completed",
+    content: blocks.map((b) => ({ type: "diff" as const, ...b }))
+  } as SessionUpdate;
+}
+
+describe("revertEditToolCall", () => {
+  it("restores the prior full-file content", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-revert-"));
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "new content", "utf8");
+
+    revertEditToolCall(diffToolCall([{ path: file, oldText: "old content", newText: "new content" }]));
+
+    expect(fs.readFileSync(file, "utf8")).toBe("old content");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reverts a chunked replace by substring", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-revert-"));
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before\nNEW\nafter", "utf8");
+
+    revertEditToolCall(diffToolCall([{ path: file, oldText: "OLD", newText: "NEW" }]));
+
+    expect(fs.readFileSync(file, "utf8")).toBe("before\nOLD\nafter");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("deletes a file that was newly created (oldText null)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-revert-"));
+    const file = path.join(dir, "new.txt");
+    fs.writeFileSync(file, "created", "utf8");
+
+    revertEditToolCall(diffToolCall([{ path: file, oldText: null, newText: "created" }]));
+
+    expect(fs.existsSync(file)).toBe(false);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("leaves the file alone when content has diverged since the edit", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-revert-"));
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "something else entirely", "utf8");
+
+    revertEditToolCall(diffToolCall([{ path: file, oldText: "old", newText: "new" }]));
+
+    expect(fs.readFileSync(file, "utf8")).toBe("something else entirely");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("no-ops when the file no longer exists", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-revert-"));
+    const file = path.join(dir, "gone.txt");
+
+    expect(() => revertEditToolCall(diffToolCall([{ path: file, oldText: "old", newText: "new" }]))).not.toThrow();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { isPlanFile, parsePlanEntries, planIdForPath, planUpdateFromMarkdown } from "../src/db/plan.js";
+
+describe("isPlanFile", () => {
+  it("matches agy brain markdown paths", () => {
+    expect(
+      isPlanFile(
+        "/Users/me/.gemini/antigravity-cli/brain/abc/.system_generated/steps/1/implementation_plan.md"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects ordinary project files", () => {
+    expect(isPlanFile("/repo/docs/plan.md")).toBe(false);
+    expect(isPlanFile("/Users/me/.gemini/antigravity-cli/brain/x/note.txt")).toBe(false);
+  });
+});
+
+describe("parsePlanEntries", () => {
+  it("parses numbered and bulleted items", () => {
+    expect(
+      parsePlanEntries("# Plan\n\n1. First\n2. Second\n- Third\n").map((e) => e.content)
+    ).toEqual(["First", "Second", "Third"]);
+  });
+
+  it("maps checkbox markers to status", () => {
+    expect(
+      parsePlanEntries("- [ ] open\n- [x] done\n- [~] mid\n- [X] DONE2\n")
+    ).toEqual([
+      { content: "open", priority: "high", status: "pending" },
+      { content: "done", priority: "high", status: "completed" },
+      { content: "mid", priority: "high", status: "in_progress" },
+      { content: "DONE2", priority: "medium", status: "completed" }
+    ]);
+  });
+
+  it("falls back to the first heading when there is no list", () => {
+    expect(parsePlanEntries("# Ship the feature\n\nSome prose only.\n")).toEqual([
+      { content: "Ship the feature", priority: "medium", status: "pending" }
+    ]);
+  });
+});
+
+describe("planUpdateFromMarkdown", () => {
+  it("builds a classic plan update with stable meta", () => {
+    const path = "/Users/me/.gemini/antigravity-cli/brain/c/plan.md";
+    const md = "1. A\n2. B\n";
+    const update = planUpdateFromMarkdown(path, md) as {
+      sessionUpdate: string;
+      entries: unknown[];
+      _meta?: Record<string, unknown>;
+    };
+    expect(update.sessionUpdate).toBe("plan");
+    expect(update.entries).toHaveLength(2);
+    expect(update._meta?.["agy-acp/planId"]).toBe(planIdForPath(path));
+    expect(update._meta?.["agy-acp/planMarkdown"]).toBe(md);
+  });
+});


### PR DESCRIPTION
## Summary

- Expand the interactive permission bridge beyond `run_command` to file tools sharing agy's ToolConfirmationPanel, and bridge single-select `ask_question` through `session/request_permission` (standard ACP allow/reject option ids for edits).
- Route completed edits through client `fs/read_text_file` + `fs/write_text_file` when advertised so native review UIs (e.g. Zed Review Changes) own the change; fall back to local keep/reject with disk restore when write-through is unavailable.
- Advertise native ACP v1 session modes (`default` / `accept-edits` / `plan`) with `session/set_mode` and dual-sync to the mode config option.
- Emit structured ACP plans from brain markdown (v1 `plan` + draft-v2 `plan_update`), and draft-v2 agent-owned `terminal_update` for execute tools.
- Ship as package **0.2.8**; condense README and extract the ACP coverage checklist into `ROADMAP.md`.

## Test plan

- [x] Unit/integration coverage on the branch for permission bridging, edit revert/FS write-through, session modes, plans, and terminals
- [ ] CI green on the PR
- [ ] Manual smoke in Zed (or other ACP client): approve a file-edit permission; confirm Review Changes tracks write-through when FS caps are on
- [ ] Confirm single-select `ask_question` appears as a permission prompt; multi-select still fails closed
- [ ] Confirm `session/set_mode` and mode config option stay dual-synced
- [ ] Confirm print / skip-permissions paths still complete turns without hanging on the bridge