### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-23
+
+### Fixed
+
+- `available_commands_update` on `session/new` never reached clients that
+  register a session only after receiving the `session/new` response (Zed
+  included): the notification was sent before the response, referencing a
+  `sessionId` the client didn't recognize yet, so it was silently dropped and
+  slash commands never appeared. It's now deferred until just after the
+  response goes out.
+- `agy-acp --login` (terminal auth method) left the user sitting inside agy's own
+  interactive chat TUI after a successful web/API-key sign-in, with no automatic
+  way back to the ACP client. A background poll now watches `agy models` during
+  login and closes the terminal automatically as soon as sign-in succeeds.
+- Auth methods collapsed from two entries ("Google Antigravity (CLI)" +
+  "Use existing Antigravity login") down to a single "Login" terminal method,
+  matching the single-button pattern other ACP agents use. Session creation
+  already skips auth entirely when `agy` is already signed in, so the second
+  "check existing login" method was redundant.
+- Clicking "Login" never opened a terminal in some ACP clients (e.g. Zed): the
+  native `type: "terminal"` auth mechanism is still experimental/beta-gated on
+  the client side, and clients without it enabled expect a legacy
+  `_meta["terminal-auth"]` payload (`{ label, command, args }`) describing
+  exactly what to spawn instead. The terminal auth method now includes that
+  payload alongside the native fields, so `authenticate` no longer gets called
+  with nothing having launched `agy` at all.
+- The `auth_required` message shown next to the Login button surfaced agy's
+  raw probe error (e.g. `agy models exited with status 1: <no stderr>`),
+  which is meaningless to an end user. It now shows a fixed disclaimer
+  ("By continuing, you agree to https://antigravity.google/terms") instead;
+  the real probe error is still logged server-side (stderr) for debugging.
+
 ## [0.3.0] - 2026-07-23
 
 Authentication, curated slash commands, native session modes, structured plans,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agy-acp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agy-acp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agy-acp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Agent Client Protocol adapter that wraps the Google Antigravity CLI (ACP v1 + experimental draft ACP v2)",
   "type": "module",
   "author": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -146,6 +146,21 @@ interface SessionState {
   promptAbort?: AbortController;
 }
 
