### PR TITLE
Send both `current_mode_update` and `config_option_update` on mode changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ for draft v2 may still change before ACP v2 stabilizes.
   artifacts aren't shredded into bogus plan entries.
 - Bridge agy 1.1.7's `ask_permission` sandbox-bypass interaction instead of
   throwing `Unsupported agy interaction 'ask_permission'`.
+- Send both `current_mode_update` and `config_option_update` notifications on
+  every mode-change path (`set_config_option`, `set_mode`, slash commands) so
+  clients watching either mechanism stay in sync during the ACP v1 transition
+  period. Previously some paths emitted only one, causing Zed to log
+  `Parse error: missing field configOptions`. (#15)
 
 ## [0.3.2] - 2026-07-24
 

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -310,7 +310,8 @@ export class AcpAgent {
     return handleSetConfigOptionV1(params, client, {
       requireSession: (id) => this.requireSession(id),
       applyConfigOption: (sessionId, configId, value) => this.applyConfigOption(sessionId, configId, value),
-      notifyCurrentModeUpdate
+      notifyCurrentModeUpdate,
+      notifyConfigOptionUpdateV1
     });
   }
 

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -109,14 +109,7 @@ export async function handlePromptV1(
     {
       // ACP transition: send both legacy current_mode_update (modes-API clients)
       // and config_option_update (configOptions clients) on slash-command mode changes.
-      modeChanged: async (mode) => {
-        await deps.notifyCurrentModeUpdate(client, params.sessionId, mode);
-        await deps.notifyConfigOptionUpdateV1(
-          client,
-          params.sessionId,
-          deps.requireSession(params.sessionId)
-        );
-      },
+      modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
       configChanged: async () => {
         await deps.notifyConfigOptionUpdateV1(
           client,

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -107,7 +107,16 @@ export async function handlePromptV1(
     params.sessionId,
     prompt,
     {
-      modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
+      // ACP transition: send both legacy current_mode_update (modes-API clients)
+      // and config_option_update (configOptions clients) on slash-command mode changes.
+      modeChanged: async (mode) => {
+        await deps.notifyCurrentModeUpdate(client, params.sessionId, mode);
+        await deps.notifyConfigOptionUpdateV1(
+          client,
+          params.sessionId,
+          deps.requireSession(params.sessionId)
+        );
+      },
       configChanged: async () => {
         await deps.notifyConfigOptionUpdateV1(
           client,

--- a/src/acp/session/set-config-option.ts
+++ b/src/acp/session/set-config-option.ts
@@ -26,6 +26,7 @@ export async function handleSetConfigOptionV1(
   client: V1AgentContext | undefined,
   deps: SetConfigOptionDeps & {
     notifyCurrentModeUpdate(client: V1AgentContext, sessionId: string, mode: SessionModeId): Promise<void>;
+    notifyConfigOptionUpdateV1(client: V1AgentContext, sessionId: string, session: SessionState): Promise<void>;
   }
 ): Promise<V1SetSessionConfigOptionResponse> {
   const configId = params.configId;
@@ -33,9 +34,13 @@ export async function handleSetConfigOptionV1(
   await deps.applyConfigOption(params.sessionId, configId, readConfigValue(params));
   const session = deps.requireSession(params.sessionId);
 
-  // Keep native modes UI in sync when mode changes via config option.
+  // ACP transition: when mode changes via config option, send both the legacy
+  // current_mode_update (modes-API clients) and an out-of-band config_option_update
+  // (configOptions clients). The response already carries the full option list, but
+  // clients that only watch notifications need the out-of-band push too.
   if (client && configId === MODE_CONFIG_ID && session.agy.config.mode !== previousMode) {
     await deps.notifyCurrentModeUpdate(client, params.sessionId, session.agy.config.mode);
+    await deps.notifyConfigOptionUpdateV1(client, params.sessionId, session);
   }
 
   return { configOptions: sessionConfigOptionsV1(session) };

--- a/src/acp/session/set-mode.ts
+++ b/src/acp/session/set-mode.ts
@@ -1,6 +1,7 @@
 // ACP session/set_mode: mirrors the `mode` config option onto agy `--mode`.
-// Pushes `config_option_update` so clients that only watch config options stay
-// aligned (set_mode is outside set_config_option).
+// Pushes both `current_mode_update` (legacy modes clients) and
+// `config_option_update` (configOptions clients) so both stay aligned during
+// the ACP transition period. See: https://agentclientprotocol.com/protocol/v1/session-config-options#relationship-to-session-modes
 // Docs: https://agentclientprotocol.com/protocol/v1/session-modes#setting-the-current-mode
 
 import type {
@@ -21,7 +22,7 @@ export interface SetSessionModeDeps {
 
 export async function handleSetSessionMode(
   params: SetSessionModeRequest,
-  client: V1AgentContext,
+  client: V1AgentContext | undefined,
   deps: SetSessionModeDeps
 ): Promise<SetSessionModeResponse> {
   const previousMode = deps.requireSession(params.sessionId).agy.config.mode;
@@ -29,7 +30,9 @@ export async function handleSetSessionMode(
   const session = deps.requireSession(params.sessionId);
   const mode = session.agy.config.mode;
 
-  if (mode !== previousMode) {
+  if (client && mode !== previousMode) {
+    // ACP transition: send both legacy current_mode_update (modes-API clients)
+    // and config_option_update (configOptions clients) to stay in sync.
     await deps.notifyCurrentModeUpdate(client, params.sessionId, mode);
     await deps.notifyConfigOptionUpdateV1(client, params.sessionId, session);
   }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -882,11 +882,14 @@ describe("session modes and config option sync", () => {
         value: "accept-edits"
       });
       expect(modeViaConfig.configOptions[0].currentValue).toBe("accept-edits");
-      expect(updates).toEqual([
-        { sessionUpdate: "current_mode_update", currentModeId: "accept-edits" }
-      ]);
-      // Config UI already received the full list in the set_config_option response.
-      expect(updates.some((u) => u.sessionUpdate === "config_option_update")).toBe(false);
+      // ACP transition: both legacy current_mode_update and out-of-band config_option_update are sent.
+      expect(updates).toEqual(
+        expect.arrayContaining([
+          { sessionUpdate: "current_mode_update", currentModeId: "accept-edits" },
+          expect.objectContaining({ sessionUpdate: "config_option_update" })
+        ])
+      );
+      expect(updates.some((u) => u.sessionUpdate === "current_mode_update")).toBe(true);
 
       updates.length = 0;
       await connection.agent.request(methods.agent.session.setMode, {
@@ -1018,7 +1021,13 @@ describe("available_commands_update and slash commands", () => {
       });
       expect(updates).toEqual(
         expect.arrayContaining([
-          { sessionUpdate: "current_mode_update", currentModeId: "accept-edits" }
+          { sessionUpdate: "current_mode_update", currentModeId: "accept-edits" },
+          expect.objectContaining({
+            sessionUpdate: "config_option_update",
+            configOptions: expect.arrayContaining([
+              expect.objectContaining({ id: "mode", currentValue: "accept-edits" })
+            ])
+          })
         ])
       );
     } finally {


### PR DESCRIPTION
## Summary

Zed logged `Parse error: missing field configOptions, json {}, phase: deserialization` at `agent_servers/src/acp.rs:1372` when receiving ACP v1 session update notifications on mode changes.

## Fix

- Emit both `current_mode_update` (for legacy modes clients) and `config_option_update` (for `configOptions` clients like Zed) on every mode-change path (`set_config_option`, `set_mode`, slash commands).
- Update unit tests in `tests/acp-server.test.ts` to assert both notifications are sent.
- Update `CHANGELOG.md`.
