### PR TITLE
Fix agent_thought_chunk not emitted for step 15 thought payload

### DIFF
--- a/src/agy/db/step-payload.ts
+++ b/src/agy/db/step-payload.ts
@@ -83,6 +83,7 @@ export interface UserPrompt {
 
 export interface AgentText {
   text: string;
+  thought?: string;
 }
 
 export interface TitleUpdate {
@@ -240,7 +241,10 @@ function decodeUserPrompt(bytes: Uint8Array): UserPrompt {
 }
 
 function decodeAgentText(bytes: Uint8Array): AgentText {
-  return readMessage(bytes, { text: "" }, { 1: (m, r) => (m.text = r.string()) });
+  return readMessage<AgentText>(bytes, { text: "" }, {
+    1: (m, r) => (m.text = r.string()),
+    3: (m, r) => (m.thought = r.string())
+  });
 }
 
 function decodeTitleUpdate(bytes: Uint8Array): TitleUpdate {

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -231,6 +231,11 @@ export class Translator {
   }
 
   private handleAgentText(row: StepRow, out: SessionUpdate[]): void {
+    const thought = row.stepPayload.agentText?.thought;
+    if (thought) {
+      this.emitThought(thoughtChunk(thought, `agent-thought-${row.idx}`), out);
+    }
+
     const text = row.stepPayload.agentText?.text ?? "";
     const messageId = String(row.idx);
 

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -30,11 +30,32 @@ export type { UpdateContext } from "./tool-call-updates.js";
  */
 const LIFECYCLE_STEP_TYPES = new Set<number>([90, 98, 101]);
 
-/** Step type 15 — a chunk of the agent's streamed text message. */
-function agentUpdate(stepRow: StepRow): SessionUpdate {
+/** Step type 15 — a chunk of the agent's streamed text message (+ optional thought). */
+function agentUpdate(stepRow: StepRow): SessionUpdate | SessionUpdate[] {
+  const text = stepRow.stepPayload.agentText?.text ?? "";
+  const thought = stepRow.stepPayload.agentText?.thought;
+
+  if (thought) {
+    const updates: SessionUpdate[] = [
+      {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: thought },
+        messageId: `agent-thought-${stepRow.idx}`
+      }
+    ];
+    if (text) {
+      updates.push({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text },
+        messageId: String(stepRow.idx)
+      });
+    }
+    return updates;
+  }
+
   return {
     sessionUpdate: "agent_message_chunk",
-    content: { type: "text", text: stepRow.stepPayload.agentText?.text ?? "" },
+    content: { type: "text", text },
     messageId: String(stepRow.idx)
   };
 }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -58,6 +58,27 @@ describe("ConversationDb", () => {
     expect(rows[1].stepPayload.toolRun?.call?.rawInputJson).toBe('{"CommandLine":"echo hi"}');
   });
 
+  it("decodes agent text thinking/reasoning (tag 3) from step type 15 payload", () => {
+    const db = createConversationDb(dir, "conv-thought-step15");
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      stepPayload: encodeStepPayload({
+        agentText: { text: "Result: 309524", thought: "Calculating 347 * 892..." }
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-thought-step15");
+    expect(conn).not.toBeNull();
+    const rows = conn!.readAfter(0);
+    conn!.close();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].stepPayload.agentText?.text).toBe("Result: 309524");
+    expect(rows[0].stepPayload.agentText?.thought).toBe("Calculating 347 * 892...");
+  });
+
   it("returns null for a missing conversation", () => {
     expect(ConversationDb.open(dir, "does-not-exist")).toBeNull();
   });
@@ -243,6 +264,56 @@ describe("Translator", () => {
     const conn2 = ConversationDb.open(dir, "conv-thought")!;
     expect(translator.translate(conn2.readAfter(0))).toHaveLength(0);
     conn2.close();
+  });
+
+  it("emits agent_thought_chunk for step type 15 carrying thought payload in streaming and replay modes", () => {
+    const db = createConversationDb(dir, "conv-agent-thought-stream");
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      stepPayload: encodeStepPayload({
+        agentText: { text: "Final output", thought: "Thinking deeply..." }
+      })
+    });
+    db.close();
+
+    // Stream mode
+    const connStream = ConversationDb.open(dir, "conv-agent-thought-stream")!;
+    const streamTranslator = new Translator({ mode: "stream", skipNarration: false });
+    const streamUpdates = streamTranslator.translate(connStream.readAfter(0));
+    connStream.close();
+
+    expect(streamUpdates).toEqual([
+      {
+        sessionUpdate: "agent_thought_chunk",
+        messageId: "agent-thought-1",
+        content: { type: "text", text: "Thinking deeply..." }
+      },
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "Final output" }
+      }
+    ]);
+
+    // Replay mode
+    const connReplay = ConversationDb.open(dir, "conv-agent-thought-stream")!;
+    const replayTranslator = new Translator({ mode: "replay", skipNarration: false });
+    const replayUpdates = replayTranslator.translate(connReplay.readAfter(-1));
+    connReplay.close();
+
+    expect(replayUpdates).toEqual([
+      {
+        sessionUpdate: "agent_thought_chunk",
+        messageId: "agent-thought-1",
+        content: { type: "text", text: "Thinking deeply..." }
+      },
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "Final output" }
+      }
+    ]);
   });
 
 

