### PR TITLE
Fix duplicated command and output in run_command tool updates

### DIFF
--- a/src/acp/terminal/index.ts
+++ b/src/acp/terminal/index.ts
@@ -88,8 +88,10 @@ export function executeTerminalMeta(update: V1SessionUpdate): ExecuteTerminalMet
 
   let output = typeof rawOutput.output === "string" ? rawOutput.output : undefined;
   if (output == null && texts.length >= 1) {
-    // executeUpdate: content[0] is output when present (or content[1] in legacy updates).
-    output = texts[texts.length - 1];
+    // executeUpdate puts stdout as content[0]; auxiliary blocks (permission,
+    // error, task) are appended after by toolCallUpdate, so always pick the
+    // first text block for the terminal output.
+    output = texts[0];
   }
 
   const exitCode = typeof rawOutput.exitCode === "number" ? rawOutput.exitCode : undefined;

--- a/src/acp/terminal/index.ts
+++ b/src/acp/terminal/index.ts
@@ -87,11 +87,9 @@ export function executeTerminalMeta(update: V1SessionUpdate): ExecuteTerminalMet
   const cwd = pickString(rawInput, "Cwd", "cwd");
 
   let output = typeof rawOutput.output === "string" ? rawOutput.output : undefined;
-  if (output == null && texts.length >= 2) {
-    // executeUpdate: content[0] = command, content[1] = output when both present.
-    output = texts[1];
-  } else if (output == null && texts.length === 1 && command && texts[0] !== command) {
-    output = texts[0];
+  if (output == null && texts.length >= 1) {
+    // executeUpdate: content[0] is output when present (or content[1] in legacy updates).
+    output = texts[texts.length - 1];
   }
 
   const exitCode = typeof rawOutput.exitCode === "number" ? rawOutput.exitCode : undefined;

--- a/src/acp/terminal/index.ts
+++ b/src/acp/terminal/index.ts
@@ -81,7 +81,6 @@ export function executeTerminalMeta(update: V1SessionUpdate): ExecuteTerminalMet
 
   const command =
     pickString(rawInput, "CommandLine", "commandLine", "command") ??
-    (texts[0]?.includes("\n") ? texts[0].split("\n")[0] : texts[0]) ??
     (typeof raw.title === "string" && raw.title.trim() ? raw.title.trim() : undefined);
 
   const cwd = pickString(rawInput, "Cwd", "cwd");

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -388,7 +388,6 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     firstLine || asStr(toolRun?.titlePrimary)?.trim() || asStr(toolRun?.titleSecondary)?.trim() || "Command Execution";
 
   const content: Record<string, unknown>[] = [];
-  if (command?.trim()) content.push(codeBlock(command));
   // Prefer decoded field-28 output over empty; surface when non-empty.
   const output = commandResult?.output ?? "";
   if (output.trim()) content.push(codeBlock(output));
@@ -407,11 +406,10 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     locations
   }) as SessionUpdate & { rawOutput?: unknown };
 
-  // Attach structured exit/output when present (without dropping error rawOutput).
+  // Attach structured exit when present (without dropping error rawOutput).
   if (commandResult && !stepRow.error) {
     update.rawOutput = {
-      exitCode: commandResult.exitCode,
-      ...(output.trim() ? { output } : {})
+      exitCode: commandResult.exitCode
     };
   }
   return update;

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -408,7 +408,18 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     kind: "execute",
     content,
     locations
-  }) as SessionUpdate & { rawOutput?: unknown };
+  }) as SessionUpdate & { rawOutput?: unknown; rawInput?: unknown };
+
+  // When the command was recovered from commandResult.command (rawInputJson
+  // missing/malformed), inject it into rawInput so downstream consumers
+  // (e.g. executeTerminalMeta) can always find it via rawInput.CommandLine
+  // instead of falling back to title (which may now be toolSummary).
+  if (command && update.rawInput != null && typeof update.rawInput === "object" && !Array.isArray(update.rawInput)) {
+    const input = update.rawInput as Record<string, unknown>;
+    if (!input.CommandLine && !input.commandLine && !input.command) {
+      input.CommandLine = command;
+    }
+  }
 
   // Attach structured exit when present (without dropping error rawOutput).
   if (commandResult && !stepRow.error) {

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -383,9 +383,13 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     asStr(pick(rawInput, "CommandLine", "commandLine", "command")) ??
     (commandResult?.command?.trim() ? commandResult.command : null);
   const firstLine = (command?.split("\n")[0] ?? "").trim();
-
+  const summary = asStr(pick(rawInput, "toolSummary", "ToolSummary", "toolAction", "ToolAction"))?.trim();
   const title =
-    firstLine || asStr(toolRun?.titlePrimary)?.trim() || asStr(toolRun?.titleSecondary)?.trim() || "Command Execution";
+    summary ||
+    firstLine ||
+    asStr(toolRun?.titlePrimary)?.trim() ||
+    asStr(toolRun?.titleSecondary)?.trim() ||
+    "Command Execution";
 
   const content: Record<string, unknown>[] = [];
   // Prefer decoded field-28 output over empty; surface when non-empty.

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -284,7 +284,7 @@ describe("Translator", () => {
     };
     expect(update.sessionUpdate).toBe("tool_call");
     expect(update.kind).toBe("execute");
-    expect(update.rawOutput).toMatchObject({ exitCode: 0, output: "README.md\n" });
+    expect(update.rawOutput).toMatchObject({ exitCode: 0 });
     const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
     expect(body).toContain("README.md");
   });


### PR DESCRIPTION
### Changes
- Remove redundant `codeBlock(command)` from `content` array in `executeUpdate`.
- Keep `rawOutput` limited to structured status (`{ exitCode }`) to prevent duplicate rendering of execution output text in ACP v1 clients (like Zed).
- Prioritize `rawInput.toolSummary` and `toolAction` for `ACP.title` when available.
- Update `executeTerminalMeta` in `src/acp/terminal/index.ts` to handle single-block output extraction.