+/**
+ * Runs `fn` after the current request handler's response has gone out on the
+ * wire. The ACP connection queues outbound messages in call order, so a
+ * `setImmediate` — which only fires once the microtask queue (including the
+ * response's own send) has drained — is enough to guarantee it lands second.
+ */
+function deferAfterResponse(fn: () => Promise<void>): void {
+  setImmediate(() => {
+    fn().catch(() => {
+      // Connection may already be closed by the time this fires (client
+      // disconnected right after session/new) — nothing left to notify.
+    });
+  });
+}
+
 export class AcpAgent {
   readonly #env: NodeJS.ProcessEnv;
   readonly #argv: string[];
@@ -324,7 +339,11 @@ export class AcpAgent {
     await this.requireAuthenticated(params.cwd);
     const session = await this.createSession(params.cwd, params.additionalDirectories);
     if (client) {
-      await this.notifyAvailableCommandsV1(client, session.sessionId);
+      // Clients (e.g. Zed) only learn this sessionId from the `session/new`
+      // response and register it then; a notification sent earlier targets a
+      // session the client doesn't recognize yet and gets silently dropped.
+      // Defer past the response so it's on the wire second, not first.
+      deferAfterResponse(() => this.notifyAvailableCommandsV1(client, session.sessionId));
     }
     return {
       sessionId: session.sessionId,
@@ -341,7 +360,9 @@ export class AcpAgent {
     const session = await this.createSession(params.cwd, params.additionalDirectories);
     // Draft v2 has no native session/set_mode surface; mode is the config option only.
     if (client) {
-      await this.notifyAvailableCommandsV2(client, session.sessionId);
+      // See newSessionV1: must not resolve before the response is sent, or
+      // the client drops it as a notification for an unknown session.
+      deferAfterResponse(() => this.notifyAvailableCommandsV2(client, session.sessionId));
     }
     return {
       sessionId: session.sessionId,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -60,7 +60,7 @@ import { ReplayCache } from "./agy/db/replay.js";
 import type { ClientFileSystem } from "./file-system/bridge.js";
 import { ensureAgyInstalled } from "./agy/installer.js";
 import {
-  AUTH_METHOD_TERMINAL_LOGIN,
+  AUTH_REQUIRED_MESSAGE,
   isAgyAuthenticated,
   isKnownAuthMethodId,
   logoutAgyViaSlashCommand,
@@ -265,9 +265,10 @@ export class AcpAgent {
     await this.ensureAgyReady();
     const status = await isAgyAuthenticated(this.#backend, this.authProbeConfig(cwd));
     if (status.ok) return;
+    console.error(`[agy-acp] auth required: ${status.reason}`);
     throw RequestError.authRequired(
       { authMethods: v1AuthMethods() },
-      status.reason
+      AUTH_REQUIRED_MESSAGE
     );
   }
 
@@ -282,9 +283,10 @@ export class AcpAgent {
     }
     const status = await isAgyAuthenticated(this.#backend, this.authProbeConfig());
     if (status.ok) return {};
+    console.error(`[agy-acp] auth required: ${status.reason}`);
     throw RequestError.authRequired(
       { authMethods: v1AuthMethods() },
-      `${status.reason} Complete terminal login (method "${AUTH_METHOD_TERMINAL_LOGIN}"), then call authenticate again.`
+      AUTH_REQUIRED_MESSAGE
     );
   }
 

--- a/src/agy/auth.ts
+++ b/src/agy/auth.ts
@@ -2,18 +2,20 @@
 //
 // Login is interactive (Google AI Pro web code paste, or API key) inside the agy TUI.
 // ACP terminal auth launches `agy-acp --login`, which runs interactive `agy` with
-// inherited stdio so the user can complete that flow. Logout maps to TUI `/logout`
-// via a short-lived PTY, then re-probes with `agy models`.
+// inherited stdio so the user can complete that flow. A background poll watches for
+// the resulting keyring login (via `agy models`) and closes the terminal as soon as
+// it succeeds, so the user isn't left sitting inside agy's own chat TUI afterward.
+// Logout maps to TUI `/logout` via a short-lived PTY, then re-probes with `agy models`.
 
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { once } from "node:events";
 import type { AuthMethod as V1AuthMethod } from "@agentclientprotocol/sdk";
 import type { AuthMethod as V2AuthMethod } from "@agentclientprotocol/sdk/experimental/v2";
 import {
+  AgyCliBackend,
   AgyCliError,
   configFromEnv,
   defaultPtyFactory,
-  type AgyCliBackend,
   type AgyCliConfig,
   type PtyFactory,
   type PtyProcess
@@ -23,11 +25,32 @@ import { ensureAgyInstalled } from "./installer.js";
 /** ACP method id for interactive terminal login (client runs agent binary with --login). */
 export const AUTH_METHOD_TERMINAL_LOGIN = "agy-login";
 
-/** ACP method id for re-checking an existing keyring login (agent-side probe only). */
-export const AUTH_METHOD_AGENT_STATUS = "agy-status";
+/**
+ * `_meta["terminal-auth"]` payload some clients (e.g. Zed, prior to the native
+ * `type: "terminal"` auth method stabilizing) look for instead of the native
+ * mechanism: `{ label, command, args, env }` describing exactly what to spawn in
+ * a terminal. Without this, such clients silently skip opening any terminal at
+ * all and just re-call `authenticate`, which can never succeed.
+ * `env` is intentionally omitted: the terminal already inherits a normal shell
+ * environment, and forwarding this process's full `process.env` over the wire
+ * would risk leaking secrets into client logs.
+ */
+function terminalAuthMeta(): { "terminal-auth": { label: string; command: string; args: string[] } } {
+  return {
+    "terminal-auth": {
+      label: "agy /login",
+      command: process.execPath,
+      args: [...process.argv.slice(1), "--login"]
+    }
+  };
+}
 
 const NOT_LOGGED_IN_RE = /not logged into antigravity|not logged in|authentication required|please log in|login required/i;
 const IDLE_MARKER = "for shortcuts";
+/** How often to probe `agy models` in the background during interactive login. */
+const LOGIN_POLL_INTERVAL_MS = 3_000;
+/** Grace period after SIGTERM before escalating to SIGKILL once login succeeds. */
+const LOGIN_KILL_GRACE_MS = 3_000;
 const LOGOUT_SETTLE_MS = 1_500;
 const LOGOUT_IDLE_TIMEOUT_MS = 20_000;
 
@@ -36,18 +59,12 @@ export function v1AuthMethods(): V1AuthMethod[] {
     {
       type: "terminal",
       id: AUTH_METHOD_TERMINAL_LOGIN,
-      name: "Google Antigravity (CLI)",
+      name: "Login",
       description:
         "Opens a terminal to sign in with Google AI Pro (web auth + paste code) or an API key. " +
-        "Complete the agy login prompts, then return to the editor.",
-      args: ["--login"]
-    },
-    {
-      id: AUTH_METHOD_AGENT_STATUS,
-      name: "Use existing Antigravity login",
-      description:
-        "Succeeds if agy is already signed in on this machine (keyring). " +
-        "If not, complete terminal login first."
+        "The terminal closes automatically once sign-in succeeds; no need to exit agy yourself.",
+      args: ["--login"],
+      _meta: terminalAuthMeta()
     }
   ];
 }
@@ -57,26 +74,27 @@ export function v2AuthMethods(): V2AuthMethod[] {
     {
       type: "terminal",
       methodId: AUTH_METHOD_TERMINAL_LOGIN,
-      name: "Google Antigravity (CLI)",
+      name: "Login",
       description:
         "Opens a terminal to sign in with Google AI Pro (web auth + paste code) or an API key. " +
-        "Complete the agy login prompts, then return to the editor.",
-      args: ["--login"]
-    },
-    {
-      type: "agent",
-      methodId: AUTH_METHOD_AGENT_STATUS,
-      name: "Use existing Antigravity login",
-      description:
-        "Succeeds if agy is already signed in on this machine (keyring). " +
-        "If not, complete terminal login first."
+        "The terminal closes automatically once sign-in succeeds; no need to exit agy yourself.",
+      args: ["--login"],
+      _meta: terminalAuthMeta()
     }
   ];
 }
 
 export function isKnownAuthMethodId(methodId: string): boolean {
-  return methodId === AUTH_METHOD_TERMINAL_LOGIN || methodId === AUTH_METHOD_AGENT_STATUS;
+  return methodId === AUTH_METHOD_TERMINAL_LOGIN;
 }
+
+/**
+ * User-facing text shown next to the Login method whenever auth is required.
+ * Deliberately not agy's raw probe error (exit codes / "<no stderr>" are
+ * meaningless to an end user); the real reason is still logged server-side by
+ * callers for debugging.
+ */
+export const AUTH_REQUIRED_MESSAGE = "By continuing, you agree to https://antigravity.google/terms";
 
 /**
  * True when `agy models` succeeds with at least one model.
@@ -120,14 +138,38 @@ export function looksUnauthenticated(reason: string): boolean {
   return NOT_LOGGED_IN_RE.test(reason) || /sign in may be required/i.test(reason);
 }
 
+/** Spawns the interactive login child process (default: real `agy`, inherited stdio). */
+export type InteractiveLoginSpawn = (
+  command: string,
+  args: string[],
+  options: { cwd: string; env?: NodeJS.ProcessEnv }
+) => ChildProcess;
+
+function defaultInteractiveLoginSpawn(
+  command: string,
+  args: string[],
+  options: { cwd: string; env?: NodeJS.ProcessEnv }
+): ChildProcess {
+  return spawn(command, args, { cwd: options.cwd, env: options.env, stdio: "inherit" });
+}
+
 /**
  * Interactive login for `agy-acp --login` (terminal auth method).
  * Runs `agy` with inherited stdio so the user can complete API key or web+code flow.
+ *
+ * A background poll probes `agy models` every few seconds; once it succeeds, the
+ * child is terminated automatically so the caller doesn't need to manually exit
+ * agy's own chat TUI to return control to the ACP client. If the child exits on
+ * its own first (user quit, or login abandoned), its exit code is returned as-is.
  */
 export async function runInteractiveAgyLogin(options: {
   env?: NodeJS.ProcessEnv;
   cwd?: string;
   argv?: string[];
+  backend?: AgyCliBackend;
+  spawnLogin?: InteractiveLoginSpawn;
+  pollIntervalMs?: number;
+  killGraceMs?: number;
 }): Promise<number> {
   const env = options.env ?? process.env;
   const cwd = options.cwd ?? process.cwd();
@@ -137,14 +179,59 @@ export async function runInteractiveAgyLogin(options: {
   });
 
   const config = configFromEnv({ cwd, env, argv: options.argv ?? [] });
-  const child = spawn(config.agyPath, [], {
-    cwd,
-    env: config.env ?? env,
-    stdio: "inherit"
+  const backend = options.backend ?? new AgyCliBackend();
+  const spawnLogin = options.spawnLogin ?? defaultInteractiveLoginSpawn;
+  const pollIntervalMs = options.pollIntervalMs ?? LOGIN_POLL_INTERVAL_MS;
+  const killGraceMs = options.killGraceMs ?? LOGIN_KILL_GRACE_MS;
+
+  const child = spawnLogin(config.agyPath, [], { cwd, env: config.env ?? env });
+
+  let settled = false;
+  let autoClosed = false;
+
+  const exitPromise = once(child, "exit").then(([code]) =>
+    typeof code === "number" ? code : null
+  );
+
+  const pollForCompletion = (async () => {
+    while (!settled) {
+      await sleep(pollIntervalMs);
+      if (settled) return;
+      const status = await isAgyAuthenticated(backend, config).catch(
+        (): { ok: false; reason: string } => ({ ok: false, reason: "" })
+      );
+      if (!status.ok || settled) continue;
+
+      autoClosed = true;
+      settled = true;
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* already exited */
+      }
+      const killedPromptly = await Promise.race([
+        once(child, "exit").then(() => true),
+        sleep(killGraceMs).then(() => false)
+      ]);
+      if (!killedPromptly) {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          /* already exited */
+        }
+      }
+      return;
+    }
+  })();
+
+  const exitCode = await exitPromise;
+  settled = true;
+  pollForCompletion.catch(() => {
+    // Background probe may still be mid-flight when the child exits on its
+    // own; nothing left to act on once the outer promise has resolved.
   });
 
-  const [code] = await once(child, "exit");
-  return typeof code === "number" ? code : 1;
+  return autoClosed ? 0 : exitCode ?? 1;
 }
 
 /**

--- a/src/slash-commands/index.ts
+++ b/src/slash-commands/index.ts
@@ -14,6 +14,7 @@ export const MODE_SLASH = "mode";
 export const PLAN_SLASH = "plan";
 export const MODEL_SLASH = "model";
 export const EFFORT_SLASH = "effort";
+export const SKILLS_SLASH = "skills";
 
 /** Commands advertised to clients for typeahead / slash menus. */
 export const AVAILABLE_COMMANDS: readonly AvailableCommand[] = [
@@ -35,6 +36,10 @@ export const AVAILABLE_COMMANDS: readonly AvailableCommand[] = [
     name: EFFORT_SLASH,
     description: "Set reasoning effort for the current model (agy --effort).",
     input: { hint: "low | medium | high" }
+  },
+  {
+    name: SKILLS_SLASH,
+    description: "List skills discovered by agy for this session."
   }
 ];
 

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -30,6 +30,16 @@ import type { SessionConfigOption, SessionUpdate } from "@agentclientprotocol/sd
 
 type SelectConfigOption = Extract<SessionConfigOption, { type: "select" }>;
 
+/**
+ * `available_commands_update` on session/new is deferred past the response
+ * (via setImmediate) so real clients register the session before seeing a
+ * notification for it. Await this once after session/new to drain that
+ * notification before asserting on / resetting the `updates` array.
+ */
+function flushDeferredNotifications(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
 describe("contentBlocksToText", () => {
   it("joins text content blocks", () => {
     expect(contentBlocksToText([
@@ -340,6 +350,7 @@ describe("session prompt", () => {
           additionalDirectories: [],
           mcpServers: []
         });
+        await flushDeferredNotifications();
         updates.length = 0;
         const response = await connection.agent.request(methods.agent.session.prompt, {
           sessionId: session.sessionId,
@@ -385,6 +396,7 @@ describe("session prompt", () => {
           additionalDirectories: [],
           mcpServers: []
         });
+        await flushDeferredNotifications();
         updates.length = 0;
         const response = await connection.agent.request(methods.agent.session.prompt, {
           sessionId: session.sessionId,
@@ -809,6 +821,7 @@ describe("available_commands_update and slash commands", () => {
         additionalDirectories: [],
         mcpServers: []
       });
+      await flushDeferredNotifications();
 
       const commandUpdate = updates.find((u) => u.sessionUpdate === "available_commands_update");
       expect(commandUpdate).toMatchObject({

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -65,12 +65,9 @@ describe("initialize", () => {
       expect(response.agentCapabilities?.promptCapabilities?.image).toBe(true);
       expect(response.agentCapabilities?.sessionCapabilities?.additionalDirectories).toEqual({});
       expect(response.agentCapabilities?.auth?.logout).toEqual({});
-      expect(response.authMethods).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ type: "terminal", id: "agy-login", args: ["--login"] }),
-          expect.objectContaining({ id: "agy-status" })
-        ])
-      );
+      expect(response.authMethods).toEqual([
+        expect.objectContaining({ type: "terminal", id: "agy-login", args: ["--login"] })
+      ]);
       expect(installSpy).toHaveBeenCalledOnce();
     } finally {
       installSpy.mockRestore();
@@ -130,7 +127,7 @@ describe("authentication", () => {
         clientCapabilities: {}
       });
       await expect(
-        connection.agent.request(methods.agent.authenticate, { methodId: "agy-status" })
+        connection.agent.request(methods.agent.authenticate, { methodId: "agy-login" })
       ).resolves.toEqual({});
     } finally {
       connection.close();

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,49 +1,66 @@
-import { describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import * as installer from "../src/agy/installer.js";
 import {
-  AUTH_METHOD_AGENT_STATUS,
   AUTH_METHOD_TERMINAL_LOGIN,
   formatAuthProbeError,
   isKnownAuthMethodId,
   looksUnauthenticated,
+  runInteractiveAgyLogin,
   v1AuthMethods,
-  v2AuthMethods
+  v2AuthMethods,
+  type InteractiveLoginSpawn
 } from "../src/agy/auth.js";
-import { AgyCliError } from "../src/agy/cli.js";
+import { AgyCliError, type AgyCliBackend } from "../src/agy/cli.js";
+
+/** Minimal fake for the login child process: an EventEmitter with a `kill` that
+ *  simulates the child exiting shortly after receiving a signal. */
+class FakeLoginChild extends EventEmitter {
+  killedWith: string[] = [];
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.killedWith.push(String(signal));
+    queueMicrotask(() => this.emit("exit", null, signal ?? "SIGTERM"));
+    return true;
+  }
+}
 
 describe("auth methods", () => {
-  it("advertises terminal login and agent status methods", () => {
+  it("advertises a single terminal login method", () => {
     const v1 = v1AuthMethods();
-    expect(v1).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "terminal",
-          id: AUTH_METHOD_TERMINAL_LOGIN,
-          args: ["--login"]
-        }),
-        expect.objectContaining({ id: AUTH_METHOD_AGENT_STATUS })
-      ])
-    );
+    expect(v1).toEqual([
+      expect.objectContaining({
+        type: "terminal",
+        id: AUTH_METHOD_TERMINAL_LOGIN,
+        args: ["--login"]
+      })
+    ]);
 
     const v2 = v2AuthMethods();
-    expect(v2).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "terminal",
-          methodId: AUTH_METHOD_TERMINAL_LOGIN,
-          args: ["--login"]
-        }),
-        expect.objectContaining({
-          type: "agent",
-          methodId: AUTH_METHOD_AGENT_STATUS
-        })
-      ])
-    );
+    expect(v2).toEqual([
+      expect.objectContaining({
+        type: "terminal",
+        methodId: AUTH_METHOD_TERMINAL_LOGIN,
+        args: ["--login"]
+      })
+    ]);
   });
 
   it("recognizes known method ids", () => {
     expect(isKnownAuthMethodId(AUTH_METHOD_TERMINAL_LOGIN)).toBe(true);
-    expect(isKnownAuthMethodId(AUTH_METHOD_AGENT_STATUS)).toBe(true);
     expect(isKnownAuthMethodId("other")).toBe(false);
+  });
+
+  it("includes a legacy _meta['terminal-auth'] payload for clients without native terminal-auth support", () => {
+    for (const method of [...v1AuthMethods(), ...v2AuthMethods()]) {
+      const meta = (method as { _meta?: Record<string, unknown> })._meta;
+      const terminalAuth = meta?.["terminal-auth"] as
+        | { label: string; command: string; args: string[] }
+        | undefined;
+      expect(terminalAuth?.label).toBeTruthy();
+      expect(terminalAuth?.command).toBe(process.execPath);
+      expect(terminalAuth?.args.at(-1)).toBe("--login");
+    }
   });
 });
 
@@ -57,5 +74,61 @@ describe("auth probe helpers", () => {
     );
     expect(formatAuthProbeError(err)).toBe("You are not logged into Antigravity.");
     expect(looksUnauthenticated(formatAuthProbeError(err))).toBe(true);
+  });
+});
+
+describe("runInteractiveAgyLogin", () => {
+  it("auto-closes the terminal once agy models reports a successful login", async () => {
+    vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("agy");
+
+    const child = new FakeLoginChild();
+    let listModelsCalls = 0;
+    const backend = {
+      listModels: vi.fn(async () => {
+        listModelsCalls += 1;
+        // Not authenticated on the first poll, signed in from the second one.
+        return listModelsCalls >= 2 ? ["gemini-3.5-flash"] : [];
+      })
+    } as unknown as AgyCliBackend;
+    const spawnLogin: InteractiveLoginSpawn = () => child as unknown as ChildProcess;
+
+    const code = await runInteractiveAgyLogin({
+      env: {},
+      cwd: "/tmp",
+      backend,
+      spawnLogin,
+      pollIntervalMs: 5,
+      killGraceMs: 20
+    });
+
+    expect(code).toBe(0);
+    expect(child.killedWith).toContain("SIGTERM");
+    expect(listModelsCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  it("returns the child's own exit code when the user quits before login succeeds", async () => {
+    vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("agy");
+
+    const child = new FakeLoginChild();
+    const backend = {
+      listModels: vi.fn(async () => [])
+    } as unknown as AgyCliBackend;
+    const spawnLogin: InteractiveLoginSpawn = () => child as unknown as ChildProcess;
+
+    const codePromise = runInteractiveAgyLogin({
+      env: {},
+      cwd: "/tmp",
+      backend,
+      spawnLogin,
+      pollIntervalMs: 5,
+      killGraceMs: 20
+    });
+
+    // The user exits agy manually (e.g. Ctrl+C) before the background poll ever succeeds.
+    setTimeout(() => child.emit("exit", 130, null), 10);
+
+    const code = await codePromise;
+    expect(code).toBe(130);
+    expect(child.killedWith).toEqual([]);
   });
 });

--- a/tests/slash-commands.test.ts
+++ b/tests/slash-commands.test.ts
@@ -61,6 +61,7 @@ describe("interpretSlashCommand", () => {
     expect(interpretSlashCommand({ name: "mode", input: "turbo" }).kind).toBe("error");
     expect(interpretSlashCommand({ name: "plan", input: "extra" }).kind).toBe("error");
     expect(interpretSlashCommand({ name: "help", input: "" })).toEqual({ kind: "pass" });
+    expect(interpretSlashCommand({ name: "skills", input: "" })).toEqual({ kind: "pass" });
   });
 });
 
@@ -88,7 +89,7 @@ describe("availableCommandsUpdate", () => {
       availableCommands: AVAILABLE_COMMANDS
     });
     expect(AVAILABLE_COMMANDS.map((c) => c.name).sort()).toEqual(
-      ["effort", "mode", "model", "plan"].sort()
+      ["effort", "mode", "model", "plan", "skills"].sort()
     );
   });
 });


### PR DESCRIPTION
## Summary

- Defer `available_commands_update` until after the `session/new` response so clients (e.g. Zed) that register the session from the response actually receive slash commands.
- Auth polish: single "Login" method, `_meta["terminal-auth"]` for clients without native terminal auth, auto-close login TUI once `agy models` succeeds, fixed `auth_required` disclaimer (probe reason on stderr).
- Advertise curated `/skills` slash command.
- Bump package to 0.3.1 and document fixes in CHANGELOG.

## Test plan

- [x] `npm test` (typecheck + vitest, 126 tests)
- [ ] CI green on the PR
- [ ] After merge: tag `v0.3.1` on `main` to trigger release publish