### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 - Pause the turn deadline while awaiting a `session/request_permission`
   response and extend it by the wait duration, so slow or multi-prompt answers
   no longer hit the 5m timeout. (#10)
+- Re-arm turn deadline on prompt resolution and reset deadline on active DB progress, fixing 5m turn timeouts.
 - Re-forward re-armed status-9 prompts on the same `run_command` step (each
   segment of `a && b`), deduping on the permission signature instead of the
   tool-call id, so compound commands no longer hang.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pause the turn deadline while awaiting a `session/request_permission`
+  response and extend it by the wait duration, so slow or multi-prompt answers
+  no longer hit the 5m timeout. (#10)
+- Re-forward re-armed status-9 prompts on the same `run_command` step (each
+  segment of `a && b`), deduping on the permission signature instead of the
+  tool-call id, so compound commands no longer hang.
+- Complete turns that end on a terminal tool step with no trailing agent
+  message (denied/failed command, status 7).
+- Retry torn step-payload reads on the next poll instead of dropping them
+  until an unrelated data-version bump.
+- Restrict `isPlanFile` to `implementation_plan.md` / `plan.md` so prose brain
+  artifacts aren't shredded into bogus plan entries.
+- Bridge agy 1.1.7's `ask_permission` sandbox-bypass interaction instead of
+  throwing `Unsupported agy interaction 'ask_permission'`.
+
 ## [0.3.2] - 2026-07-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ for draft v2 may still change before ACP v2 stabilizes.
   artifacts aren't shredded into bogus plan entries.
 - Bridge agy 1.1.7's `ask_permission` sandbox-bypass interaction instead of
   throwing `Unsupported agy interaction 'ask_permission'`.
+- Decode `grep_search` hit field 2 as a varint line number instead of a string,
+  preventing protobuf parser misalignment, premature EOF errors, and dropped
+  search steps. (#12, #18)
 
 ## [0.3.2] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ for draft v2 may still change before ACP v2 stabilizes.
   artifacts aren't shredded into bogus plan entries.
 - Bridge agy 1.1.7's `ask_permission` sandbox-bypass interaction instead of
   throwing `Unsupported agy interaction 'ask_permission'`.
+- Send both `current_mode_update` and `config_option_update` notifications on
+  every mode-change path (`set_config_option`, `set_mode`, slash commands) so
+  clients watching either mechanism stay in sync during the ACP v1 transition
+  period. Previously some paths emitted only one, causing Zed to log
+  `Parse error: missing field configOptions`. (#15)
 
 ## [0.3.2] - 2026-07-24
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agy-acp
 
-ACP adapter for Google Antigravity CLI.  
+ACP adapter for Google Antigravity CLI.
 
 ## Usage
 
@@ -13,7 +13,7 @@ curl -fsSL https://antigravity.google/cli/install.sh | bash
 ```
 
 ```sh
-npx agy-acp                 # stable (0.3.0)
+npx agy-acp                 # stable (0.3.3)
 npx agy-acp@alpha           # draft ACP v2 channel
 npx agy-acp@1.0.0-alpha.0   # pin a pre-release
 ```

--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
 # agy-acp
 
-ACP adapter for Google Antigravity's `agy` CLI. TypeScript, `npx`-runnable, built on
-`@agentclientprotocol/sdk`. Runs a persistent interactive `agy` process so ACP clients
-can answer permission requests while keeping the logged-in Antigravity CLI experience.
-
-**Package:** `0.3.0` (`latest`) — ACP v1 + experimental draft ACP v2 via `initialize`
-negotiation. Draft v2 continues on the `alpha` dist-tag (`1.0.0-alpha.*`). See the
-[ACP v2 draft](https://agentclientprotocol.com/announcements/acp-v2-draft) and
-[migration guide](https://agentclientprotocol.com/protocol/v2/migration). Requires
-**Node.js 22+**.
+ACP adapter for Google Antigravity CLI.  
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agy-acp",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agy-acp",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/src/acp/agent-plan/index.ts
+++ b/src/acp/agent-plan/index.ts
@@ -17,14 +17,25 @@ export function planIdForPath(targetFile: string): string {
   return `file:${targetFile}`;
 }
 
-/** True when a write target looks like an agy brain plan artifact. */
+/**
+ * Plan artifact filenames agy writes under `brain/**`. Only these are the
+ * checklist-style plan; the brain directory also holds many prose artifacts
+ * (`task.md`, `walkthrough.md`, `content.md`, `code_review_*.md`,
+ * `*_analysis.md`, ...) that must NOT be shredded into bogus plan entries.
+ */
+const PLAN_FILENAMES = new Set(["implementation_plan.md", "plan.md"]);
+
+/** True when a write target is an agy brain *plan* artifact (not any brain md). */
 export function isPlanFile(targetFile: string): boolean {
-  return (
-    targetFile.includes(".gemini") &&
-    targetFile.includes("antigravity-cli") &&
-    targetFile.includes("brain") &&
-    targetFile.endsWith("md")
-  );
+  if (
+    !targetFile.includes(".gemini") ||
+    !targetFile.includes("antigravity-cli") ||
+    !targetFile.includes("brain")
+  ) {
+    return false;
+  }
+  const base = (targetFile.split(/[\\/]/).pop() ?? "").toLowerCase();
+  return PLAN_FILENAMES.has(base);
 }
 
 /**

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -310,7 +310,8 @@ export class AcpAgent {
     return handleSetConfigOptionV1(params, client, {
       requireSession: (id) => this.requireSession(id),
       applyConfigOption: (sessionId, configId, value) => this.applyConfigOption(sessionId, configId, value),
-      notifyCurrentModeUpdate
+      notifyCurrentModeUpdate,
+      notifyConfigOptionUpdateV1
     });
   }
 

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -109,14 +109,7 @@ export async function handlePromptV1(
     {
       // ACP transition: send both legacy current_mode_update (modes-API clients)
       // and config_option_update (configOptions clients) on slash-command mode changes.
-      modeChanged: async (mode) => {
-        await deps.notifyCurrentModeUpdate(client, params.sessionId, mode);
-        await deps.notifyConfigOptionUpdateV1(
-          client,
-          params.sessionId,
-          deps.requireSession(params.sessionId)
-        );
-      },
+      modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
       configChanged: async () => {
         await deps.notifyConfigOptionUpdateV1(
           client,

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -107,7 +107,16 @@ export async function handlePromptV1(
     params.sessionId,
     prompt,
     {
-      modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
+      // ACP transition: send both legacy current_mode_update (modes-API clients)
+      // and config_option_update (configOptions clients) on slash-command mode changes.
+      modeChanged: async (mode) => {
+        await deps.notifyCurrentModeUpdate(client, params.sessionId, mode);
+        await deps.notifyConfigOptionUpdateV1(
+          client,
+          params.sessionId,
+          deps.requireSession(params.sessionId)
+        );
+      },
       configChanged: async () => {
         await deps.notifyConfigOptionUpdateV1(
           client,

--- a/src/acp/session/set-config-option.ts
+++ b/src/acp/session/set-config-option.ts
@@ -26,6 +26,7 @@ export async function handleSetConfigOptionV1(
   client: V1AgentContext | undefined,
   deps: SetConfigOptionDeps & {
     notifyCurrentModeUpdate(client: V1AgentContext, sessionId: string, mode: SessionModeId): Promise<void>;
+    notifyConfigOptionUpdateV1(client: V1AgentContext, sessionId: string, session: SessionState): Promise<void>;
   }
 ): Promise<V1SetSessionConfigOptionResponse> {
   const configId = params.configId;
@@ -33,9 +34,13 @@ export async function handleSetConfigOptionV1(
   await deps.applyConfigOption(params.sessionId, configId, readConfigValue(params));
   const session = deps.requireSession(params.sessionId);
 
-  // Keep native modes UI in sync when mode changes via config option.
+  // ACP transition: when mode changes via config option, send both the legacy
+  // current_mode_update (modes-API clients) and an out-of-band config_option_update
+  // (configOptions clients). The response already carries the full option list, but
+  // clients that only watch notifications need the out-of-band push too.
   if (client && configId === MODE_CONFIG_ID && session.agy.config.mode !== previousMode) {
     await deps.notifyCurrentModeUpdate(client, params.sessionId, session.agy.config.mode);
+    await deps.notifyConfigOptionUpdateV1(client, params.sessionId, session);
   }
 
   return { configOptions: sessionConfigOptionsV1(session) };

--- a/src/acp/session/set-mode.ts
+++ b/src/acp/session/set-mode.ts
@@ -1,6 +1,7 @@
 // ACP session/set_mode: mirrors the `mode` config option onto agy `--mode`.
-// Pushes `config_option_update` so clients that only watch config options stay
-// aligned (set_mode is outside set_config_option).
+// Pushes both `current_mode_update` (legacy modes clients) and
+// `config_option_update` (configOptions clients) so both stay aligned during
+// the ACP transition period. See: https://agentclientprotocol.com/protocol/v1/session-config-options#relationship-to-session-modes
 // Docs: https://agentclientprotocol.com/protocol/v1/session-modes#setting-the-current-mode
 
 import type {
@@ -21,7 +22,7 @@ export interface SetSessionModeDeps {
 
 export async function handleSetSessionMode(
   params: SetSessionModeRequest,
-  client: V1AgentContext,
+  client: V1AgentContext | undefined,
   deps: SetSessionModeDeps
 ): Promise<SetSessionModeResponse> {
   const previousMode = deps.requireSession(params.sessionId).agy.config.mode;
@@ -29,7 +30,9 @@ export async function handleSetSessionMode(
   const session = deps.requireSession(params.sessionId);
   const mode = session.agy.config.mode;
 
-  if (mode !== previousMode) {
+  if (client && mode !== previousMode) {
+    // ACP transition: send both legacy current_mode_update (modes-API clients)
+    // and config_option_update (configOptions clients) to stay in sync.
     await deps.notifyCurrentModeUpdate(client, params.sessionId, mode);
     await deps.notifyConfigOptionUpdateV1(client, params.sessionId, session);
   }

--- a/src/acp/tool-calls/permissions.ts
+++ b/src/acp/tool-calls/permissions.ts
@@ -31,6 +31,7 @@ export interface AskQuestionPayload {
 export function isBridgeablePermissionTool(toolName: string): boolean {
   if (!toolName || toolName === "ask_question") return false;
   if (toolName === "run_command") return true;
+  if (toolName === "ask_permission") return true;
   if (toolName === "view_file" || toolName === "list_dir") return true;
   if (isEditToolName(toolName)) return true;
   return false;
@@ -181,6 +182,14 @@ export function permissionOptions(toolCall: SessionUpdate, toolName?: string): P
     return askQuestionOptions(toolCall);
   }
 
+  // agy's sandbox-bypass request (run a command / read a file outside the
+  // sandbox). Its TUI menu is the same 4-row layout as run_command
+  // (Yes / always-in-conversation / persist / No), so the standard
+  // permissionKeys navigation applies.
+  if (toolName === "ask_permission") {
+    return askPermissionOptions(toolCall);
+  }
+
   // File edits: standard ACP option ids/kinds so clients can render native
   // Keep / Reject (or equivalent) review UI against the tool_call diff.
   if (isEditToolName(toolName ?? "") || (toolName == null && isEditToolCall(toolCall))) {
@@ -251,6 +260,34 @@ function standardEditPermissionOptions(): PermissionMenuOption[] {
     { optionId: "allow-once", kind: "allow_once", name: "Allow" },
     { optionId: "allow-always", kind: "allow_always", name: "Always allow" },
     { optionId: "reject-once", kind: "reject_once", name: "Reject" }
+  ];
+}
+
+/**
+ * Options for agy's `ask_permission` sandbox-bypass request. rawInput carries
+ * `Action` (e.g. `run_command` / `read_file`), `Target`, and `Reason`; the TUI
+ * renders the standard 4-row permission menu, so we mirror run_command's ids.
+ */
+function askPermissionOptions(toolCall: SessionUpdate): PermissionMenuOption[] {
+  const input = toolRawInput(toolCall);
+  const raw = toolCall as unknown as Record<string, unknown>;
+  const target =
+    pickString(input, "Target", "target", "CommandLine", "commandLine", "command") ??
+    pickString(input, "toolAction", "ToolAction") ??
+    (typeof raw.title === "string" && raw.title.trim() ? raw.title.trim() : "this action");
+  return [
+    { optionId: "agy-allow-once", kind: "allow_once", name: "Yes" },
+    {
+      optionId: "agy-allow-conversation",
+      kind: "allow_always",
+      name: `Yes, and always allow '${target}' in this conversation`
+    },
+    {
+      optionId: "agy-allow-settings",
+      kind: "allow_always",
+      name: `Yes, and always allow '${target}' (Persist to settings.json)`
+    },
+    { optionId: "agy-reject-once", kind: "reject_once", name: "No" }
   ];
 }
 

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -30,6 +30,7 @@ const POLL_INTERVAL_MS = 200;
 /** Trailing polls after the process exits, to catch rows flushed right around exit. */
 const TRAILING_POLL_ATTEMPTS = 3;
 const TRAILING_POLL_DELAY_MS = 100;
+const PERMISSION_RENDER_SETTLE_MS = 20;
 
 /** Signature of the permission decision agy has recorded for a gated step.
  *  A re-armed status-9 prompt (e.g. the next segment of `a && b`) changes this
@@ -150,7 +151,10 @@ export class AgyCliSession {
   #ptyIdleMarkerCount = 0;
   #ptyIdleMatchTail = "";
   #ptyPermissionMarkerCount = 0;
-  #ptyPermissionMatchTail = "";
+  #ptyPermissionRender = "";
+  #ptyPermissionMarkerTail = "";
+  #ptyPermissionPanelVisible = false;
+  #ptyPermissionRenderTimer: ReturnType<typeof setTimeout> | undefined;
   #ptyConfig = "";
   #cancelled = false;
   #cancelTurn: (() => void) | undefined;
@@ -318,8 +322,12 @@ export class AgyCliSession {
       this.#ptyIdleMarkerCount = 0;
       this.#ptyIdleMatchTail = "";
       this.#ptyPermissionMarkerCount = 0;
-      this.#ptyPermissionMatchTail = "";
-      this.#pty.onData((data) => {
+      this.#ptyPermissionRender = "";
+      this.#ptyPermissionMarkerTail = "";
+      this.#ptyPermissionPanelVisible = false;
+      const activePty = this.#pty;
+      activePty.onData((data) => {
+        if (this.#pty !== activePty) return;
         const idleMarker = "for shortcuts";
         const searchable = this.#ptyIdleMatchTail + data;
         let offset = 0;
@@ -329,17 +337,16 @@ export class AgyCliSession {
         }
         this.#ptyIdleMatchTail = searchable.slice(-(idleMarker.length - 1));
 
-        // Unlike the generic footer above, this text is specific to agy's
-        // standard permission panel. Its redraw is the only observable new
-        // occurrence when two consecutive gates write identical DB bytes.
-        const permissionMarker = "Yes, and always allow";
-        const permissionSearchable = this.#ptyPermissionMatchTail + data;
-        offset = 0;
-        while ((offset = permissionSearchable.indexOf(permissionMarker, offset)) >= 0) {
-          this.#ptyPermissionMarkerCount++;
-          offset += permissionMarker.length;
-        }
-        this.#ptyPermissionMatchTail = permissionSearchable.slice(-(permissionMarker.length - 1));
+        // Treat a transition into agy's permission panel as one occurrence.
+        // Arrow-key navigation redraws the same panel and must not re-arm the
+        // gate; consecutive identical gates transition through a non-panel
+        // render while the approved command segment runs.
+        this.#ptyPermissionRender = (this.#ptyPermissionRender + data).slice(-16_384);
+        if (this.#ptyPermissionRenderTimer) clearTimeout(this.#ptyPermissionRenderTimer);
+        this.#ptyPermissionRenderTimer = setTimeout(
+          () => this.flushPermissionRender(),
+          PERMISSION_RENDER_SETTLE_MS
+        );
         this.#ptyOutput = (this.#ptyOutput + data).slice(-16_384);
       });
       this.#ptyExit = new Promise((resolve) => this.#pty!.onExit(resolve));
@@ -451,6 +458,7 @@ export class AgyCliSession {
                 this.#ptyOutput
               );
             }
+            if (interaction.toolName !== "ask_question") this.markCurrentPermissionPanel();
             this.#pty?.write(keys);
             gateMarkerCounts.set(id, this.#ptyPermissionMarkerCount);
             // An idle marker printed before the decision cannot mean that the
@@ -738,6 +746,11 @@ export class AgyCliSession {
   private async stopPty(): Promise<void> {
     const pty = this.#pty;
     const exit = this.#ptyExit;
+    if (this.#ptyPermissionRenderTimer) clearTimeout(this.#ptyPermissionRenderTimer);
+    this.#ptyPermissionRenderTimer = undefined;
+    this.#ptyPermissionRender = "";
+    this.#ptyPermissionMarkerTail = "";
+    this.#ptyPermissionPanelVisible = false;
     this.#pty = undefined;
     this.#ptyExit = undefined;
     if (pty) {
@@ -752,9 +765,41 @@ export class AgyCliSession {
     }
   }
 
+  private flushPermissionRender(): void {
+    const marker = "Yes, and always allow";
+    const output = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
+    const visible = output.includes(marker);
+    this.#ptyPermissionMarkerTail = markerPrefixTail(output, marker);
+    if (visible) {
+      if (!this.#ptyPermissionPanelVisible) this.#ptyPermissionMarkerCount++;
+      this.#ptyPermissionPanelVisible = true;
+    } else if (this.#ptyPermissionMarkerTail.length === 0) {
+      this.#ptyPermissionPanelVisible = false;
+    }
+    this.#ptyPermissionRender = "";
+    this.#ptyPermissionRenderTimer = undefined;
+  }
+
+  private markCurrentPermissionPanel(): void {
+    if (this.#ptyPermissionRenderTimer) clearTimeout(this.#ptyPermissionRenderTimer);
+    this.#ptyPermissionRenderTimer = undefined;
+    this.#ptyPermissionRender = "";
+    this.#ptyPermissionMarkerTail = "";
+    this.#ptyPermissionPanelVisible = true;
+  }
+
   async close(): Promise<void> {
     await this.cancel();
   }
+}
+
+function markerPrefixTail(output: string, marker: string): string {
+  const max = Math.min(output.length, marker.length - 1);
+  for (let length = max; length > 0; length--) {
+    const suffix = output.slice(-length);
+    if (marker.startsWith(suffix)) return suffix;
+  }
+  return "";
 }
 
 export class AgyCliBackend {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -31,6 +31,7 @@ const POLL_INTERVAL_MS = 200;
 const TRAILING_POLL_ATTEMPTS = 3;
 const TRAILING_POLL_DELAY_MS = 100;
 const PERMISSION_RENDER_SETTLE_MS = 20;
+const PERMISSION_REDRAW_TIMEOUT_MS = 500;
 
 /** Signature of the permission decision agy has recorded for a gated step.
  *  A re-armed status-9 prompt (e.g. the next segment of `a && b`) changes this
@@ -443,6 +444,16 @@ export class AgyCliSession {
               }
             }
 
+            if (interaction.toolName !== "ask_question" && !await this.waitForPermissionPanel(deadline)) {
+              if (this.#cancelled) break;
+              throw new AgyCliError(
+                "agy permission panel was not observed before requesting permission",
+                [this.config.agyPath],
+                null,
+                this.#ptyOutput
+              );
+            }
+
             const choice = await this.raceTurnCallback(
               onPermission(toolCall, { toolName: interaction.toolName })
             );
@@ -458,8 +469,11 @@ export class AgyCliSession {
                 this.#ptyOutput
               );
             }
-            if (interaction.toolName !== "ask_question") this.markCurrentPermissionPanel();
-            this.#pty?.write(keys);
+            if (interaction.toolName === "ask_question") {
+              this.#pty?.write(keys);
+            } else {
+              if (!await this.writePermissionKeys(keys, deadline)) break;
+            }
             gateMarkerCounts.set(id, this.#ptyPermissionMarkerCount);
             // An idle marker printed before the decision cannot mean that the
             // approved/rejected command has finished.
@@ -771,7 +785,7 @@ export class AgyCliSession {
     const visible = output.includes(marker);
     this.#ptyPermissionMarkerTail = markerPrefixTail(output, marker);
     if (visible) {
-      if (!this.#ptyPermissionPanelVisible) this.#ptyPermissionMarkerCount++;
+      this.#ptyPermissionMarkerCount++;
       this.#ptyPermissionPanelVisible = true;
     } else if (this.#ptyPermissionMarkerTail.length === 0) {
       this.#ptyPermissionPanelVisible = false;
@@ -780,12 +794,55 @@ export class AgyCliSession {
     this.#ptyPermissionRenderTimer = undefined;
   }
 
-  private markCurrentPermissionPanel(): void {
-    if (this.#ptyPermissionRenderTimer) clearTimeout(this.#ptyPermissionRenderTimer);
-    this.#ptyPermissionRenderTimer = undefined;
-    this.#ptyPermissionRender = "";
-    this.#ptyPermissionMarkerTail = "";
-    this.#ptyPermissionPanelVisible = true;
+  private async writePermissionKeys(keys: string, deadline: number): Promise<boolean> {
+    if (!await this.waitForPermissionPanel(deadline)) {
+      if (this.#cancelled) return false;
+      throw new AgyCliError(
+        "agy permission panel did not settle before applying the permission response",
+        [this.config.agyPath],
+        null,
+        this.#ptyOutput
+      );
+    }
+
+    const down = "\x1b[B";
+    let offset = 0;
+    while (keys.startsWith(down, offset)) {
+      const renderCount = this.#ptyPermissionMarkerCount;
+      this.#pty?.write(down);
+      if (!await this.waitForPermissionRenderAfter(renderCount, deadline)) {
+        if (this.#cancelled) return false;
+        throw new AgyCliError(
+          "agy permission panel did not redraw after menu navigation",
+          [this.config.agyPath],
+          null,
+          this.#ptyOutput
+        );
+      }
+      offset += down.length;
+    }
+    this.#pty?.write(keys.slice(offset));
+    return true;
+  }
+
+  private async waitForPermissionPanel(deadline: number): Promise<boolean> {
+    const expires = Math.min(deadline, Date.now() + PERMISSION_REDRAW_TIMEOUT_MS);
+    while (
+      (!this.#ptyPermissionPanelVisible || this.#ptyPermissionRenderTimer !== undefined) &&
+      !this.#cancelled &&
+      Date.now() < expires
+    ) {
+      await sleep(5);
+    }
+    return this.#ptyPermissionPanelVisible && this.#ptyPermissionRenderTimer === undefined;
+  }
+
+  private async waitForPermissionRenderAfter(renderCount: number, deadline: number): Promise<boolean> {
+    const expires = Math.min(deadline, Date.now() + PERMISSION_REDRAW_TIMEOUT_MS);
+    while (this.#ptyPermissionMarkerCount <= renderCount && !this.#cancelled && Date.now() < expires) {
+      await sleep(5);
+    }
+    return this.#ptyPermissionMarkerCount > renderCount;
   }
 
   async close(): Promise<void> {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { conversationSnapshot } from "./db/scan.js";
 import { defaultInstallBinDir, ensureAgyInstalled } from "./installer.js";
 import { StreamPoller } from "./db/streaming.js";
+import type { StepRow } from "./db/types.js";
 import { revertEditToolCall } from "./edit/revert.js";
 import {
   primeEditReadThroughClient,
@@ -29,6 +30,15 @@ const POLL_INTERVAL_MS = 200;
 /** Trailing polls after the process exits, to catch rows flushed right around exit. */
 const TRAILING_POLL_ATTEMPTS = 3;
 const TRAILING_POLL_DELAY_MS = 100;
+
+/** Signature of the permission decision agy has recorded for a gated step.
+ *  A re-armed status-9 prompt (e.g. the next segment of `a && b`) changes this
+ *  even though the toolCallId is unchanged, letting the turn loop tell a fresh
+ *  decision apart from a redundant re-emission of the same still-pending one. */
+function permissionSignature(row: StepRow): string {
+  const p = row.permission;
+  return p ? `${p.kind}\u0000${p.value}\u0000${p.decision}` : "none";
+}
 
 export type SpawnedProcess = ChildProcessWithoutNullStreams;
 
@@ -327,14 +337,14 @@ export class AgyCliSession {
     // edit once agy applies it, at which point it's still worth routing
     // through the client's fs write-through so its native review UI tracks
     // the edit — that's a second, independent decision for the same id.
-    const requestedGate = new Set<string>();
+    const requestedGate = new Map<string, string>();
     const requestedEditReview = new Set<string>();
     // ids that already went through the live gate above, so a later
     // completed-edit sighting shouldn't trigger a second (redundant) local
     // permission prompt if the client has no fs write-through.
     const gatedIds = new Set<string>();
     const activePtyExit = this.#ptyExit!;
-    const deadline = Date.now() + parsePrintTimeoutMs(this.config.printTimeout);
+    let deadline = Date.now() + parsePrintTimeoutMs(this.config.printTimeout);
     let candidateRevision = -1;
     let seenRevision = -1;
     // A newly spawned TUI first draws its initial idle prompt, then draws
@@ -356,9 +366,22 @@ export class AgyCliSession {
         for (const interaction of poller.takePending()) {
           const toolCall = interaction.update;
           const id = String((toolCall as unknown as { toolCallId?: string }).toolCallId);
-          const seen = interaction.blocked ? requestedGate : requestedEditReview;
-          if (seen.has(id)) continue;
-          seen.add(id);
+          if (interaction.blocked) {
+            // A single agy run_command step can gate several sequential
+            // decisions (each segment of `a && b`, a sandbox escalation, ...):
+            // agy records the just-resolved decision in the row's permission
+            // column but keeps the step at status 9 until every decision is
+            // answered. Dedup on that permission signature (not the toolCallId
+            // alone) so a re-armed prompt on the same step is forwarded again
+            // instead of being swallowed — swallowing it hangs the turn until
+            // the deadline.
+            const signature = permissionSignature(interaction.row);
+            if (requestedGate.get(id) === signature) continue;
+            requestedGate.set(id, signature);
+          } else {
+            if (requestedEditReview.has(id)) continue;
+            requestedEditReview.add(id);
+          }
 
           if (interaction.blocked) {
             if (!canBridgeInteraction(interaction.toolName, toolCall)) {
@@ -386,10 +409,11 @@ export class AgyCliSession {
               }
             }
 
+            const startPermission = Date.now();
             const choice = await this.raceTurnCallback(
-              onPermission(toolCall, { toolName: interaction.toolName }),
-              deadline
+              onPermission(toolCall, { toolName: interaction.toolName })
             );
+            deadline += Date.now() - startPermission;
             if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
 
             const keys = interactionKeys(choice, interaction.toolName, toolCall);
@@ -434,10 +458,11 @@ export class AgyCliSession {
           // Genuinely ungated (no live agy gate ever asked) and no client
           // write-through available — offer local review: keep is a no-op,
           // reject restores prior text.
+          const startPermission = Date.now();
           const choice = await this.raceTurnCallback(
-            onPermission(toolCall, { toolName: interaction.toolName }),
-            deadline
+            onPermission(toolCall, { toolName: interaction.toolName })
           );
+          deadline += Date.now() - startPermission;
           if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
           if (normalizePermissionChoice(choice) === "agy-reject-once") revertEditToolCall(toolCall);
         }
@@ -460,11 +485,14 @@ export class AgyCliSession {
     }
   }
 
-  private async raceTurnCallback<T>(callback: Promise<T>, deadline: number): Promise<T | "cancelled"> {
+  private async raceTurnCallback<T>(callback: Promise<T>, deadline?: number): Promise<T | "cancelled"> {
     const guarded = callback.catch((error) => {
       if (this.#cancelled) return "cancelled" as const;
       throw error;
     });
+    if (deadline === undefined) {
+      return await Promise.race([guarded, this.#cancelWait.then(() => "cancelled" as const)]);
+    }
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timedOut = new Promise<never>((_, reject) => {
       timer = setTimeout(() => reject(new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final idle marker was observed`, [this.config.agyPath], null, this.#ptyOutput)), Math.max(0, deadline - Date.now()));

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -941,7 +941,7 @@ function unsupportedInteractionDetail(toolName: string, toolCall: SessionUpdate)
     if (ask.options.length === 0) return "ask_question has no selectable options";
     return "ask_question could not be bridged";
   }
-  return "only standard permission menus (run_command, file read/write) and single-select ask_question can be bridged safely";
+  return "only standard permission menus (run_command, ask_permission, file read/write) and single-select ask_question can be bridged safely";
 }
 
 function isAgyStatusLine(line: string): boolean {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -344,7 +344,8 @@ export class AgyCliSession {
     // permission prompt if the client has no fs write-through.
     const gatedIds = new Set<string>();
     const activePtyExit = this.#ptyExit!;
-    let deadline = Date.now() + parsePrintTimeoutMs(this.config.printTimeout);
+    const timeoutMs = parsePrintTimeoutMs(this.config.printTimeout);
+    let deadline = Date.now() + timeoutMs;
     let candidateRevision = -1;
     let seenRevision = -1;
     // A newly spawned TUI first draws its initial idle prompt, then draws
@@ -355,12 +356,13 @@ export class AgyCliSession {
     try {
       while (true) {
         if (this.#cancelled) break;
-        if (Date.now() >= deadline) throw new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final idle marker was observed`, [this.config.agyPath], null, this.#ptyOutput);
         const updates = poller.poll();
         if (poller.revision !== seenRevision) {
           seenRevision = poller.revision;
           candidateRevision = poller.turnCompleteCandidate ? poller.revision : -1;
+          deadline = Date.now() + timeoutMs;
         } else if (!poller.turnCompleteCandidate) candidateRevision = -1;
+        if (Date.now() >= deadline) throw new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final idle marker was observed`, [this.config.agyPath], null, this.#ptyOutput);
         for (const update of updates) await this.raceTurnCallback(onUpdate(update), deadline);
         if (this.#cancelled) break;
         for (const interaction of poller.takePending()) {
@@ -409,11 +411,10 @@ export class AgyCliSession {
               }
             }
 
-            const startPermission = Date.now();
             const choice = await this.raceTurnCallback(
               onPermission(toolCall, { toolName: interaction.toolName })
             );
-            deadline += Date.now() - startPermission;
+            deadline = Date.now() + timeoutMs;
             if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
 
             const keys = interactionKeys(choice, interaction.toolName, toolCall);
@@ -458,11 +459,10 @@ export class AgyCliSession {
           // Genuinely ungated (no live agy gate ever asked) and no client
           // write-through available — offer local review: keep is a no-op,
           // reject restores prior text.
-          const startPermission = Date.now();
           const choice = await this.raceTurnCallback(
             onPermission(toolCall, { toolName: interaction.toolName })
           );
-          deadline += Date.now() - startPermission;
+          deadline = Date.now() + timeoutMs;
           if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
           if (normalizePermissionChoice(choice) === "agy-reject-once") revertEditToolCall(toolCall);
         }

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -149,6 +149,8 @@ export class AgyCliSession {
   #ptyOutput = "";
   #ptyIdleMarkerCount = 0;
   #ptyIdleMatchTail = "";
+  #ptyPermissionMarkerCount = 0;
+  #ptyPermissionMatchTail = "";
   #ptyConfig = "";
   #cancelled = false;
   #cancelTurn: (() => void) | undefined;
@@ -315,15 +317,29 @@ export class AgyCliSession {
       this.#ptyOutput = "";
       this.#ptyIdleMarkerCount = 0;
       this.#ptyIdleMatchTail = "";
+      this.#ptyPermissionMarkerCount = 0;
+      this.#ptyPermissionMatchTail = "";
       this.#pty.onData((data) => {
-        const marker = "for shortcuts";
+        const idleMarker = "for shortcuts";
         const searchable = this.#ptyIdleMatchTail + data;
         let offset = 0;
-        while ((offset = searchable.indexOf(marker, offset)) >= 0) {
+        while ((offset = searchable.indexOf(idleMarker, offset)) >= 0) {
           this.#ptyIdleMarkerCount++;
-          offset += marker.length;
+          offset += idleMarker.length;
         }
-        this.#ptyIdleMatchTail = searchable.slice(-(marker.length - 1));
+        this.#ptyIdleMatchTail = searchable.slice(-(idleMarker.length - 1));
+
+        // Unlike the generic footer above, this text is specific to agy's
+        // standard permission panel. Its redraw is the only observable new
+        // occurrence when two consecutive gates write identical DB bytes.
+        const permissionMarker = "Yes, and always allow";
+        const permissionSearchable = this.#ptyPermissionMatchTail + data;
+        offset = 0;
+        while ((offset = permissionSearchable.indexOf(permissionMarker, offset)) >= 0) {
+          this.#ptyPermissionMarkerCount++;
+          offset += permissionMarker.length;
+        }
+        this.#ptyPermissionMatchTail = permissionSearchable.slice(-(permissionMarker.length - 1));
         this.#ptyOutput = (this.#ptyOutput + data).slice(-16_384);
       });
       this.#ptyExit = new Promise((resolve) => this.#pty!.onExit(resolve));
@@ -338,6 +354,8 @@ export class AgyCliSession {
     // through the client's fs write-through so its native review UI tracks
     // the edit — that's a second, independent decision for the same id.
     const requestedGate = new Map<string, string>();
+    const gateMarkerCounts = new Map<string, number>();
+    const rearmedGateIds = new Set<string>();
     const requestedEditReview = new Set<string>();
     // ids that already went through the live gate above, so a later
     // completed-edit sighting shouldn't trigger a second (redundant) local
@@ -365,6 +383,14 @@ export class AgyCliSession {
         if (Date.now() >= deadline) throw new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final idle marker was observed`, [this.config.agyPath], null, this.#ptyOutput);
         for (const update of updates) await this.raceTurnCallback(onUpdate(update), deadline);
         if (this.#cancelled) break;
+        for (const [id, markerCount] of gateMarkerCounts) {
+          if (this.#ptyPermissionMarkerCount <= markerCount) continue;
+          // An identical permission gate can redraw without changing the DB at
+          // all. Use the permission-panel-specific redraw as its occurrence
+          // signal; a normal progress or completion redraw must not requeue it.
+          if (poller.requeuePending(id)) rearmedGateIds.add(id);
+          gateMarkerCounts.delete(id);
+        }
         for (const interaction of poller.takePending()) {
           const toolCall = interaction.update;
           const id = String((toolCall as unknown as { toolCallId?: string }).toolCallId);
@@ -373,12 +399,11 @@ export class AgyCliSession {
             // decisions (each segment of `a && b`, a sandbox escalation, ...):
             // agy records the just-resolved decision in the row's permission
             // column but keeps the step at status 9 until every decision is
-            // answered. Dedup on that permission signature (not the toolCallId
-            // alone) so a re-armed prompt on the same step is forwarded again
-            // instead of being swallowed — swallowing it hangs the turn until
-            // the deadline.
+            // answered. Content dedup handles ordinary DB updates; a
+            // permission-panel redraw explicitly re-arms an identical gate.
             const signature = permissionSignature(interaction.row);
-            if (requestedGate.get(id) === signature) continue;
+            const rearmed = rearmedGateIds.delete(id);
+            if (!rearmed && requestedGate.get(id) === signature) continue;
             requestedGate.set(id, signature);
           } else {
             if (requestedEditReview.has(id)) continue;
@@ -427,6 +452,7 @@ export class AgyCliSession {
               );
             }
             this.#pty?.write(keys);
+            gateMarkerCounts.set(id, this.#ptyPermissionMarkerCount);
             // An idle marker printed before the decision cannot mean that the
             // approved/rejected command has finished.
             requiredIdleMarkerCount = this.#ptyIdleMarkerCount + 1;

--- a/src/agy/db/database.ts
+++ b/src/agy/db/database.ts
@@ -112,19 +112,22 @@ export class ConversationDb {
    * not take down the whole poll loop. Since it's dropped, not consumed, its
    * idx isn't advanced past, so it's naturally retried on the next read once
    * the write settles. */
-  readAfter(afterStepIdx: number): StepRow[] {
+  readAfter(afterStepIdx: number): StepRow[] & { hasDecodeError: boolean } {
     const rows = this.stmt.all(afterStepIdx) as RawRow[];
-    const out: StepRow[] = [];
+    const out: StepRow[] & { hasDecodeError?: boolean } = [];
+    let hasDecodeError = false;
     for (const r of rows) {
       try {
         out.push(rowToStep(r));
       } catch (error) {
+        hasDecodeError = true;
         console.error(
           `[agy-acp] WARN: failed to decode step ${r.idx}, skipping: ${(error as Error).message}`
         );
       }
     }
-    return out;
+    out.hasDecodeError = hasDecodeError;
+    return out as StepRow[] & { hasDecodeError: boolean };
   }
 
   /** SQLite generation counter, incremented when another connection commits. */

--- a/src/agy/db/step-payload.ts
+++ b/src/agy/db/step-payload.ts
@@ -26,10 +26,14 @@ export interface ToolRun {
   titleSecondary: string;
 }
 
-/** Fields 1-5 of a grep/web-search hit; likely file path, line, matched text, etc. */
+/** One grep_search hit. Field numbers are reverse-engineered from real agy
+ *  conversation DBs: 1 = relative file path, 2 = line number (varint),
+ *  3 = matched line text, 4 = absolute file path. Field 5 has not been
+ *  observed populated in real DBs but is retained for forward-compat. */
 export interface SearchHit {
   field1: string;
-  field2: string;
+  /** 1-based line number of the match, or 0 when agy omits it. */
+  field2: number;
   field3: string;
   field4: string;
   field5: string;
@@ -164,9 +168,9 @@ function decodeToolRun(bytes: Uint8Array): ToolRun {
 }
 
 function decodeSearchHit(bytes: Uint8Array): SearchHit {
-  return readMessage(bytes, { field1: "", field2: "", field3: "", field4: "", field5: "" }, {
+  return readMessage(bytes, { field1: "", field2: 0, field3: "", field4: "", field5: "" }, {
     1: (m, r) => (m.field1 = r.string()),
-    2: (m, r) => (m.field2 = r.string()),
+    2: (m, r) => (m.field2 = readInt(r)),
     3: (m, r) => (m.field3 = r.string()),
     4: (m, r) => (m.field4 = r.string()),
     5: (m, r) => (m.field5 = r.string())

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -48,6 +48,7 @@ export class StreamPoller {
   private failedDataVersion: number | null = null;
   private failedDataVersionAttempts = 0;
   private rowSnapshot = "";
+  private readonly activePending = new Map<string, PendingInteraction>();
 
   constructor(private readonly opts: StreamOptions) {
     this.boundId = opts.conversationId;
@@ -75,6 +76,15 @@ export class StreamPoller {
     const pending = this._pending;
     this._pending = [];
     return pending;
+  }
+
+  /** Requeue a still-blocked interaction when the TUI redraws an identical gate. */
+  requeuePending(id: string): boolean {
+    if (this._pending.some((interaction) => toolCallId(interaction.row) === id)) return false;
+    const interaction = this.activePending.get(id);
+    if (!interaction) return false;
+    this._pending.push(interaction);
+    return true;
   }
 
   get turnCompleteCandidate(): boolean {
@@ -137,22 +147,28 @@ export class StreamPoller {
       latest !== undefined && (latest.status === 3 || latest.status === 6 || latest.status === 7);
     const updates = this.translator.translate(rows);
     const rowsByToolCallId = new Map(rows.map((row) => [toolCallId(row), row]));
+    const blockedIds = new Set(rows.filter((row) => row.status === 9).map(toolCallId));
+    for (const id of this.activePending.keys()) {
+      if (!blockedIds.has(id)) this.activePending.delete(id);
+    }
     for (const update of updates) {
       const raw = update as unknown as { status?: string; kind?: string; toolCallId?: string };
       const blocked = raw.status === "pending";
+      const id = String(raw.toolCallId);
       // Edits that complete without ever pausing (accept-edits / skip-permissions)
       // still get offered for review — see PendingInteraction.blocked.
       const completedEdit = raw.kind === "edit" && raw.status === "completed";
       if (!blocked && !completedEdit) continue;
-      const id = String(raw.toolCallId);
       const row = rowsByToolCallId.get(id);
       if (row) {
-        this._pending.push({
+        const interaction = {
           update,
           row,
           toolName: row.stepPayload.toolRun?.call?.namePrimary || row.stepPayload.toolRun?.call?.nameSecondary || "unknown",
           blocked
-        });
+        };
+        if (blocked) this.activePending.set(id, interaction);
+        this._pending.push(interaction);
       }
     }
     return updates;

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -96,9 +96,11 @@ export class StreamPoller {
 
     const dataVersion = this.db.dataVersion();
     if (this.dataVersion === dataVersion) return [];
-    this.dataVersion = dataVersion;
 
     const rows = this.db.readAfter(this.opts.baseStepIdx);
+    if (!rows.hasDecodeError) {
+      this.dataVersion = dataVersion;
+    }
     const snapshot = JSON.stringify(rows.map((row) => [
       row.idx,
       row.stepType,

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -144,7 +144,9 @@ export class StreamPoller {
     // Gate completion on "latest step is terminal" (3/6/7), not "latest is an
     // agent message", so those turns don't hang until the deadline.
     this._latestStepTerminal =
-      latest !== undefined && (latest.status === 3 || latest.status === 6 || latest.status === 7);
+      !rows.hasDecodeError &&
+      latest !== undefined &&
+      (latest.status === 3 || latest.status === 6 || latest.status === 7);
     const updates = this.translator.translate(rows);
     const rowsByToolCallId = new Map(rows.map((row) => [toolCallId(row), row]));
     const blockedIds = new Set(rows.filter((row) => row.status === 9).map(toolCallId));

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -42,7 +42,7 @@ export class StreamPoller {
   private _pending: PendingInteraction[] = [];
   private _hasRows = false;
   private _busy = false;
-  private _latestAgentComplete = false;
+  private _latestStepTerminal = false;
   private _revision = 0;
   private dataVersion: number | null = null;
   private rowSnapshot = "";
@@ -76,7 +76,7 @@ export class StreamPoller {
   }
 
   get turnCompleteCandidate(): boolean {
-    return this._hasRows && !this._busy && this._latestAgentComplete;
+    return this._hasRows && !this._busy && this._latestStepTerminal;
   }
 
   /** Increments whenever the observed rows (including growing in-place rows) change. */
@@ -114,7 +114,13 @@ export class StreamPoller {
     this._hasRows = rows.length > 0;
     this._busy = rows.some((row) => row.status !== 3 && row.status !== 6 && row.status !== 7);
     const latest = rows.at(-1);
-    this._latestAgentComplete = latest?.stepType === 15 && latest.status === 3;
+    // A turn can end on a completed agent message, but also on a terminal tool
+    // step with no trailing message — most notably a denied/failed command
+    // (status 7), after which agy returns to idle without emitting more text.
+    // Gate completion on "latest step is terminal" (3/6/7), not "latest is an
+    // agent message", so those turns don't hang until the deadline.
+    this._latestStepTerminal =
+      latest !== undefined && (latest.status === 3 || latest.status === 6 || latest.status === 7);
     const updates = this.translator.translate(rows);
     const rowsByToolCallId = new Map(rows.map((row) => [toolCallId(row), row]));
     for (const update of updates) {

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -45,6 +45,8 @@ export class StreamPoller {
   private _latestStepTerminal = false;
   private _revision = 0;
   private dataVersion: number | null = null;
+  private failedDataVersion: number | null = null;
+  private failedDataVersionAttempts = 0;
   private rowSnapshot = "";
 
   constructor(private readonly opts: StreamOptions) {
@@ -100,6 +102,18 @@ export class StreamPoller {
     const rows = this.db.readAfter(this.opts.baseStepIdx);
     if (!rows.hasDecodeError) {
       this.dataVersion = dataVersion;
+      this.failedDataVersion = null;
+      this.failedDataVersionAttempts = 0;
+    } else {
+      if (this.failedDataVersion === dataVersion) {
+        this.failedDataVersionAttempts++;
+      } else {
+        this.failedDataVersion = dataVersion;
+        this.failedDataVersionAttempts = 1;
+      }
+      if (this.failedDataVersionAttempts >= 3) {
+        this.dataVersion = dataVersion;
+      }
     }
     const snapshot = JSON.stringify(rows.map((row) => [
       row.idx,

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -321,11 +321,14 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   return toolCallUpdate({ stepRow, title, kind: "read", content, locations });
 }
 
-/** Render grep hits (generic field1..field5) into readable, pipe-joined lines. */
+/** Render grep hits into readable, pipe-joined lines. `field2` is the line
+ *  number (a varint in the wire format); coerce it to a string for display. */
 function renderHits(hits: SearchHit[] | undefined): string {
   if (!hits || hits.length === 0) return "";
   return hits
-    .map((h) => [h.field1, h.field2, h.field3, h.field4, h.field5].filter((v) => v.trim().length > 0).join(" | "))
+    .map((h) => [h.field1, h.field2 ? String(h.field2) : "", h.field3, h.field4, h.field5]
+      .filter((v) => v.trim().length > 0)
+      .join(" | "))
     .filter((line) => line.length > 0)
     .join("\n");
 }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -882,11 +882,14 @@ describe("session modes and config option sync", () => {
         value: "accept-edits"
       });
       expect(modeViaConfig.configOptions[0].currentValue).toBe("accept-edits");
-      expect(updates).toEqual([
-        { sessionUpdate: "current_mode_update", currentModeId: "accept-edits" }
-      ]);
-      // Config UI already received the full list in the set_config_option response.
-      expect(updates.some((u) => u.sessionUpdate === "config_option_update")).toBe(false);
+      // ACP transition: both legacy current_mode_update and out-of-band config_option_update are sent.
+      expect(updates).toEqual(
+        expect.arrayContaining([
+          { sessionUpdate: "current_mode_update", currentModeId: "accept-edits" },
+          expect.objectContaining({ sessionUpdate: "config_option_update" })
+        ])
+      );
+      expect(updates.some((u) => u.sessionUpdate === "current_mode_update")).toBe(true);
 
       updates.length = 0;
       await connection.agent.request(methods.agent.session.setMode, {
@@ -1018,7 +1021,13 @@ describe("available_commands_update and slash commands", () => {
       });
       expect(updates).toEqual(
         expect.arrayContaining([
-          { sessionUpdate: "current_mode_update", currentModeId: "accept-edits" }
+          { sessionUpdate: "current_mode_update", currentModeId: "accept-edits" },
+          expect.objectContaining({
+            sessionUpdate: "config_option_update",
+            configOptions: expect.arrayContaining([
+              expect.objectContaining({ id: "mode", currentValue: "accept-edits" })
+            ])
+          })
         ])
       );
     } finally {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1503,7 +1503,7 @@ const TEST_MODELS_OUTPUT =
   "gemini-3.5-flash-medium\ngemini-3.5-flash-high\nclaude-opus-4-6-thinking\nclaude-sonnet-4-6\n";
 
 function printModeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
-  return { ...overrides, AGY_ACP_INTERACTIVE_PERMISSIONS: "0" };
+  return { AGY_ACP_MODEL_CACHE: "0", ...overrides, AGY_ACP_INTERACTIVE_PERMISSIONS: "0" };
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -385,6 +385,74 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("re-forwards identical sequential permission prompts on the same step without swallowing", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "identical-gates");
+      insertStep(db, pendingToolRow("run_command", '{"CommandLine":"echo x && echo x && echo x"}'));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    let calls = 0;
+    const result = session.prompt("go", async () => {}, async () => {
+      calls++;
+      const { default: Database } = await import("better-sqlite3");
+      const db = new Database(path.join(dir, "identical-gates.db"));
+      if (calls < 3) {
+        // Same permission details (kind, value, decision) on consecutive gates
+        db.prepare("UPDATE steps SET permissions = ? WHERE idx = 1").run(
+          Buffer.from(encodePermissions({ kind: "command", value: "echo x", decision: 1 }))
+        );
+        setTimeout(() => pty.emitData("Yes, and always allow"), 10);
+      } else {
+        db.prepare("UPDATE steps SET permissions = ?, status = 3 WHERE idx = 1").run(
+          Buffer.from(encodePermissions({ kind: "command", value: "echo x", decision: 1 }))
+        );
+        insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+        setTimeout(() => pty.emitData("? for shortcuts"), 50);
+      }
+      db.close();
+      return "agy-allow-once";
+    });
+    expect((await result).stopReason).toBe("end_turn");
+    expect(calls).toBe(3);
+    expect(pty.writes).toEqual(["\r", "\r", "\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not treat a normal TUI footer redraw as another permission gate", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "gate-footer-redraw");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    let calls = 0;
+    const result = session.prompt("go", async () => {}, async () => {
+      calls++;
+      // A generic repaint may arrive while the DB still shows the answered
+      // status-9 row. It must not replay the cached permission interaction.
+      setTimeout(() => pty.emitData("? for shortcuts"), 10);
+      setTimeout(async () => {
+        const { default: Database } = await import("better-sqlite3");
+        const db = new Database(path.join(dir, "gate-footer-redraw.db"));
+        updateStep(db, 1, { status: 3 });
+        insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+        db.close();
+        pty.emitData("? for shortcuts");
+      }, 300);
+      return "agy-allow-once";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    expect(calls).toBe(1);
+    expect(pty.writes).toEqual(["\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("bridges single-select ask_question via PTY option keys", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const askInput = JSON.stringify({

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -403,7 +403,10 @@ describe("permission bridge", () => {
         db.prepare("UPDATE steps SET permissions = ? WHERE idx = 1").run(
           Buffer.from(encodePermissions({ kind: "command", value: "echo x", decision: 1 }))
         );
-        setTimeout(() => pty.emitData("Yes, and always allow"), 10);
+        setTimeout(() => pty.emitData("executing approved segment"), 5);
+        // Split the marker across settled PTY bursts to exercise tail matching.
+        setTimeout(() => pty.emitData("Yes, and "), 50);
+        setTimeout(() => pty.emitData("always allow"), 80);
       } else {
         db.prepare("UPDATE steps SET permissions = ?, status = 3 WHERE idx = 1").run(
           Buffer.from(encodePermissions({ kind: "command", value: "echo x", decision: 1 }))
@@ -421,7 +424,7 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("does not treat a normal TUI footer redraw as another permission gate", async () => {
+  it("does not treat arrow-key redraws of the same permission panel as another gate", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {
       const db = createConversationDb(dir, "gate-footer-redraw");
@@ -432,9 +435,10 @@ describe("permission bridge", () => {
     let calls = 0;
     const result = session.prompt("go", async () => {}, async () => {
       calls++;
-      // A generic repaint may arrive while the DB still shows the answered
-      // status-9 row. It must not replay the cached permission interaction.
-      setTimeout(() => pty.emitData("? for shortcuts"), 10);
+      // The initial panel render can still be inside the debounce window when
+      // the ACP response resolves. The Down key then redraws that same panel.
+      pty.emitData("Yes, and always allow");
+      setTimeout(() => pty.emitData("Yes, and always allow"), 10);
       setTimeout(async () => {
         const { default: Database } = await import("better-sqlite3");
         const db = new Database(path.join(dir, "gate-footer-redraw.db"));
@@ -443,12 +447,12 @@ describe("permission bridge", () => {
         db.close();
         pty.emitData("? for shortcuts");
       }, 300);
-      return "agy-allow-once";
+      return "agy-allow-conversation";
     });
 
     expect((await result).stopReason).toBe("end_turn");
     expect(calls).toBe(1);
-    expect(pty.writes).toEqual(["\r"]);
+    expect(pty.writes).toEqual(["\x1b[B\r"]);
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -318,6 +318,36 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("re-arms turn deadline to full printTimeout after permission prompt resolves", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "permission-rearm");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    // Set a short printTimeout of 300ms
+    const session = interactiveSession(dir, pty, "300ms");
+
+    const result = session.prompt("go", async () => {}, async () => {
+      // User takes 150ms to answer permission prompt
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      // After permission resolves, agy executes command which completes 250ms later (total 400ms wall clock)
+      setTimeout(async () => {
+        const { default: Database } = await import("better-sqlite3");
+        const db = new Database(path.join(dir, "permission-rearm.db"));
+        updateStep(db, 1, { status: 3 });
+        insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+        db.close();
+        pty.emitData("? for shortcuts");
+      }, 250);
+      return "agy-allow-once";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("re-forwards a re-armed status-9 prompt on the same run_command step (compound `a && b`)", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -162,6 +162,35 @@ describe("permission bridge", () => {
     expect(interactionKeys("agy-q-skip", "ask_question", askCall)).toBe("\x1b");
   });
 
+  it("bridges agy's ask_permission sandbox-bypass request as a command-style menu", () => {
+    // agy 1.1.7 gates sandbox bypass (run a command / read a file outside the
+    // sandbox) through a status-9 `ask_permission` step whose TUI menu is the
+    // same 4-row layout as run_command. It must be bridged, not thrown on.
+    const askPermission = {
+      sessionUpdate: "tool_call" as const,
+      toolCallId: "ap1",
+      title: "Permission request for git directory",
+      kind: "other" as const,
+      status: "pending" as const,
+      rawInput: {
+        Action: "read_file",
+        Reason: "To allow git inside the sandbox to read the parent repository",
+        Target: "/repo/.git",
+        toolAction: "Requesting read access to the git parent repository"
+      }
+    };
+    expect(isBridgeablePermissionTool("ask_permission")).toBe(true);
+    expect(canBridgeInteraction("ask_permission", askPermission)).toBe(true);
+    expect(permissionOptions(askPermission, "ask_permission")).toEqual([
+      { optionId: "agy-allow-once", kind: "allow_once", name: "Yes" },
+      { optionId: "agy-allow-conversation", kind: "allow_always", name: "Yes, and always allow '/repo/.git' in this conversation" },
+      { optionId: "agy-allow-settings", kind: "allow_always", name: "Yes, and always allow '/repo/.git' (Persist to settings.json)" },
+      { optionId: "agy-reject-once", kind: "reject_once", name: "No" }
+    ]);
+    expect(interactionKeys("agy-allow-once", "ask_permission", askPermission)).toBe("\r");
+    expect(interactionKeys("agy-reject-once", "ask_permission", askPermission)).toBe("\x1b[B\x1b[B\x1b[B\r");
+  });
+
   for (const [choice, keys] of [
     ["agy-allow-once", "\r"],
     ["agy-allow-conversation", "\x1b[B\r"],

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -198,6 +198,29 @@ describe("permission bridge", () => {
     });
   }
 
+  it("completes a turn that ends on a denied command (failed tool step, no trailing message)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "denied");
+      insertStep(db, pendingToolRow("run_command", '{"CommandLine":"git reset"}'));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const result = session.prompt("go", async () => {}, async () => {
+      // agy records the denial and fails the command; the turn ends here with
+      // NO trailing agent-text step (matches real denied-command turns).
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "denied.db"));
+      updateStep(db, 1, { status: 7 });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 50);
+      return "agy-reject-once";
+    });
+    expect((await result).stopReason).toBe("end_turn");
+    expect(pty.writes).toEqual(["\x1b[B\x1b[B\x1b[B\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("accepts an idle marker emitted after the DB write but before the next poll", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -27,7 +27,7 @@ import {
   permissionOptions
 } from "../src/acp/tool-calls/permissions.js";
 import { createConversationDb, insertStep, updateStep } from "./fixtures/conversation-db.js";
-import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
+import { encodePermissions, encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 
 /** Collects updates via the `onUpdate` callback `AgyCliSession.prompt` takes. */
 async function collectUpdates(
@@ -265,17 +265,64 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("times out while the ACP client leaves a permission request unanswered", async () => {
+  it("pauses turn deadline while waiting for ACP client permission response and extends turn timeout", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {
       const db = createConversationDb(dir, "permission-timeout");
       insertStep(db, pendingToolRow("run_command"));
       db.close();
     });
-    const session = interactiveSession(dir, pty, "30ms");
+    const session = interactiveSession(dir, pty, "2s");
 
-    await expect(session.prompt("go", async () => {}, () => new Promise(() => {}))).rejects.toThrow(/timed out after 30ms/);
-    expect(pty.killed).toBe(true);
+    const result = session.prompt("go", async () => {}, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "permission-timeout.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 450);
+      return "agy-allow-once";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("re-forwards a re-armed status-9 prompt on the same run_command step (compound `a && b`)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "compound");
+      insertStep(db, pendingToolRow("run_command", '{"CommandLine":"git status && git log"}'));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    let calls = 0;
+    const result = session.prompt("go", async () => {}, async () => {
+      calls++;
+      const { default: Database } = await import("better-sqlite3");
+      const db = new Database(path.join(dir, "compound.db"));
+      if (calls === 1) {
+        // agy granted segment 1 (`git status`) but stays at status 9 awaiting
+        // the next segment's decision — a re-armed prompt on the same step.
+        db.prepare("UPDATE steps SET permissions = ? WHERE idx = 1").run(
+          Buffer.from(encodePermissions({ kind: "command", value: "git status", decision: 1 }))
+        );
+      } else {
+        db.prepare("UPDATE steps SET permissions = ?, status = 3 WHERE idx = 1").run(
+          Buffer.from(encodePermissions({ kind: "unsandboxed", value: "git log", decision: 1 }))
+        );
+        insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+        setTimeout(() => pty.emitData("? for shortcuts"), 50);
+      }
+      db.close();
+      return "agy-allow-conversation";
+    });
+    expect((await result).stopReason).toBe("end_turn");
+    // Both segments gated — the second must not be swallowed by toolCallId dedup.
+    expect(calls).toBe(2);
+    expect(pty.writes).toEqual(["\x1b[B\r", "\x1b[B\r"]);
+    await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -220,7 +220,7 @@ describe("permission bridge", () => {
       expect(resolved).toBe(false);
       expect((await result).stopReason).toBe("end_turn");
       expect(calls).toBe(1);
-      expect(pty.writes).toEqual([keys]);
+      expect(pty.writes).toEqual(permissionWriteChunks(keys));
       await session.close();
       expect(pty.killed).toBe(true);
       fs.rmSync(dir, { recursive: true, force: true });
@@ -241,11 +241,11 @@ describe("permission bridge", () => {
       const db = new (await import("better-sqlite3")).default(path.join(dir, "denied.db"));
       updateStep(db, 1, { status: 7 });
       db.close();
-      setTimeout(() => pty.emitData("? for shortcuts"), 50);
+      setTimeout(() => pty.emitData("? for shortcuts"), 150);
       return "agy-reject-once";
     });
     expect((await result).stopReason).toBe("end_turn");
-    expect(pty.writes).toEqual(["\x1b[B\x1b[B\x1b[B\r"]);
+    expect(pty.writes).toEqual(["\x1b[B", "\x1b[B", "\x1b[B", "\r"]);
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -380,7 +380,7 @@ describe("permission bridge", () => {
     expect((await result).stopReason).toBe("end_turn");
     // Both segments gated — the second must not be swallowed by toolCallId dedup.
     expect(calls).toBe(2);
-    expect(pty.writes).toEqual(["\x1b[B\r", "\x1b[B\r"]);
+    expect(pty.writes).toEqual(["\x1b[B", "\r", "\x1b[B", "\r"]);
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -403,10 +403,12 @@ describe("permission bridge", () => {
         db.prepare("UPDATE steps SET permissions = ? WHERE idx = 1").run(
           Buffer.from(encodePermissions({ kind: "command", value: "echo x", decision: 1 }))
         );
-        setTimeout(() => pty.emitData("executing approved segment"), 5);
-        // Split the marker across settled PTY bursts to exercise tail matching.
-        setTimeout(() => pty.emitData("Yes, and "), 50);
-        setTimeout(() => pty.emitData("always allow"), 80);
+        // The next identical panel arrives immediately, with no marker-free
+        // render or debounce gap between permission generations.
+        setTimeout(() => {
+          pty.emitData("Yes, and ");
+          pty.emitData("always allow");
+        }, 5);
       } else {
         db.prepare("UPDATE steps SET permissions = ?, status = 3 WHERE idx = 1").run(
           Buffer.from(encodePermissions({ kind: "command", value: "echo x", decision: 1 }))
@@ -452,7 +454,7 @@ describe("permission bridge", () => {
 
     expect((await result).stopReason).toBe("end_turn");
     expect(calls).toBe(1);
-    expect(pty.writes).toEqual(["\x1b[B\r"]);
+    expect(pty.writes).toEqual(["\x1b[B", "\r"]);
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -749,6 +751,42 @@ describe("permission bridge", () => {
     await session.cancel();
     expect((await pending).stopReason).toBe("cancelled");
     expect(pty.writes).toEqual([]);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("cancels cleanly while waiting for the permission panel to render", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "cancel-panel-wait");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    pty.emitPermissionPanelOnStart = false;
+    const session = interactiveSession(dir, pty);
+    const pending = session.prompt("go", async () => {}, async () => "agy-allow-once");
+    setTimeout(() => void session.cancel(), 50);
+
+    expect((await pending).stopReason).toBe("cancelled");
+    expect(pty.writes).toEqual([]);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("cancels cleanly while waiting for an arrow-key panel redraw", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "cancel-panel-redraw");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    pty.emitArrowRedraw = false;
+    const session = interactiveSession(dir, pty);
+    const pending = session.prompt("go", async () => {}, async () => {
+      setTimeout(() => void session.cancel(), 50);
+      return "agy-allow-conversation";
+    });
+
+    expect((await pending).stopReason).toBe("cancelled");
+    expect(pty.writes).toEqual(["\x1b[B"]);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
@@ -1097,17 +1135,38 @@ function interactiveSession(dir: string, pty: FakePty, printTimeout = "3s") {
   } as PtyFactory);
 }
 
+function permissionWriteChunks(keys: string): string[] {
+  const chunks: string[] = [];
+  const down = "\x1b[B";
+  let offset = 0;
+  while (keys.startsWith(down, offset)) {
+    chunks.push(down);
+    offset += down.length;
+  }
+  if (offset < keys.length) chunks.push(keys.slice(offset));
+  return chunks;
+}
+
 class FakePty implements PtyProcess {
   writes: string[] = [];
   killed = false;
+  emitPermissionPanelOnStart = true;
+  emitArrowRedraw = true;
   private dataListeners: Array<(data: string) => void> = [];
   private exitListeners: Array<(event: { exitCode: number }) => void> = [];
   constructor(private readonly onSpawn?: () => void) {}
   start() {
     this.onSpawn?.();
-    queueMicrotask(() => this.emitData("? for shortcuts"));
+    queueMicrotask(() => this.emitData(
+      this.emitPermissionPanelOnStart ? "? for shortcuts\nYes, and always allow" : "? for shortcuts"
+    ));
   }
-  write(data: string) { this.writes.push(data); }
+  write(data: string) {
+    this.writes.push(data);
+    if (data === "\x1b[B" && this.emitArrowRedraw) {
+      setTimeout(() => this.emitData("Yes, and always allow"), 0);
+    }
+  }
   kill() { this.killed = true; for (const listener of this.exitListeners) listener({ exitCode: 0 }); }
   onData(listener: (data: string) => void) { this.dataListeners.push(listener); return { dispose() {} }; }
   onExit(listener: (event: { exitCode: number }) => void) { this.exitListeners.push(listener); return { dispose() {} }; }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -884,6 +884,56 @@ describe("StreamPoller", () => {
     poller.close();
     db.close();
   });
+
+  it("does not complete from a terminal row when a trailing row failed to decode", () => {
+    const db = createConversationDb(dir, "conv-terminal-before-corrupt");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({ callId: "cmd-1", namePrimary: "run_command", rawInputJson: "{}" })
+        })
+      })
+    });
+    db.prepare("INSERT INTO steps (idx, step_type, status, step_payload) VALUES (?, ?, ?, ?)").run(
+      2, 15, 3, Buffer.from([0x0a, 0xff])
+    );
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-terminal-before-corrupt",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    // The surviving terminal tool must not hide the undecodable final row,
+    // including after retries for this data version have been bounded.
+    expect(poller.poll()).toHaveLength(1);
+    expect(poller.turnCompleteCandidate).toBe(false);
+    expect(poller.poll()).toEqual([]);
+    expect(poller.turnCompleteCandidate).toBe(false);
+    expect(poller.poll()).toEqual([]);
+    expect(poller.turnCompleteCandidate).toBe(false);
+    expect(poller.poll()).toEqual([]);
+    expect(poller.turnCompleteCandidate).toBe(false);
+
+    db.prepare("UPDATE steps SET step_payload = ? WHERE idx = 2").run(
+      Buffer.from(encodeStepPayload({ agentText: "done" }))
+    );
+    expect(poller.poll()).toEqual([
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "2",
+        content: { type: "text", text: "done" }
+      }
+    ]);
+    expect(poller.turnCompleteCandidate).toBe(true);
+
+    poller.close();
+    db.close();
+  });
 });
 
 describe("ReplayCache", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -770,6 +770,54 @@ describe("StreamPoller", () => {
     db.close();
   });
 
+  it("queues a new pending interaction when an identical status-9 gate is re-armed", () => {
+    const db = createConversationDb(dir, "conv-identical-gate");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 9,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "cmd-identical",
+            namePrimary: "run_command",
+            rawInputJson: '{"CommandLine":"echo x && echo x"}'
+          })
+        })
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-identical-gate",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    expect(poller.poll()).toHaveLength(1);
+    expect(poller.takePending()).toHaveLength(1);
+
+    const permission = Buffer.from(encodePermissions({ kind: "command", value: "echo x", decision: 1 }));
+    db.prepare("UPDATE steps SET permissions = ? WHERE idx = 1").run(permission);
+    expect(poller.poll()).toHaveLength(1);
+    expect(poller.takePending()).toHaveLength(1);
+
+    // SQLite does not advance data_version when the exact same bytes are
+    // written, so the poll itself has no occurrence to report.
+    db.prepare("UPDATE steps SET permissions = ? WHERE idx = 1").run(permission);
+    expect(poller.poll()).toEqual([]);
+    expect(poller.takePending()).toEqual([]);
+
+    // The TUI redraw supplies the generation in this case. Requeueing remains
+    // deduplicated until the queued occurrence is consumed.
+    poller.requeuePending("cmd-identical");
+    poller.requeuePending("cmd-identical");
+    expect(poller.takePending()).toHaveLength(1);
+
+    poller.close();
+    db.close();
+  });
+
   it("retries readAfter on next poll if a torn read decode error occurs", () => {
     const db = createConversationDb(dir, "conv-torn-read");
     // Insert step with invalid/corrupt blob payload to simulate premature EOF

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -11,7 +11,9 @@ import { createConversationDb, insertStep, updateStep, updateStepPayload } from 
 import {
   encodeAgentText,
   encodeCommandResult,
+  encodeGrepSearchResult,
   encodePermissions,
+  encodeSearchHit,
   encodeStepPayload,
   encodeToolCall,
   encodeToolRun,
@@ -325,6 +327,59 @@ describe("Translator", () => {
     const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
     expect(body).toContain("Query: agy acp adapter");
     expect(body).toContain("https://www.google.com/search");
+  });
+
+  it("decodes grep_search hits whose field 2 is a varint line number (regression for issue #12)", () => {
+    const db = createConversationDb(dir, "conv-grep");
+    insertStep(db, {
+      idx: 1,
+      stepType: 7,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "g-1",
+            namePrimary: "grep_search",
+            rawInputJson: '{"Query":"Unreleased","SearchPath":"/repo"}'
+          })
+        }),
+        grepSearch: encodeGrepSearchResult({
+          query: "Unreleased",
+          cwdUri: "file:///repo",
+          hits: [
+            encodeSearchHit({ field1: "CHANGELOG.md", field2: 9, field3: "## [Unreleased]", field4: "/repo/CHANGELOG.md" }),
+            encodeSearchHit({ field1: "CHANGELOG.md", field2: 42, field3: "## [Unreleased] - 2026-01-01", field4: "/repo/CHANGELOG.md" })
+          ]
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-grep")!;
+    const rows = conn.readAfter(-1);
+    conn.close();
+
+    // The whole point of the regression: this must not throw "premature EOF"
+    // / "cant skip wire type 6/7", and the hits must carry line numbers.
+    expect(rows).toHaveLength(1);
+    const hits = rows[0].stepPayload.grepSearch?.hits ?? [];
+    expect(hits).toHaveLength(2);
+    expect(hits[0].field1).toBe("CHANGELOG.md");
+    expect(hits[0].field2).toBe(9);
+    expect(hits[0].field3).toBe("## [Unreleased]");
+    expect(hits[0].field4).toBe("/repo/CHANGELOG.md");
+    expect(hits[1].field2).toBe(42);
+
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const conn2 = ConversationDb.open(dir, "conv-grep")!;
+    const updates = translator.translate(conn2.readAfter(-1));
+    conn2.close();
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as { kind: string; content?: Array<{ content?: { text?: string } }> };
+    expect(update.kind).toBe("search");
+    const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
+    expect(body).toContain("CHANGELOG.md | 9 | ## [Unreleased]");
+    expect(body).toContain("CHANGELOG.md | 42 | ## [Unreleased] - 2026-01-01");
   });
 
   it("surfaces fetched URL body from field 40", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -808,6 +808,34 @@ describe("StreamPoller", () => {
     poller.close();
     db.close();
   });
+
+  it("bounds retries on a permanently undecodable row after 3 failed attempts on the same dataVersion", () => {
+    const db = createConversationDb(dir, "conv-perm-corrupt");
+    // Insert step with invalid/corrupt blob payload to simulate permanently corrupted data
+    db.prepare("INSERT INTO steps (idx, step_type, status, step_payload) VALUES (?, ?, ?, ?)").run(
+      1, 21, 9, Buffer.from([0x08, 0xff])
+    );
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-perm-corrupt",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    // Poll 1: encounters decode error (attempt 1), returns []
+    expect(poller.poll()).toEqual([]);
+    // Poll 2: encounters decode error (attempt 2), returns []
+    expect(poller.poll()).toEqual([]);
+    // Poll 3: encounters decode error (attempt 3), caches dataVersion and returns []
+    expect(poller.poll()).toEqual([]);
+
+    // Poll 4: because dataVersion is now cached, poll() immediately returns [] without re-reading/re-logging
+    expect(poller.poll()).toEqual([]);
+
+    poller.close();
+    db.close();
+  });
 });
 
 describe("ReplayCache", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -714,6 +714,45 @@ describe("StreamPoller", () => {
     poller.close();
     db.close();
   });
+
+  it("retries readAfter on next poll if a torn read decode error occurs", () => {
+    const db = createConversationDb(dir, "conv-torn-read");
+    // Insert step with invalid/corrupt blob payload to simulate premature EOF
+    db.prepare("INSERT INTO steps (idx, step_type, status, step_payload) VALUES (?, ?, ?, ?)").run(
+      1, 21, 9, Buffer.from([0x08, 0xff])
+    );
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-torn-read",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    // First poll encounters decode error, so dataVersion is NOT cached
+    expect(poller.poll()).toEqual([]);
+
+    // Now update row 1 to hold a valid payload (simulating completed write)
+    db.prepare("UPDATE steps SET step_payload = ? WHERE idx = 1").run(
+      Buffer.from(encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "cmd-1",
+            namePrimary: "run_command",
+            rawInputJson: '{"CommandLine":"ls"}'
+          })
+        })
+      }))
+    );
+
+    // Second poll retries reading and successfully decodes the step
+    const updates = poller.poll();
+    expect(updates).toHaveLength(1);
+    expect((updates[0] as { sessionUpdate: string }).sessionUpdate).toBe("tool_call");
+
+    poller.close();
+    db.close();
+  });
 });
 
 describe("ReplayCache", () => {

--- a/tests/fixtures/step-encoder.ts
+++ b/tests/fixtures/step-encoder.ts
@@ -115,6 +115,40 @@ export function encodeViewFileResult(result: {
   return w.finish();
 }
 
+/** grep_search hit: 1 = relative path, 2 = line number (varint),
+ *  3 = matched text, 4 = absolute path. Mirrors `decodeSearchHit`. */
+export function encodeSearchHit(hit: {
+  field1?: string;
+  field2?: number;
+  field3?: string;
+  field4?: string;
+}): Uint8Array {
+  const w = new BinaryWriter();
+  if (hit.field1) w.tag(1, 2).string(hit.field1);
+  if (hit.field2 !== undefined) w.tag(2, 0).int64(hit.field2);
+  if (hit.field3) w.tag(3, 2).string(hit.field3);
+  if (hit.field4) w.tag(4, 2).string(hit.field4);
+  return w.finish();
+}
+
+export function encodeGrepSearchResult(result: {
+  query?: string;
+  includeGlob?: string;
+  textOutput?: string;
+  hits?: Uint8Array[];
+  shellCommand?: string;
+  cwdUri?: string;
+}): Uint8Array {
+  const w = new BinaryWriter();
+  if (result.query) w.tag(1, 2).string(result.query);
+  if (result.includeGlob) w.tag(2, 2).string(result.includeGlob);
+  if (result.textOutput) w.tag(3, 2).string(result.textOutput);
+  for (const hit of result.hits ?? []) submessage(w, 4, hit);
+  if (result.shellCommand) w.tag(10, 2).string(result.shellCommand);
+  if (result.cwdUri) w.tag(11, 2).string(result.cwdUri);
+  return w.finish();
+}
+
 /** permissions column: { 2: { 1: { 1: kind, 2: value }, 2: decision } }. */
 export function encodePermissions(info: { kind?: string; value?: string; decision?: number }): Uint8Array {
   const target = new BinaryWriter();
@@ -137,11 +171,13 @@ export function encodeStepPayload(opts: {
   userPrompt?: string;
   commandResult?: Uint8Array;
   viewFile?: Uint8Array;
+  grepSearch?: Uint8Array;
   webSearch?: Uint8Array;
   urlContent?: Uint8Array;
 }): Uint8Array {
   const w = new BinaryWriter();
   if (opts.toolRun) submessage(w, 5, opts.toolRun);
+  if (opts.grepSearch) submessage(w, 13, opts.grepSearch);
   if (opts.viewFile) submessage(w, 14, opts.viewFile);
   if (opts.userPrompt !== undefined) submessage(w, 19, encodeUserPrompt(opts.userPrompt));
   if (opts.agentText !== undefined) submessage(w, 20, encodeAgentText(opts.agentText));

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -14,6 +14,15 @@ describe("isPlanFile", () => {
     expect(isPlanFile("/repo/docs/plan.md")).toBe(false);
     expect(isPlanFile("/Users/me/.gemini/antigravity-cli/brain/x/note.txt")).toBe(false);
   });
+
+  it("rejects non-plan brain markdown artifacts", () => {
+    const base = "/Users/me/.gemini/antigravity-cli/brain/abc";
+    expect(isPlanFile(`${base}/code_review_v0.3.3.md`)).toBe(false);
+    expect(isPlanFile(`${base}/walkthrough.md`)).toBe(false);
+    expect(isPlanFile(`${base}/task.md`)).toBe(false);
+    expect(isPlanFile(`${base}/content.md`)).toBe(false);
+    expect(isPlanFile(`${base}/comparison_analysis.md`)).toBe(false);
+  });
 });
 
 describe("parsePlanEntries", () => {


### PR DESCRIPTION
## Overview
This release implements crucial protocol bridging bug fixes, robustness improvements, and compatibility updates for ACP integration, specifically wrapping `agy` version 1.1.7+.

### Fixed & Improved
* **Timeout & Hang Fixes (#10)**: Turn deadlines are now paused and extended while waiting for `session/request_permission` responses, preventing slow responses from triggering the 5-minute timeout. The deadline is also correctly re-armed on prompt resolution.
* **Compound Command Execution**: Dedupes status-9 prompts on the permission signature rather than the tool-call ID. This allows compound command steps (e.g., `a && b`) to successfully re-forward prompts rather than hanging.
* **Terminal Steps Turn Completion**: Turn completion now correctly registers turns ending on terminal tool steps with status 7 (denied/failed commands) when no trailing agent message exists.
* **Torn Read Recovery**: `StreamPoller` now retries reading torn/partially-written SQLite rows on the next poll instead of permanently skipping updates.
* **`ask_permission` Bridging**: Added bridging support for the new `ask_permission` sandbox-bypass interaction introduced in `agy` 1.1.7.
* **`grep_search` Protobuf Alignment (#12, #18)**: Fixed a parser misalignment by decoding hit field 2 (line number) as a varint instead of a string, resolving premature EOF errors and dropped search steps.
* **Prose Markdown Artifact Filtering**: Limited `isPlanFile` logic to `implementation_plan.md` and `plan.md`, preventing non-plan prose files in the brain directory from being parsed as plan entries.
* **Dual-Sync Mode Updates (#15)**: Emits both `current_mode_update` and `config_option_update` on all mode changing pathways. This ensures clients like Zed stay in sync and avoids `Parse error: missing field configOptions` exceptions.
