### PR TITLE
Pause turn deadline during permission prompts, and stream poller fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pause the turn deadline while awaiting a `session/request_permission`
+  response and extend it by the wait duration, so slow or multi-prompt answers
+  no longer hit the 5m timeout. (#10)
+- Re-forward re-armed status-9 prompts on the same `run_command` step (each
+  segment of `a && b`), deduping on the permission signature instead of the
+  tool-call id, so compound commands no longer hang.
+- Complete turns that end on a terminal tool step with no trailing agent
+  message (denied/failed command, status 7).
+- Retry torn step-payload reads on the next poll instead of dropping them
+  until an unrelated data-version bump.
+- Restrict `isPlanFile` to `implementation_plan.md` / `plan.md` so prose brain
+  artifacts aren't shredded into bogus plan entries.
+- Bridge agy 1.1.7's `ask_permission` sandbox-bypass interaction instead of
+  throwing `Unsupported agy interaction 'ask_permission'`.
+
 ## [0.3.2] - 2026-07-24
 
 ### Added

--- a/src/acp/agent-plan/index.ts
+++ b/src/acp/agent-plan/index.ts
@@ -17,14 +17,25 @@ export function planIdForPath(targetFile: string): string {
   return `file:${targetFile}`;
 }
 
-/** True when a write target looks like an agy brain plan artifact. */
+/**
+ * Plan artifact filenames agy writes under `brain/**`. Only these are the
+ * checklist-style plan; the brain directory also holds many prose artifacts
+ * (`task.md`, `walkthrough.md`, `content.md`, `code_review_*.md`,
+ * `*_analysis.md`, ...) that must NOT be shredded into bogus plan entries.
+ */
+const PLAN_FILENAMES = new Set(["implementation_plan.md", "plan.md"]);
+
+/** True when a write target is an agy brain *plan* artifact (not any brain md). */
 export function isPlanFile(targetFile: string): boolean {
-  return (
-    targetFile.includes(".gemini") &&
-    targetFile.includes("antigravity-cli") &&
-    targetFile.includes("brain") &&
-    targetFile.endsWith("md")
-  );
+  if (
+    !targetFile.includes(".gemini") ||
+    !targetFile.includes("antigravity-cli") ||
+    !targetFile.includes("brain")
+  ) {
+    return false;
+  }
+  const base = (targetFile.split(/[\\/]/).pop() ?? "").toLowerCase();
+  return PLAN_FILENAMES.has(base);
 }
 
 /**

--- a/src/acp/tool-calls/permissions.ts
+++ b/src/acp/tool-calls/permissions.ts
@@ -31,6 +31,7 @@ export interface AskQuestionPayload {
 export function isBridgeablePermissionTool(toolName: string): boolean {
   if (!toolName || toolName === "ask_question") return false;
   if (toolName === "run_command") return true;
+  if (toolName === "ask_permission") return true;
   if (toolName === "view_file" || toolName === "list_dir") return true;
   if (isEditToolName(toolName)) return true;
   return false;
@@ -181,6 +182,14 @@ export function permissionOptions(toolCall: SessionUpdate, toolName?: string): P
     return askQuestionOptions(toolCall);
   }
 
+  // agy's sandbox-bypass request (run a command / read a file outside the
+  // sandbox). Its TUI menu is the same 4-row layout as run_command
+  // (Yes / always-in-conversation / persist / No), so the standard
+  // permissionKeys navigation applies.
+  if (toolName === "ask_permission") {
+    return askPermissionOptions(toolCall);
+  }
+
   // File edits: standard ACP option ids/kinds so clients can render native
   // Keep / Reject (or equivalent) review UI against the tool_call diff.
   if (isEditToolName(toolName ?? "") || (toolName == null && isEditToolCall(toolCall))) {
@@ -251,6 +260,34 @@ function standardEditPermissionOptions(): PermissionMenuOption[] {
     { optionId: "allow-once", kind: "allow_once", name: "Allow" },
     { optionId: "allow-always", kind: "allow_always", name: "Always allow" },
     { optionId: "reject-once", kind: "reject_once", name: "Reject" }
+  ];
+}
+
+/**
+ * Options for agy's `ask_permission` sandbox-bypass request. rawInput carries
+ * `Action` (e.g. `run_command` / `read_file`), `Target`, and `Reason`; the TUI
+ * renders the standard 4-row permission menu, so we mirror run_command's ids.
+ */
+function askPermissionOptions(toolCall: SessionUpdate): PermissionMenuOption[] {
+  const input = toolRawInput(toolCall);
+  const raw = toolCall as unknown as Record<string, unknown>;
+  const target =
+    pickString(input, "Target", "target", "CommandLine", "commandLine", "command") ??
+    pickString(input, "toolAction", "ToolAction") ??
+    (typeof raw.title === "string" && raw.title.trim() ? raw.title.trim() : "this action");
+  return [
+    { optionId: "agy-allow-once", kind: "allow_once", name: "Yes" },
+    {
+      optionId: "agy-allow-conversation",
+      kind: "allow_always",
+      name: `Yes, and always allow '${target}' in this conversation`
+    },
+    {
+      optionId: "agy-allow-settings",
+      kind: "allow_always",
+      name: `Yes, and always allow '${target}' (Persist to settings.json)`
+    },
+    { optionId: "agy-reject-once", kind: "reject_once", name: "No" }
   ];
 }
 

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { conversationSnapshot } from "./db/scan.js";
 import { defaultInstallBinDir, ensureAgyInstalled } from "./installer.js";
 import { StreamPoller } from "./db/streaming.js";
+import type { StepRow } from "./db/types.js";
 import { revertEditToolCall } from "./edit/revert.js";
 import {
   primeEditReadThroughClient,
@@ -29,6 +30,15 @@ const POLL_INTERVAL_MS = 200;
 /** Trailing polls after the process exits, to catch rows flushed right around exit. */
 const TRAILING_POLL_ATTEMPTS = 3;
 const TRAILING_POLL_DELAY_MS = 100;
+
+/** Signature of the permission decision agy has recorded for a gated step.
+ *  A re-armed status-9 prompt (e.g. the next segment of `a && b`) changes this
+ *  even though the toolCallId is unchanged, letting the turn loop tell a fresh
+ *  decision apart from a redundant re-emission of the same still-pending one. */
+function permissionSignature(row: StepRow): string {
+  const p = row.permission;
+  return p ? `${p.kind}\u0000${p.value}\u0000${p.decision}` : "none";
+}
 
 export type SpawnedProcess = ChildProcessWithoutNullStreams;
 
@@ -327,14 +337,14 @@ export class AgyCliSession {
     // edit once agy applies it, at which point it's still worth routing
     // through the client's fs write-through so its native review UI tracks
     // the edit — that's a second, independent decision for the same id.
-    const requestedGate = new Set<string>();
+    const requestedGate = new Map<string, string>();
     const requestedEditReview = new Set<string>();
     // ids that already went through the live gate above, so a later
     // completed-edit sighting shouldn't trigger a second (redundant) local
     // permission prompt if the client has no fs write-through.
     const gatedIds = new Set<string>();
     const activePtyExit = this.#ptyExit!;
-    const deadline = Date.now() + parsePrintTimeoutMs(this.config.printTimeout);
+    let deadline = Date.now() + parsePrintTimeoutMs(this.config.printTimeout);
     let candidateRevision = -1;
     let seenRevision = -1;
     // A newly spawned TUI first draws its initial idle prompt, then draws
@@ -356,9 +366,22 @@ export class AgyCliSession {
         for (const interaction of poller.takePending()) {
           const toolCall = interaction.update;
           const id = String((toolCall as unknown as { toolCallId?: string }).toolCallId);
-          const seen = interaction.blocked ? requestedGate : requestedEditReview;
-          if (seen.has(id)) continue;
-          seen.add(id);
+          if (interaction.blocked) {
+            // A single agy run_command step can gate several sequential
+            // decisions (each segment of `a && b`, a sandbox escalation, ...):
+            // agy records the just-resolved decision in the row's permission
+            // column but keeps the step at status 9 until every decision is
+            // answered. Dedup on that permission signature (not the toolCallId
+            // alone) so a re-armed prompt on the same step is forwarded again
+            // instead of being swallowed — swallowing it hangs the turn until
+            // the deadline.
+            const signature = permissionSignature(interaction.row);
+            if (requestedGate.get(id) === signature) continue;
+            requestedGate.set(id, signature);
+          } else {
+            if (requestedEditReview.has(id)) continue;
+            requestedEditReview.add(id);
+          }
 
           if (interaction.blocked) {
             if (!canBridgeInteraction(interaction.toolName, toolCall)) {
@@ -386,10 +409,11 @@ export class AgyCliSession {
               }
             }
 
+            const startPermission = Date.now();
             const choice = await this.raceTurnCallback(
-              onPermission(toolCall, { toolName: interaction.toolName }),
-              deadline
+              onPermission(toolCall, { toolName: interaction.toolName })
             );
+            deadline += Date.now() - startPermission;
             if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
 
             const keys = interactionKeys(choice, interaction.toolName, toolCall);
@@ -434,10 +458,11 @@ export class AgyCliSession {
           // Genuinely ungated (no live agy gate ever asked) and no client
           // write-through available — offer local review: keep is a no-op,
           // reject restores prior text.
+          const startPermission = Date.now();
           const choice = await this.raceTurnCallback(
-            onPermission(toolCall, { toolName: interaction.toolName }),
-            deadline
+            onPermission(toolCall, { toolName: interaction.toolName })
           );
+          deadline += Date.now() - startPermission;
           if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
           if (normalizePermissionChoice(choice) === "agy-reject-once") revertEditToolCall(toolCall);
         }
@@ -460,11 +485,14 @@ export class AgyCliSession {
     }
   }
 
-  private async raceTurnCallback<T>(callback: Promise<T>, deadline: number): Promise<T | "cancelled"> {
+  private async raceTurnCallback<T>(callback: Promise<T>, deadline?: number): Promise<T | "cancelled"> {
     const guarded = callback.catch((error) => {
       if (this.#cancelled) return "cancelled" as const;
       throw error;
     });
+    if (deadline === undefined) {
+      return await Promise.race([guarded, this.#cancelWait.then(() => "cancelled" as const)]);
+    }
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timedOut = new Promise<never>((_, reject) => {
       timer = setTimeout(() => reject(new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final idle marker was observed`, [this.config.agyPath], null, this.#ptyOutput)), Math.max(0, deadline - Date.now()));

--- a/src/agy/db/database.ts
+++ b/src/agy/db/database.ts
@@ -112,19 +112,22 @@ export class ConversationDb {
    * not take down the whole poll loop. Since it's dropped, not consumed, its
    * idx isn't advanced past, so it's naturally retried on the next read once
    * the write settles. */
-  readAfter(afterStepIdx: number): StepRow[] {
+  readAfter(afterStepIdx: number): StepRow[] & { hasDecodeError: boolean } {
     const rows = this.stmt.all(afterStepIdx) as RawRow[];
-    const out: StepRow[] = [];
+    const out: StepRow[] & { hasDecodeError?: boolean } = [];
+    let hasDecodeError = false;
     for (const r of rows) {
       try {
         out.push(rowToStep(r));
       } catch (error) {
+        hasDecodeError = true;
         console.error(
           `[agy-acp] WARN: failed to decode step ${r.idx}, skipping: ${(error as Error).message}`
         );
       }
     }
-    return out;
+    out.hasDecodeError = hasDecodeError;
+    return out as StepRow[] & { hasDecodeError: boolean };
   }
 
   /** SQLite generation counter, incremented when another connection commits. */

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -96,9 +96,11 @@ export class StreamPoller {
 
     const dataVersion = this.db.dataVersion();
     if (this.dataVersion === dataVersion) return [];
-    this.dataVersion = dataVersion;
 
     const rows = this.db.readAfter(this.opts.baseStepIdx);
+    if (!rows.hasDecodeError) {
+      this.dataVersion = dataVersion;
+    }
     const snapshot = JSON.stringify(rows.map((row) => [
       row.idx,
       row.stepType,

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -42,7 +42,7 @@ export class StreamPoller {
   private _pending: PendingInteraction[] = [];
   private _hasRows = false;
   private _busy = false;
-  private _latestAgentComplete = false;
+  private _latestStepTerminal = false;
   private _revision = 0;
   private dataVersion: number | null = null;
   private rowSnapshot = "";
@@ -76,7 +76,7 @@ export class StreamPoller {
   }
 
   get turnCompleteCandidate(): boolean {
-    return this._hasRows && !this._busy && this._latestAgentComplete;
+    return this._hasRows && !this._busy && this._latestStepTerminal;
   }
 
   /** Increments whenever the observed rows (including growing in-place rows) change. */
@@ -114,7 +114,13 @@ export class StreamPoller {
     this._hasRows = rows.length > 0;
     this._busy = rows.some((row) => row.status !== 3 && row.status !== 6 && row.status !== 7);
     const latest = rows.at(-1);
-    this._latestAgentComplete = latest?.stepType === 15 && latest.status === 3;
+    // A turn can end on a completed agent message, but also on a terminal tool
+    // step with no trailing message — most notably a denied/failed command
+    // (status 7), after which agy returns to idle without emitting more text.
+    // Gate completion on "latest step is terminal" (3/6/7), not "latest is an
+    // agent message", so those turns don't hang until the deadline.
+    this._latestStepTerminal =
+      latest !== undefined && (latest.status === 3 || latest.status === 6 || latest.status === 7);
     const updates = this.translator.translate(rows);
     const rowsByToolCallId = new Map(rows.map((row) => [toolCallId(row), row]));
     for (const update of updates) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -162,6 +162,35 @@ describe("permission bridge", () => {
     expect(interactionKeys("agy-q-skip", "ask_question", askCall)).toBe("\x1b");
   });
 
+  it("bridges agy's ask_permission sandbox-bypass request as a command-style menu", () => {
+    // agy 1.1.7 gates sandbox bypass (run a command / read a file outside the
+    // sandbox) through a status-9 `ask_permission` step whose TUI menu is the
+    // same 4-row layout as run_command. It must be bridged, not thrown on.
+    const askPermission = {
+      sessionUpdate: "tool_call" as const,
+      toolCallId: "ap1",
+      title: "Permission request for git directory",
+      kind: "other" as const,
+      status: "pending" as const,
+      rawInput: {
+        Action: "read_file",
+        Reason: "To allow git inside the sandbox to read the parent repository",
+        Target: "/repo/.git",
+        toolAction: "Requesting read access to the git parent repository"
+      }
+    };
+    expect(isBridgeablePermissionTool("ask_permission")).toBe(true);
+    expect(canBridgeInteraction("ask_permission", askPermission)).toBe(true);
+    expect(permissionOptions(askPermission, "ask_permission")).toEqual([
+      { optionId: "agy-allow-once", kind: "allow_once", name: "Yes" },
+      { optionId: "agy-allow-conversation", kind: "allow_always", name: "Yes, and always allow '/repo/.git' in this conversation" },
+      { optionId: "agy-allow-settings", kind: "allow_always", name: "Yes, and always allow '/repo/.git' (Persist to settings.json)" },
+      { optionId: "agy-reject-once", kind: "reject_once", name: "No" }
+    ]);
+    expect(interactionKeys("agy-allow-once", "ask_permission", askPermission)).toBe("\r");
+    expect(interactionKeys("agy-reject-once", "ask_permission", askPermission)).toBe("\x1b[B\x1b[B\x1b[B\r");
+  });
+
   for (const [choice, keys] of [
     ["agy-allow-once", "\r"],
     ["agy-allow-conversation", "\x1b[B\r"],

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -198,6 +198,29 @@ describe("permission bridge", () => {
     });
   }
 
+  it("completes a turn that ends on a denied command (failed tool step, no trailing message)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "denied");
+      insertStep(db, pendingToolRow("run_command", '{"CommandLine":"git reset"}'));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const result = session.prompt("go", async () => {}, async () => {
+      // agy records the denial and fails the command; the turn ends here with
+      // NO trailing agent-text step (matches real denied-command turns).
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "denied.db"));
+      updateStep(db, 1, { status: 7 });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 50);
+      return "agy-reject-once";
+    });
+    expect((await result).stopReason).toBe("end_turn");
+    expect(pty.writes).toEqual(["\x1b[B\x1b[B\x1b[B\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("accepts an idle marker emitted after the DB write but before the next poll", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -27,7 +27,7 @@ import {
   permissionOptions
 } from "../src/acp/tool-calls/permissions.js";
 import { createConversationDb, insertStep, updateStep } from "./fixtures/conversation-db.js";
-import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
+import { encodePermissions, encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 
 /** Collects updates via the `onUpdate` callback `AgyCliSession.prompt` takes. */
 async function collectUpdates(
@@ -265,17 +265,64 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("times out while the ACP client leaves a permission request unanswered", async () => {
+  it("pauses turn deadline while waiting for ACP client permission response and extends turn timeout", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {
       const db = createConversationDb(dir, "permission-timeout");
       insertStep(db, pendingToolRow("run_command"));
       db.close();
     });
-    const session = interactiveSession(dir, pty, "30ms");
+    const session = interactiveSession(dir, pty, "2s");
 
-    await expect(session.prompt("go", async () => {}, () => new Promise(() => {}))).rejects.toThrow(/timed out after 30ms/);
-    expect(pty.killed).toBe(true);
+    const result = session.prompt("go", async () => {}, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "permission-timeout.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 450);
+      return "agy-allow-once";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("re-forwards a re-armed status-9 prompt on the same run_command step (compound `a && b`)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "compound");
+      insertStep(db, pendingToolRow("run_command", '{"CommandLine":"git status && git log"}'));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    let calls = 0;
+    const result = session.prompt("go", async () => {}, async () => {
+      calls++;
+      const { default: Database } = await import("better-sqlite3");
+      const db = new Database(path.join(dir, "compound.db"));
+      if (calls === 1) {
+        // agy granted segment 1 (`git status`) but stays at status 9 awaiting
+        // the next segment's decision — a re-armed prompt on the same step.
+        db.prepare("UPDATE steps SET permissions = ? WHERE idx = 1").run(
+          Buffer.from(encodePermissions({ kind: "command", value: "git status", decision: 1 }))
+        );
+      } else {
+        db.prepare("UPDATE steps SET permissions = ?, status = 3 WHERE idx = 1").run(
+          Buffer.from(encodePermissions({ kind: "unsandboxed", value: "git log", decision: 1 }))
+        );
+        insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+        setTimeout(() => pty.emitData("? for shortcuts"), 50);
+      }
+      db.close();
+      return "agy-allow-conversation";
+    });
+    expect((await result).stopReason).toBe("end_turn");
+    // Both segments gated — the second must not be swallowed by toolCallId dedup.
+    expect(calls).toBe(2);
+    expect(pty.writes).toEqual(["\x1b[B\r", "\x1b[B\r"]);
+    await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -714,6 +714,45 @@ describe("StreamPoller", () => {
     poller.close();
     db.close();
   });
+
+  it("retries readAfter on next poll if a torn read decode error occurs", () => {
+    const db = createConversationDb(dir, "conv-torn-read");
+    // Insert step with invalid/corrupt blob payload to simulate premature EOF
+    db.prepare("INSERT INTO steps (idx, step_type, status, step_payload) VALUES (?, ?, ?, ?)").run(
+      1, 21, 9, Buffer.from([0x08, 0xff])
+    );
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-torn-read",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    // First poll encounters decode error, so dataVersion is NOT cached
+    expect(poller.poll()).toEqual([]);
+
+    // Now update row 1 to hold a valid payload (simulating completed write)
+    db.prepare("UPDATE steps SET step_payload = ? WHERE idx = 1").run(
+      Buffer.from(encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "cmd-1",
+            namePrimary: "run_command",
+            rawInputJson: '{"CommandLine":"ls"}'
+          })
+        })
+      }))
+    );
+
+    // Second poll retries reading and successfully decodes the step
+    const updates = poller.poll();
+    expect(updates).toHaveLength(1);
+    expect((updates[0] as { sessionUpdate: string }).sessionUpdate).toBe("tool_call");
+
+    poller.close();
+    db.close();
+  });
 });
 
 describe("ReplayCache", () => {

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -14,6 +14,15 @@ describe("isPlanFile", () => {
     expect(isPlanFile("/repo/docs/plan.md")).toBe(false);
     expect(isPlanFile("/Users/me/.gemini/antigravity-cli/brain/x/note.txt")).toBe(false);
   });
+
+  it("rejects non-plan brain markdown artifacts", () => {
+    const base = "/Users/me/.gemini/antigravity-cli/brain/abc";
+    expect(isPlanFile(`${base}/code_review_v0.3.3.md`)).toBe(false);
+    expect(isPlanFile(`${base}/walkthrough.md`)).toBe(false);
+    expect(isPlanFile(`${base}/task.md`)).toBe(false);
+    expect(isPlanFile(`${base}/content.md`)).toBe(false);
+    expect(isPlanFile(`${base}/comparison_analysis.md`)).toBe(false);
+  });
 });
 
 describe("parsePlanEntries", () => {


### PR DESCRIPTION
This PR targets `release/v0.3.3` with the following fixes:

- **Turn Deadline**: Pauses the turn deadline during permission prompts and extends it by the wait duration, avoiding 5m timeouts.
- **Compound Commands**: Re-forwards re-armed prompts on the same `run_command` step (e.g., compound commands), deduping on permission signature so they don't hang.
- **Turn Completion**: Turn completion for turns ending on a terminal tool step (e.g., status 7, denied/failed command).
- **Stream Polling**: Retries torn step-payload reads on the next poll instead of dropping them.
- **Plan Files**: Restricts `isPlanFile` to `implementation_plan.md` and `plan.md` to avoid parsing prose brain artifacts.
- **Agy Bridge**: Bridges agy 1.1.7's `ask_permission` sandbox-bypass interaction.