### PR TITLE
Fix 5m turn timeouts on active DB progress and prompt resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 - Pause the turn deadline while awaiting a `session/request_permission`
   response and extend it by the wait duration, so slow or multi-prompt answers
   no longer hit the 5m timeout. (#10)
+- Re-arm turn deadline on prompt resolution and reset deadline on active DB progress, fixing 5m turn timeouts.
 - Re-forward re-armed status-9 prompts on the same `run_command` step (each
   segment of `a && b`), deduping on the permission signature instead of the
   tool-call id, so compound commands no longer hang.

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -344,7 +344,8 @@ export class AgyCliSession {
     // permission prompt if the client has no fs write-through.
     const gatedIds = new Set<string>();
     const activePtyExit = this.#ptyExit!;
-    let deadline = Date.now() + parsePrintTimeoutMs(this.config.printTimeout);
+    const timeoutMs = parsePrintTimeoutMs(this.config.printTimeout);
+    let deadline = Date.now() + timeoutMs;
     let candidateRevision = -1;
     let seenRevision = -1;
     // A newly spawned TUI first draws its initial idle prompt, then draws
@@ -355,12 +356,13 @@ export class AgyCliSession {
     try {
       while (true) {
         if (this.#cancelled) break;
-        if (Date.now() >= deadline) throw new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final idle marker was observed`, [this.config.agyPath], null, this.#ptyOutput);
         const updates = poller.poll();
         if (poller.revision !== seenRevision) {
           seenRevision = poller.revision;
           candidateRevision = poller.turnCompleteCandidate ? poller.revision : -1;
+          deadline = Date.now() + timeoutMs;
         } else if (!poller.turnCompleteCandidate) candidateRevision = -1;
+        if (Date.now() >= deadline) throw new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final idle marker was observed`, [this.config.agyPath], null, this.#ptyOutput);
         for (const update of updates) await this.raceTurnCallback(onUpdate(update), deadline);
         if (this.#cancelled) break;
         for (const interaction of poller.takePending()) {
@@ -409,11 +411,10 @@ export class AgyCliSession {
               }
             }
 
-            const startPermission = Date.now();
             const choice = await this.raceTurnCallback(
               onPermission(toolCall, { toolName: interaction.toolName })
             );
-            deadline += Date.now() - startPermission;
+            deadline = Date.now() + timeoutMs;
             if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
 
             const keys = interactionKeys(choice, interaction.toolName, toolCall);
@@ -458,11 +459,10 @@ export class AgyCliSession {
           // Genuinely ungated (no live agy gate ever asked) and no client
           // write-through available — offer local review: keep is a no-op,
           // reject restores prior text.
-          const startPermission = Date.now();
           const choice = await this.raceTurnCallback(
             onPermission(toolCall, { toolName: interaction.toolName })
           );
-          deadline += Date.now() - startPermission;
+          deadline = Date.now() + timeoutMs;
           if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
           if (normalizePermissionChoice(choice) === "agy-reject-once") revertEditToolCall(toolCall);
         }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1503,7 +1503,7 @@ const TEST_MODELS_OUTPUT =
   "gemini-3.5-flash-medium\ngemini-3.5-flash-high\nclaude-opus-4-6-thinking\nclaude-sonnet-4-6\n";
 
 function printModeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
-  return { ...overrides, AGY_ACP_INTERACTIVE_PERMISSIONS: "0" };
+  return { AGY_ACP_MODEL_CACHE: "0", ...overrides, AGY_ACP_INTERACTIVE_PERMISSIONS: "0" };
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -318,6 +318,36 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("re-arms turn deadline to full printTimeout after permission prompt resolves", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "permission-rearm");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    // Set a short printTimeout of 300ms
+    const session = interactiveSession(dir, pty, "300ms");
+
+    const result = session.prompt("go", async () => {}, async () => {
+      // User takes 150ms to answer permission prompt
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      // After permission resolves, agy executes command which completes 250ms later (total 400ms wall clock)
+      setTimeout(async () => {
+        const { default: Database } = await import("better-sqlite3");
+        const db = new Database(path.join(dir, "permission-rearm.db"));
+        updateStep(db, 1, { status: 3 });
+        insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+        db.close();
+        pty.emitData("? for shortcuts");
+      }, 250);
+      return "agy-allow-once";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("re-forwards a re-armed status-9 prompt on the same run_command step (compound `a && b`)", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {


### PR DESCRIPTION
## Summary
This PR addresses 5m turn timeouts that occurred when agy made active progress or when user permission responses resolved:
1. **Re-arm turn deadline on DB progress & permission prompt resolution**: Reset turn deadline window whenever SQLite DB step poller sees progress or when a permission prompt resolves.

## Commits
- Re-arm turn deadline on DB progress and prompt resolution
- Update CHANGELOG and test env for turn deadline fixes

## Test Plan
- Ran unit test suite (`npx vitest run`) - 141/141 tests passing.
- New unit test added in `tests/cli.test.ts` verifying deadline re-arming after permission resolution.