### PR TITLE
Fix session/update errors referencing evicted terminals

### DIFF
--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -87,22 +87,28 @@ function mapToolStatusForV1(status: unknown): unknown {
 
 function withTerminalContent(
   content: unknown,
-  terminalId: string
+  terminalId: string,
+  status?: string
 ): Record<string, unknown>[] {
-  const terminalBlock = { type: "terminal", terminalId };
-  if (!Array.isArray(content) || content.length === 0) {
-    return [terminalBlock];
+  const items = Array.isArray(content)
+    ? (content.map((item) =>
+        item && typeof item === "object"
+          ? toolContentToV2(item as Record<string, unknown>)
+          : item
+      ) as Record<string, unknown>[])
+    : [];
+
+  const nonTerminalItems = items.filter((item) => item?.type !== "terminal");
+
+  // Terminal content blocks are display-only embeds for active executions.
+  // Once execution completes, fails, or cancels (or before it starts in pending),
+  // drop the terminal block so clients like Zed that evict finished terminals
+  // don't throw "Terminal with id ... not found" errors when processing tool_call_update.
+  if (status === "in_progress") {
+    return [{ type: "terminal", terminalId }, ...nonTerminalItems];
   }
-  const mapped = content.map((item) =>
-    item && typeof item === "object"
-      ? toolContentToV2(item as Record<string, unknown>)
-      : item
-  ) as Record<string, unknown>[];
-  // Avoid duplicating the same terminal embed on progressive updates.
-  if (mapped.some((item) => item?.type === "terminal" && item.terminalId === terminalId)) {
-    return mapped;
-  }
-  return [terminalBlock, ...mapped];
+
+  return nonTerminalItems;
 }
 
 /** Identity cast for the v1 wire format (builders already emit v1 shapes). */
@@ -217,7 +223,7 @@ export function expandSessionUpdateToV2(update: V1SessionUpdate): V2SessionUpdat
   }
 
   const tool = sessionUpdateToV2(update) as unknown as Record<string, unknown>;
-  tool.content = withTerminalContent(tool.content, meta.terminalId);
+  tool.content = withTerminalContent(tool.content, meta.terminalId, meta.status);
 
   return [terminalUpdateForExecute(meta), tool as V2SessionUpdate];
 }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1478,11 +1478,11 @@ describe("ACP v2 (experimental draft)", () => {
       status: "completed"
     });
     const content = expanded[1].content as Array<Record<string, unknown>>;
-    expect(content[0]).toEqual({ type: "terminal", terminalId });
+    expect(content.some((item) => item.type === "terminal")).toBe(false);
     expect(content.some((item) => item.type === "content")).toBe(true);
   });
 
-  it("emits in-progress terminal_update without exitStatus", () => {
+  it("emits in-progress terminal_update with terminal content block", () => {
     const update = {
       sessionUpdate: "tool_call",
       toolCallId: "cmd-2",
@@ -1505,6 +1505,32 @@ describe("ACP v2 (experimental draft)", () => {
       status: "in_progress",
       content: [{ type: "terminal", terminalId: terminalIdForToolCall("cmd-2") }]
     });
+  });
+
+  it("drops terminal content block on completed or failed status to prevent lookup of evicted terminals", () => {
+    const updateWithTerminal = {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "cmd-3",
+      title: "git status",
+      kind: "execute",
+      status: "completed",
+      rawInput: { CommandLine: "git status" },
+      content: [
+        { type: "terminal", terminalId: terminalIdForToolCall("cmd-3") },
+        { type: "content", content: { type: "text", text: "working tree clean" } }
+      ]
+    } as SessionUpdate;
+
+    const [terminal, tool] = expandSessionUpdateToV2(updateWithTerminal) as Array<Record<string, unknown>>;
+    expect(terminal).toMatchObject({
+      sessionUpdate: "terminal_update",
+      terminalId: terminalIdForToolCall("cmd-3"),
+      command: "git status",
+      exitStatus: {}
+    });
+    expect(tool.content).toEqual([
+      { type: "content", content: { type: "text", text: "working tree clean" } }
+    ]);
   });
 });
 


### PR DESCRIPTION
Fixes #13

## Summary
Drops `{ type: "terminal", terminalId }` content blocks from ACP `tool_call_update` messages when execute tool calls are not `in_progress`.

## Cause
When expanding execute tool calls into draft-v2 updates, `withTerminalContent()` previously attached `{ type: "terminal", terminalId }` to every `tool_call_update`, even after execution finished (`completed`/`failed`/`cancelled`). When Zed (`agent_servers::acp`) evicted finished terminals from its terminal registry, subsequent `tool_call_update` messages caused Zed to log `-32603 Internal error: Terminal with id <id> not found`.

## Fix
- Updated `withTerminalContent()` in `src/acp/session/update-wire.ts` to only attach terminal content blocks while `status === "in_progress"`.
- Added unit tests in `tests/acp-server.test.ts`.