--- a/tests/fixtures/step-encoder.ts
+++ b/tests/fixtures/step-encoder.ts
@@ -30,9 +30,15 @@ export function encodeToolRun(run: { call?: Uint8Array; titlePrimary?: string; t
   return w.finish();
 }
 
-export function encodeAgentText(text: string): Uint8Array {
+export function encodeAgentText(text: string | { text?: string; thought?: string }, thought?: string): Uint8Array {
   const w = new BinaryWriter();
-  w.tag(1, 2).string(text);
+  if (typeof text === "object") {
+    if (text.text) w.tag(1, 2).string(text.text);
+    if (text.thought) w.tag(3, 2).string(text.thought);
+  } else {
+    if (text) w.tag(1, 2).string(text);
+    if (thought) w.tag(3, 2).string(thought);
+  }
   return w.finish();
 }
 
@@ -166,7 +172,7 @@ export function encodePermissions(info: { kind?: string; value?: string; decisio
 
 export function encodeStepPayload(opts: {
   toolRun?: Uint8Array;
-  agentText?: string;
+  agentText?: string | { text?: string; thought?: string } | Uint8Array;
   titleUpdate?: string;
   userPrompt?: string;
   commandResult?: Uint8Array;
@@ -180,7 +186,10 @@ export function encodeStepPayload(opts: {
   if (opts.grepSearch) submessage(w, 13, opts.grepSearch);
   if (opts.viewFile) submessage(w, 14, opts.viewFile);
   if (opts.userPrompt !== undefined) submessage(w, 19, encodeUserPrompt(opts.userPrompt));
-  if (opts.agentText !== undefined) submessage(w, 20, encodeAgentText(opts.agentText));
+  if (opts.agentText !== undefined) {
+    const bytes = opts.agentText instanceof Uint8Array ? opts.agentText : encodeAgentText(opts.agentText);
+    submessage(w, 20, bytes);
+  }
   if (opts.commandResult) submessage(w, 28, opts.commandResult);
   if (opts.titleUpdate !== undefined) submessage(w, 30, encodeTitleUpdate(opts.titleUpdate));
   if (opts.urlContent) submessage(w, 40, opts.urlContent);


### PR DESCRIPTION
Fixes #20

## Summary
Decodes and emits `agent_thought_chunk` updates when step type 15 (`AgentText`) payload contains thinking/reasoning text (Protobuf tag 3).

## Cause / Background
Step payload decoder in `src/agy/db/step-payload.ts` previously only decoded Protobuf tag 1 (`text`), completely ignoring tag 3 (`thought`). Because tag 3 was ignored, agent reasoning/thinking chunks were never forwarded to ACP clients (e.g. Zed).

## Fix
- **Decoder**: Updated `AgentText` interface and `decodeAgentText` in `src/agy/db/step-payload.ts` to decode Protobuf tag 3 (`thought`).
- **Translator & Updates**: Updated `handleAgentText` in `Translator` (`src/agy/db/translator.ts`) and `agentUpdate` (`src/agy/db/updates.ts`) to forward `agentText.thought` via `emitThought()` as `agent_thought_chunk`.
- **Testing**: Added test fixture helper in `tests/fixtures/step-encoder.ts` and unit tests in `tests/db.test.ts` verifying Protobuf tag 3 decoding and translation in both streaming and replay modes.

## Verification
- Ran `npx vitest run`: all 120 tests passed across 5 test suites.