### PR TITLE
Decode grep_search hit field 2 as varint line number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ for draft v2 may still change before ACP v2 stabilizes.
   artifacts aren't shredded into bogus plan entries.
 - Bridge agy 1.1.7's `ask_permission` sandbox-bypass interaction instead of
   throwing `Unsupported agy interaction 'ask_permission'`.
+- Decode `grep_search` hit field 2 as a varint line number instead of a string,
+  preventing protobuf parser misalignment, premature EOF errors, and dropped
+  search steps. (#12, #18)
 
 ## [0.3.2] - 2026-07-24
 

--- a/src/agy/db/step-payload.ts
+++ b/src/agy/db/step-payload.ts
@@ -26,10 +26,14 @@ export interface ToolRun {
   titleSecondary: string;
 }
 
-/** Fields 1-5 of a grep/web-search hit; likely file path, line, matched text, etc. */
+/** One grep_search hit. Field numbers are reverse-engineered from real agy
+ *  conversation DBs: 1 = relative file path, 2 = line number (varint),
+ *  3 = matched line text, 4 = absolute file path. Field 5 has not been
+ *  observed populated in real DBs but is retained for forward-compat. */
 export interface SearchHit {
   field1: string;
-  field2: string;
+  /** 1-based line number of the match, or 0 when agy omits it. */
+  field2: number;
   field3: string;
   field4: string;
   field5: string;
@@ -164,9 +168,9 @@ function decodeToolRun(bytes: Uint8Array): ToolRun {
 }
 
 function decodeSearchHit(bytes: Uint8Array): SearchHit {
-  return readMessage(bytes, { field1: "", field2: "", field3: "", field4: "", field5: "" }, {
+  return readMessage(bytes, { field1: "", field2: 0, field3: "", field4: "", field5: "" }, {
     1: (m, r) => (m.field1 = r.string()),
-    2: (m, r) => (m.field2 = r.string()),
+    2: (m, r) => (m.field2 = readInt(r)),
     3: (m, r) => (m.field3 = r.string()),
     4: (m, r) => (m.field4 = r.string()),
     5: (m, r) => (m.field5 = r.string())

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -321,11 +321,14 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   return toolCallUpdate({ stepRow, title, kind: "read", content, locations });
 }
 
-/** Render grep hits (generic field1..field5) into readable, pipe-joined lines. */
+/** Render grep hits into readable, pipe-joined lines. `field2` is the line
+ *  number (a varint in the wire format); coerce it to a string for display. */
 function renderHits(hits: SearchHit[] | undefined): string {
   if (!hits || hits.length === 0) return "";
   return hits
-    .map((h) => [h.field1, h.field2, h.field3, h.field4, h.field5].filter((v) => v.trim().length > 0).join(" | "))
+    .map((h) => [h.field1, h.field2 ? String(h.field2) : "", h.field3, h.field4, h.field5]
+      .filter((v) => v.trim().length > 0)
+      .join(" | "))
     .filter((line) => line.length > 0)
     .join("\n");
 }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -11,7 +11,9 @@ import { createConversationDb, insertStep, updateStep, updateStepPayload } from 
 import {
   encodeAgentText,
   encodeCommandResult,
+  encodeGrepSearchResult,
   encodePermissions,
+  encodeSearchHit,
   encodeStepPayload,
   encodeToolCall,
   encodeToolRun,
@@ -325,6 +327,59 @@ describe("Translator", () => {
     const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
     expect(body).toContain("Query: agy acp adapter");
     expect(body).toContain("https://www.google.com/search");
+  });
+
+  it("decodes grep_search hits whose field 2 is a varint line number (regression for issue #12)", () => {
+    const db = createConversationDb(dir, "conv-grep");
+    insertStep(db, {
+      idx: 1,
+      stepType: 7,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "g-1",
+            namePrimary: "grep_search",
+            rawInputJson: '{"Query":"Unreleased","SearchPath":"/repo"}'
+          })
+        }),
+        grepSearch: encodeGrepSearchResult({
+          query: "Unreleased",
+          cwdUri: "file:///repo",
+          hits: [
+            encodeSearchHit({ field1: "CHANGELOG.md", field2: 9, field3: "## [Unreleased]", field4: "/repo/CHANGELOG.md" }),
+            encodeSearchHit({ field1: "CHANGELOG.md", field2: 42, field3: "## [Unreleased] - 2026-01-01", field4: "/repo/CHANGELOG.md" })
+          ]
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-grep")!;
+    const rows = conn.readAfter(-1);
+    conn.close();
+
+    // The whole point of the regression: this must not throw "premature EOF"
+    // / "cant skip wire type 6/7", and the hits must carry line numbers.
+    expect(rows).toHaveLength(1);
+    const hits = rows[0].stepPayload.grepSearch?.hits ?? [];
+    expect(hits).toHaveLength(2);
+    expect(hits[0].field1).toBe("CHANGELOG.md");
+    expect(hits[0].field2).toBe(9);
+    expect(hits[0].field3).toBe("## [Unreleased]");
+    expect(hits[0].field4).toBe("/repo/CHANGELOG.md");
+    expect(hits[1].field2).toBe(42);
+
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const conn2 = ConversationDb.open(dir, "conv-grep")!;
+    const updates = translator.translate(conn2.readAfter(-1));
+    conn2.close();
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as { kind: string; content?: Array<{ content?: { text?: string } }> };
+    expect(update.kind).toBe("search");
+    const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
+    expect(body).toContain("CHANGELOG.md | 9 | ## [Unreleased]");
+    expect(body).toContain("CHANGELOG.md | 42 | ## [Unreleased] - 2026-01-01");
   });
 
   it("surfaces fetched URL body from field 40", () => {

--- a/tests/fixtures/step-encoder.ts
+++ b/tests/fixtures/step-encoder.ts
@@ -115,6 +115,40 @@ export function encodeViewFileResult(result: {
   return w.finish();
 }
 
+/** grep_search hit: 1 = relative path, 2 = line number (varint),
+ *  3 = matched text, 4 = absolute path. Mirrors `decodeSearchHit`. */
+export function encodeSearchHit(hit: {
+  field1?: string;
+  field2?: number;
+  field3?: string;
+  field4?: string;
+}): Uint8Array {
+  const w = new BinaryWriter();
+  if (hit.field1) w.tag(1, 2).string(hit.field1);
+  if (hit.field2 !== undefined) w.tag(2, 0).int64(hit.field2);
+  if (hit.field3) w.tag(3, 2).string(hit.field3);
+  if (hit.field4) w.tag(4, 2).string(hit.field4);
+  return w.finish();
+}
+
+export function encodeGrepSearchResult(result: {
+  query?: string;
+  includeGlob?: string;
+  textOutput?: string;
+  hits?: Uint8Array[];
+  shellCommand?: string;
+  cwdUri?: string;
+}): Uint8Array {
+  const w = new BinaryWriter();
+  if (result.query) w.tag(1, 2).string(result.query);
+  if (result.includeGlob) w.tag(2, 2).string(result.includeGlob);
+  if (result.textOutput) w.tag(3, 2).string(result.textOutput);
+  for (const hit of result.hits ?? []) submessage(w, 4, hit);
+  if (result.shellCommand) w.tag(10, 2).string(result.shellCommand);
+  if (result.cwdUri) w.tag(11, 2).string(result.cwdUri);
+  return w.finish();
+}
+
 /** permissions column: { 2: { 1: { 1: kind, 2: value }, 2: decision } }. */
 export function encodePermissions(info: { kind?: string; value?: string; decision?: number }): Uint8Array {
   const target = new BinaryWriter();
@@ -137,11 +171,13 @@ export function encodeStepPayload(opts: {
   userPrompt?: string;
   commandResult?: Uint8Array;
   viewFile?: Uint8Array;
+  grepSearch?: Uint8Array;
   webSearch?: Uint8Array;
   urlContent?: Uint8Array;
 }): Uint8Array {
   const w = new BinaryWriter();
   if (opts.toolRun) submessage(w, 5, opts.toolRun);
+  if (opts.grepSearch) submessage(w, 13, opts.grepSearch);
   if (opts.viewFile) submessage(w, 14, opts.viewFile);
   if (opts.userPrompt !== undefined) submessage(w, 19, encodeUserPrompt(opts.userPrompt));
   if (opts.agentText !== undefined) submessage(w, 20, encodeAgentText(opts.agentText));


### PR DESCRIPTION
## Summary

`decodeSearchHit` read field 2 as a string, but real agy conversation DBs store it as a varint line number. Calling `r.string()` on a varint field read the line number as a byte length and swallowed that many following bytes, misaligning the parser and throwing `premature EOF` / `cant skip wire type 6/7`. `ConversationDb.readAfter` then logged a WARN and dropped the entire `grep_search` step, so the ACP client never saw the call or its results.

## Root cause (wire dump of a hit)

```
field 1 wire 2 str="CHANGELOG.md"          # relative path
field 2 wire 0 varint=9                    # line number (was read as string)
field 3 wire 2 str="## [Unreleased]"       # matched text
field 4 wire 2 str="/Users/.../CHANGELOG.md"  # absolute path
```

## Fix

- Read field 2 as a varint (`readInt`) and type it as `number` in `SearchHit`.
- Coerce it back to a string in `renderHits` for display.
- Add `encodeSearchHit` / `encodeGrepSearchResult` + a regression test using a payload shaped like real DBs (hits with line numbers).

## Verification

- `npm run build` clean.
- `npx vitest run` — 140/140 tests pass (including the new regression test).
- Re-decoding the real DB from the report (`793ff62b-...`): all 114 rows now decode; the 4 previously-dropped `grep_search` steps (idx 50, 94, 104, 105) are recovered with correct line numbers (9, 54, 279, ...). No more `failed to decode step N` warnings.

Fixes #12