### PR TITLE
Release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-07-28
+
+### Added
+
+- Emit `agent_thought_chunk` notifications in ACP v2 when step 15 carries a thought payload (tag 3), enabling clients like Zed to render model thinking content. (#30)
+- Embed terminal metadata (`_meta.terminal`) on ACP v1 `execute` tool call updates. (#28)
+
+### Fixed
+
+- Preserve permission panel visibility when intervening non-marker PTY data arrives before applying permission response in the interactive CLI session adapter.
+- Fix duplicated command line and output in `run_command` tool updates by preferring `toolSummary`/`toolAction` for titles and extracting output from the primary content block. (#27)
+- Drop terminal content blocks when an `execute` tool call is no longer `in_progress`, resolving `session/update` errors referencing evicted terminals. (#29)
+- Strip internal `kind` attributes from content items, emit incremental terminal output bytes, and bound tracker memory size per turn. (#28)
+- Deduplicate tool call updates by keying tool call snapshots with `toolCallId`. (#28)
+- Preserve `commandResult.exitCode` in `rawOutput` on failed execute steps, making `exitCode` optional on `CommandResult` instead of defaulting to zero. (#28)
+
 ## [0.3.3] - 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agy-acp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agy-acp",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agy-acp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Agent Client Protocol adapter that wraps the Google Antigravity CLI (ACP v1 + experimental draft ACP v2)",
   "type": "module",
   "author": {

--- a/src/acp/session/load.ts
+++ b/src/acp/session/load.ts
@@ -12,7 +12,7 @@ import { sessionConfigOptionsV1 } from "./config-options.js";
 import { sessionModeState } from "./modes.js";
 import type { StoredSession } from "./store.js";
 import type { SessionState } from "./types.js";
-import { sessionUpdateToV1 } from "./update-wire.js";
+import { createTerminalOutputTracker, sessionUpdateToV1 } from "./update-wire.js";
 
 export interface LoadSessionDeps {
   requireAuthenticated(cwd?: string): Promise<void>;
@@ -43,10 +43,11 @@ export async function handleLoadSession(
   );
 
   if (stored.conversationId) {
+    const tracker = createTerminalOutputTracker();
     await deps.replayConversation(session, stored.conversationId, cwd, async (update) => {
       await client.notify(v1.methods.client.session.update, {
         sessionId: params.sessionId,
-        update: sessionUpdateToV1(update)
+        update: sessionUpdateToV1(update, tracker)
       });
     });
   }

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -22,7 +22,7 @@ import { MODEL_CONFIG_ID } from "./config-options.js";
 import { MODE_CONFIG_ID } from "./modes.js";
 import { requestPermissionV1, requestPermissionV2 } from "./request-permission.js";
 import type { SessionState } from "./types.js";
-import { expandSessionUpdateToV2, sessionUpdateToV1 } from "./update-wire.js";
+import { createTerminalOutputTracker, expandSessionUpdateToV2, sessionUpdateToV1 } from "./update-wire.js";
 
 export interface PromptTurnDeps {
   requireSession(sessionId: string): SessionState;
@@ -133,10 +133,11 @@ export async function handlePromptV1(
   signal?.addEventListener("abort", cancelPrompt, { once: true });
 
   try {
+    const tracker = createTerminalOutputTracker();
     const outcome = await session.agy.prompt(prompt, async (update) => {
       await client.notify(v1.methods.client.session.update, {
         sessionId: params.sessionId,
-        update: sessionUpdateToV1(update)
+        update: sessionUpdateToV1(update, tracker)
       });
     }, async (toolCall, { toolName }) => {
       return requestPermissionV1(client, params.sessionId, toolCall, toolName, signal);

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -182,7 +182,8 @@ export function sessionUpdateToV1(
             metaObj.terminal_output = { data: Buffer.from(newChunk, "utf8").toString("base64") };
             setTrackedOutputLength(tracker, meta.terminalId, meta.output.length);
           } else if (meta.output.length < prevLen) {
-            metaObj.terminal_output = { data: Buffer.from(meta.output, "utf8").toString("base64") };
+            // terminal_output in ACP v1 is append-only. Do not append a reset snapshot
+            // to an existing terminal stream; update tracked length for future chunks.
             setTrackedOutputLength(tracker, meta.terminalId, meta.output.length);
           }
         }

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -127,7 +127,22 @@ export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
         if (meta.output != null && meta.output.length > 0) {
           metaObj.terminal_output = { data: Buffer.from(meta.output, "utf8").toString("base64") };
         }
-        if (typeof meta.exitCode === "number") {
+        const finished =
+          meta.status === "completed" ||
+          meta.status === "failed" ||
+          meta.status === "cancelled";
+        if (finished) {
+          const terminalExit: Record<string, unknown> = {};
+          if (typeof meta.exitCode === "number") {
+            terminalExit.exit_code = meta.exitCode;
+          } else if (meta.status === "cancelled") {
+            terminalExit.signal = "SIGINT";
+            terminalExit.exit_code = 130;
+          } else {
+            terminalExit.exit_code = meta.status === "failed" ? 1 : 0;
+          }
+          metaObj.terminal_exit = terminalExit;
+        } else if (typeof meta.exitCode === "number") {
           metaObj.terminal_exit = { exit_code: meta.exitCode };
         }
         v1Update._meta = metaObj;

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -87,22 +87,28 @@ function mapToolStatusForV1(status: unknown): unknown {
 
 function withTerminalContent(
   content: unknown,
-  terminalId: string
+  terminalId: string,
+  status?: string
 ): Record<string, unknown>[] {
-  const terminalBlock = { type: "terminal", terminalId };
-  if (!Array.isArray(content) || content.length === 0) {
-    return [terminalBlock];
+  const items = Array.isArray(content)
+    ? (content.map((item) =>
+        item && typeof item === "object"
+          ? toolContentToV2(item as Record<string, unknown>)
+          : item
+      ) as Record<string, unknown>[])
+    : [];
+
+  const nonTerminalItems = items.filter((item) => item?.type !== "terminal");
+
+  // Terminal content blocks are display-only embeds for active executions.
+  // Once execution completes, fails, or cancels (or before it starts in pending),
+  // drop the terminal block so clients like Zed that evict finished terminals
+  // don't throw "Terminal with id ... not found" errors when processing tool_call_update.
+  if (status === "in_progress") {
+    return [{ type: "terminal", terminalId }, ...nonTerminalItems];
   }
-  const mapped = content.map((item) =>
-    item && typeof item === "object"
-      ? toolContentToV2(item as Record<string, unknown>)
-      : item
-  ) as Record<string, unknown>[];
-  // Avoid duplicating the same terminal embed on progressive updates.
-  if (mapped.some((item) => item?.type === "terminal" && item.terminalId === terminalId)) {
-    return mapped;
-  }
-  return [terminalBlock, ...mapped];
+
+  return nonTerminalItems;
 }
 
 /** Identity cast for the v1 wire format (builders already emit v1 shapes). */
@@ -217,7 +223,7 @@ export function expandSessionUpdateToV2(update: V1SessionUpdate): V2SessionUpdat
   }
 
   const tool = sessionUpdateToV2(update) as unknown as Record<string, unknown>;
-  tool.content = withTerminalContent(tool.content, meta.terminalId);
+  tool.content = withTerminalContent(tool.content, meta.terminalId, meta.status);
 
   return [terminalUpdateForExecute(meta), tool as V2SessionUpdate];
 }

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -109,10 +109,29 @@ function withTerminalContent(
 export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
   const raw = update as unknown as Record<string, unknown>;
   if (raw.sessionUpdate === "tool_call" || raw.sessionUpdate === "tool_call_update") {
-    return {
+    const v1Update: Record<string, unknown> = {
       ...raw,
       status: mapToolStatusForV1(raw.status)
-    } as V1SessionUpdate;
+    };
+
+    if (raw.kind === "execute") {
+      const meta = executeTerminalMeta(update);
+      if (meta) {
+        const metaObj: Record<string, unknown> = {
+          ...(raw._meta as Record<string, unknown> ?? {})
+        };
+        metaObj.terminal_info = { terminal_id: meta.terminalId };
+        if (meta.output != null && meta.output.length > 0) {
+          metaObj.terminal_output = { data: Buffer.from(meta.output, "utf8").toString("base64") };
+        }
+        if (typeof meta.exitCode === "number") {
+          metaObj.terminal_exit = { exit_code: meta.exitCode };
+        }
+        v1Update._meta = metaObj;
+      }
+    }
+
+    return v1Update as V1SessionUpdate;
   }
   // Drop agent-private plan _meta keys from the v1 wire (entries stay).
   if (raw.sessionUpdate === "plan" && raw._meta && typeof raw._meta === "object") {

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -121,14 +121,39 @@ function cleanContentItem(item: unknown): unknown {
   return item;
 }
 
-const emittedTerminalOutputLengths = new Map<string, number>();
+export type TerminalOutputTracker = Map<string, number>;
+
+const MAX_TERMINAL_TRACKER_SIZE = 500;
+
+export function createTerminalOutputTracker(): TerminalOutputTracker {
+  return new Map<string, number>();
+}
+
+const defaultTerminalOutputTracker = createTerminalOutputTracker();
 
 export function resetTerminalOutputTracker(): void {
-  emittedTerminalOutputLengths.clear();
+  defaultTerminalOutputTracker.clear();
+}
+
+function setTrackedOutputLength(
+  tracker: TerminalOutputTracker,
+  terminalId: string,
+  length: number
+): void {
+  if (!tracker.has(terminalId) && tracker.size >= MAX_TERMINAL_TRACKER_SIZE) {
+    const oldestKey = tracker.keys().next().value;
+    if (oldestKey !== undefined) {
+      tracker.delete(oldestKey);
+    }
+  }
+  tracker.set(terminalId, length);
 }
 
 /** Identity cast for the v1 wire format (builders already emit v1 shapes). */
-export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
+export function sessionUpdateToV1(
+  update: V1SessionUpdate,
+  tracker: TerminalOutputTracker = defaultTerminalOutputTracker
+): V1SessionUpdate {
   const raw = update as unknown as Record<string, unknown>;
   if (raw.sessionUpdate === "tool_call" || raw.sessionUpdate === "tool_call_update") {
     const v1Update: Record<string, unknown> = {
@@ -151,11 +176,14 @@ export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
         };
         metaObj.terminal_info = { terminal_id: meta.terminalId };
         if (meta.output != null && meta.output.length > 0) {
-          const prevLen = emittedTerminalOutputLengths.get(meta.terminalId) ?? 0;
+          const prevLen = tracker.get(meta.terminalId) ?? 0;
           if (meta.output.length > prevLen) {
             const newChunk = meta.output.slice(prevLen);
             metaObj.terminal_output = { data: Buffer.from(newChunk, "utf8").toString("base64") };
-            emittedTerminalOutputLengths.set(meta.terminalId, meta.output.length);
+            setTrackedOutputLength(tracker, meta.terminalId, meta.output.length);
+          } else if (meta.output.length < prevLen) {
+            metaObj.terminal_output = { data: Buffer.from(meta.output, "utf8").toString("base64") };
+            setTrackedOutputLength(tracker, meta.terminalId, meta.output.length);
           }
         }
         const finished =
@@ -163,7 +191,7 @@ export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
           meta.status === "failed" ||
           meta.status === "cancelled";
         if (finished) {
-          emittedTerminalOutputLengths.delete(meta.terminalId);
+          tracker.delete(meta.terminalId);
           const terminalExit: Record<string, unknown> = {};
           if (typeof meta.exitCode === "number") {
             terminalExit.exit_code = meta.exitCode;

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -49,8 +49,9 @@ export function gitPatchForFile(
 }
 
 function toolContentToV2(item: Record<string, unknown>): Record<string, unknown> {
-  if (item.type !== "diff") {
-    return item;
+  const clean = cleanContentItem(item) as Record<string, unknown>;
+  if (clean.type !== "diff") {
+    return clean;
   }
 
   const path = typeof item.path === "string" ? item.path : "";
@@ -111,6 +112,21 @@ function withTerminalContent(
   return nonTerminalItems;
 }
 
+function cleanContentItem(item: unknown): unknown {
+  if (item && typeof item === "object" && !Array.isArray(item)) {
+    const rec = { ...(item as Record<string, unknown>) };
+    delete rec.kind;
+    return rec;
+  }
+  return item;
+}
+
+const emittedTerminalOutputLengths = new Map<string, number>();
+
+export function resetTerminalOutputTracker(): void {
+  emittedTerminalOutputLengths.clear();
+}
+
 /** Identity cast for the v1 wire format (builders already emit v1 shapes). */
 export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
   const raw = update as unknown as Record<string, unknown>;
@@ -119,6 +135,10 @@ export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
       ...raw,
       status: mapToolStatusForV1(raw.status)
     };
+
+    if (Array.isArray(v1Update.content)) {
+      v1Update.content = v1Update.content.map(cleanContentItem);
+    }
 
     // Attach v1 terminal metadata (_meta.terminal_info/output/exit) for execute tool calls
     // so ACP v1 clients (like Zed) can render terminal output panels.
@@ -131,13 +151,19 @@ export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
         };
         metaObj.terminal_info = { terminal_id: meta.terminalId };
         if (meta.output != null && meta.output.length > 0) {
-          metaObj.terminal_output = { data: Buffer.from(meta.output, "utf8").toString("base64") };
+          const prevLen = emittedTerminalOutputLengths.get(meta.terminalId) ?? 0;
+          if (meta.output.length > prevLen) {
+            const newChunk = meta.output.slice(prevLen);
+            metaObj.terminal_output = { data: Buffer.from(newChunk, "utf8").toString("base64") };
+            emittedTerminalOutputLengths.set(meta.terminalId, meta.output.length);
+          }
         }
         const finished =
           meta.status === "completed" ||
           meta.status === "failed" ||
           meta.status === "cancelled";
         if (finished) {
+          emittedTerminalOutputLengths.delete(meta.terminalId);
           const terminalExit: Record<string, unknown> = {};
           if (typeof meta.exitCode === "number") {
             terminalExit.exit_code = meta.exitCode;

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -114,6 +114,9 @@ export function sessionUpdateToV1(update: V1SessionUpdate): V1SessionUpdate {
       status: mapToolStatusForV1(raw.status)
     };
 
+    // Attach v1 terminal metadata (_meta.terminal_info/output/exit) for execute tool calls
+    // so ACP v1 clients (like Zed) can render terminal output panels.
+    // Docs: https://agentclientprotocol.com/protocol/v1/terminals
     if (raw.kind === "execute") {
       const meta = executeTerminalMeta(update);
       if (meta) {

--- a/src/acp/terminal/index.ts
+++ b/src/acp/terminal/index.ts
@@ -88,8 +88,10 @@ export function executeTerminalMeta(update: V1SessionUpdate): ExecuteTerminalMet
 
   let output = typeof rawOutput.output === "string" ? rawOutput.output : undefined;
   if (output == null && texts.length >= 1) {
-    // executeUpdate: content[0] is output when present (or content[1] in legacy updates).
-    output = texts[texts.length - 1];
+    // executeUpdate puts stdout as content[0]; auxiliary blocks (permission,
+    // error, task) are appended after by toolCallUpdate, so always pick the
+    // first text block for the terminal output.
+    output = texts[0];
   }
 
   const exitCode = typeof rawOutput.exitCode === "number" ? rawOutput.exitCode : undefined;

--- a/src/acp/terminal/index.ts
+++ b/src/acp/terminal/index.ts
@@ -87,11 +87,9 @@ export function executeTerminalMeta(update: V1SessionUpdate): ExecuteTerminalMet
   const cwd = pickString(rawInput, "Cwd", "cwd");
 
   let output = typeof rawOutput.output === "string" ? rawOutput.output : undefined;
-  if (output == null && texts.length >= 2) {
-    // executeUpdate: content[0] = command, content[1] = output when both present.
-    output = texts[1];
-  } else if (output == null && texts.length === 1 && command && texts[0] !== command) {
-    output = texts[0];
+  if (output == null && texts.length >= 1) {
+    // executeUpdate: content[0] is output when present (or content[1] in legacy updates).
+    output = texts[texts.length - 1];
   }
 
   const exitCode = typeof rawOutput.exitCode === "number" ? rawOutput.exitCode : undefined;

--- a/src/acp/terminal/index.ts
+++ b/src/acp/terminal/index.ts
@@ -66,6 +66,14 @@ export interface ExecuteTerminalMeta {
   status?: string;
 }
 
+function isAuxiliaryTextBlock(text: string): boolean {
+  const t = text.trim();
+  if (/^Permission (requested|granted|denied):/.test(t)) return true;
+  if (/^Error:/i.test(t)) return true;
+  if (/^Task:/i.test(t)) return true;
+  return false;
+}
+
 /** Extract execute-tool terminal fields from a v1-shaped tool call update. */
 export function executeTerminalMeta(update: V1SessionUpdate): ExecuteTerminalMeta | null {
   const raw = update as unknown as Record<string, unknown>;
@@ -86,10 +94,7 @@ export function executeTerminalMeta(update: V1SessionUpdate): ExecuteTerminalMet
   const cwd = pickString(rawInput, "Cwd", "cwd");
 
   let output = typeof rawOutput.output === "string" ? rawOutput.output : undefined;
-  if (output == null && texts.length >= 1) {
-    // executeUpdate puts stdout as content[0]; auxiliary blocks (permission,
-    // error, task) are appended after by toolCallUpdate, so always pick the
-    // first text block for the terminal output.
+  if (output == null && texts.length >= 1 && !isAuxiliaryTextBlock(texts[0])) {
     output = texts[0];
   }
 

--- a/src/acp/terminal/index.ts
+++ b/src/acp/terminal/index.ts
@@ -70,7 +70,7 @@ function isAuxiliaryTextBlock(text: string): boolean {
   const t = text.trim();
   if (/^Permission (requested|granted|denied):/.test(t)) return true;
   if (/^Error:/i.test(t)) return true;
-  if (/^Task:/i.test(t)) return true;
+  if (/(^|\n)(Task|Log):/i.test(t)) return true;
   return false;
 }
 

--- a/src/acp/terminal/index.ts
+++ b/src/acp/terminal/index.ts
@@ -66,14 +66,6 @@ export interface ExecuteTerminalMeta {
   status?: string;
 }
 
-function isAuxiliaryTextBlock(text: string): boolean {
-  const t = text.trim();
-  if (/^Permission (requested|granted|denied):/.test(t)) return true;
-  if (/^Error:/i.test(t)) return true;
-  if (/(^|\n)(Task|Log):/i.test(t)) return true;
-  return false;
-}
-
 /** Extract execute-tool terminal fields from a v1-shaped tool call update. */
 export function executeTerminalMeta(update: V1SessionUpdate): ExecuteTerminalMeta | null {
   const raw = update as unknown as Record<string, unknown>;
@@ -85,7 +77,6 @@ export function executeTerminalMeta(update: V1SessionUpdate): ExecuteTerminalMet
 
   const rawInput = asRecord(raw.rawInput) ?? {};
   const rawOutput = asRecord(raw.rawOutput) ?? {};
-  const texts = contentTexts(raw);
 
   const command =
     pickString(rawInput, "CommandLine", "commandLine", "command") ??
@@ -94,8 +85,18 @@ export function executeTerminalMeta(update: V1SessionUpdate): ExecuteTerminalMet
   const cwd = pickString(rawInput, "Cwd", "cwd");
 
   let output = typeof rawOutput.output === "string" ? rawOutput.output : undefined;
-  if (output == null && texts.length >= 1 && !isAuxiliaryTextBlock(texts[0])) {
-    output = texts[0];
+  if (output == null && Array.isArray(raw.content)) {
+    for (const item of raw.content) {
+      const block = asRecord(item);
+      if (!block || block.type !== "content") continue;
+      if (block.kind === "output") {
+        const content = asRecord(block.content);
+        if (content && typeof content.text === "string") {
+          output = unfence(content.text);
+          break;
+        }
+      }
+    }
   }
 
   const exitCode = typeof rawOutput.exitCode === "number" ? rawOutput.exitCode : undefined;

--- a/src/acp/terminal/index.ts
+++ b/src/acp/terminal/index.ts
@@ -81,7 +81,6 @@ export function executeTerminalMeta(update: V1SessionUpdate): ExecuteTerminalMet
 
   const command =
     pickString(rawInput, "CommandLine", "commandLine", "command") ??
-    (texts[0]?.includes("\n") ? texts[0].split("\n")[0] : texts[0]) ??
     (typeof raw.title === "string" && raw.title.trim() ? raw.title.trim() : undefined);
 
   const cwd = pickString(rawInput, "Cwd", "cwd");

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -334,6 +334,7 @@ export class AgyCliSession {
         let offset = 0;
         while ((offset = searchable.indexOf(idleMarker, offset)) >= 0) {
           this.#ptyIdleMarkerCount++;
+          this.#ptyPermissionPanelVisible = false;
           offset += idleMarker.length;
         }
         this.#ptyIdleMatchTail = searchable.slice(-(idleMarker.length - 1));
@@ -787,8 +788,6 @@ export class AgyCliSession {
     if (visible) {
       this.#ptyPermissionMarkerCount++;
       this.#ptyPermissionPanelVisible = true;
-    } else if (this.#ptyPermissionMarkerTail.length === 0) {
-      this.#ptyPermissionPanelVisible = false;
     }
     this.#ptyPermissionRender = "";
     this.#ptyPermissionRenderTimer = undefined;

--- a/src/agy/db/step-payload.ts
+++ b/src/agy/db/step-payload.ts
@@ -83,6 +83,7 @@ export interface UserPrompt {
 
 export interface AgentText {
   text: string;
+  thought?: string;
 }
 
 export interface TitleUpdate {
@@ -240,7 +241,10 @@ function decodeUserPrompt(bytes: Uint8Array): UserPrompt {
 }
 
 function decodeAgentText(bytes: Uint8Array): AgentText {
-  return readMessage(bytes, { text: "" }, { 1: (m, r) => (m.text = r.string()) });
+  return readMessage<AgentText>(bytes, { text: "" }, {
+    1: (m, r) => (m.text = r.string()),
+    3: (m, r) => (m.thought = r.string())
+  });
 }
 
 function decodeTitleUpdate(bytes: Uint8Array): TitleUpdate {

--- a/src/agy/db/step-payload.ts
+++ b/src/agy/db/step-payload.ts
@@ -95,7 +95,7 @@ export interface TitleUpdate {
  */
 export interface CommandResult {
   cwd: string;
-  exitCode: number;
+  exitCode?: number;
   /** Shell stdout/stderr text when present (may include truncation markers). */
   output: string;
   command: string;
@@ -266,7 +266,7 @@ export function sanitizeCommandOutput(raw: string): string {
 function decodeCommandResult(bytes: Uint8Array): CommandResult {
   return readMessage<CommandResult>(
     bytes,
-    { cwd: "", exitCode: 0, output: "", command: "" },
+    { cwd: "", output: "", command: "" },
     {
       2: (m, r) => (m.cwd = r.string()),
       6: (m, r) => (m.exitCode = readInt(r)),

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -388,7 +388,6 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     firstLine || asStr(toolRun?.titlePrimary)?.trim() || asStr(toolRun?.titleSecondary)?.trim() || "Command Execution";
 
   const content: Record<string, unknown>[] = [];
-  if (command?.trim()) content.push(codeBlock(command));
   // Prefer decoded field-28 output over empty; surface when non-empty.
   const output = commandResult?.output ?? "";
   if (output.trim()) content.push(codeBlock(output));
@@ -407,11 +406,10 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     locations
   }) as SessionUpdate & { rawOutput?: unknown };
 
-  // Attach structured exit/output when present (without dropping error rawOutput).
+  // Attach structured exit when present (without dropping error rawOutput).
   if (commandResult && !stepRow.error) {
     update.rawOutput = {
-      exitCode: commandResult.exitCode,
-      ...(output.trim() ? { output } : {})
+      exitCode: commandResult.exitCode
     };
   }
   return update;

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -77,6 +77,12 @@ function codeBlock(text: string): Record<string, unknown> {
   return textBlock(fencedCodeBlock(text));
 }
 
+function outputCodeBlock(text: string): Record<string, unknown> {
+  const block = textBlock(fencedCodeBlock(text));
+  block.kind = "output";
+  return block;
+}
+
 function errorBlock(e: ErrorDetails): Record<string, unknown> {
   const message = e.message.trim() || e.detail.trim() || "Tool call failed";
   const detail = e.detail.trim() && e.detail.trim() !== message ? `\n${e.detail.trim()}` : "";
@@ -394,7 +400,7 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
   const content: Record<string, unknown>[] = [];
   // Prefer decoded field-28 output over empty; surface when non-empty.
   const output = commandResult?.output ?? "";
-  if (output.trim()) content.push(codeBlock(output));
+  if (output.trim()) content.push(outputCodeBlock(output));
 
   // Prefer explicit Cwd from args; fall back to command-result cwd.
   const commandCwd =

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -408,7 +408,18 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     kind: "execute",
     content,
     locations
-  }) as SessionUpdate & { rawOutput?: unknown };
+  }) as SessionUpdate & { rawOutput?: unknown; rawInput?: unknown };
+
+  // When the command was recovered from commandResult.command (rawInputJson
+  // missing/malformed), inject it into rawInput so downstream consumers
+  // (e.g. executeTerminalMeta) can always find it via rawInput.CommandLine
+  // instead of falling back to title (which may now be toolSummary).
+  if (command && update.rawInput != null && typeof update.rawInput === "object" && !Array.isArray(update.rawInput)) {
+    const input = update.rawInput as Record<string, unknown>;
+    if (!input.CommandLine && !input.commandLine && !input.command) {
+      input.CommandLine = command;
+    }
+  }
 
   // Attach structured exit when present (without dropping error rawOutput).
   if (commandResult && !stepRow.error) {

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -383,9 +383,13 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     asStr(pick(rawInput, "CommandLine", "commandLine", "command")) ??
     (commandResult?.command?.trim() ? commandResult.command : null);
   const firstLine = (command?.split("\n")[0] ?? "").trim();
-
+  const summary = asStr(pick(rawInput, "toolSummary", "ToolSummary", "toolAction", "ToolAction"))?.trim();
   const title =
-    firstLine || asStr(toolRun?.titlePrimary)?.trim() || asStr(toolRun?.titleSecondary)?.trim() || "Command Execution";
+    summary ||
+    firstLine ||
+    asStr(toolRun?.titlePrimary)?.trim() ||
+    asStr(toolRun?.titleSecondary)?.trim() ||
+    "Command Execution";
 
   const content: Record<string, unknown>[] = [];
   // Prefer decoded field-28 output over empty; surface when non-empty.

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -389,18 +389,24 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     asStr(pick(rawInput, "CommandLine", "commandLine", "command")) ??
     (commandResult?.command?.trim() ? commandResult.command : null);
   const firstLine = (command?.split("\n")[0] ?? "").trim();
-  const summary = asStr(pick(rawInput, "toolSummary", "ToolSummary", "toolAction", "ToolAction"))?.trim();
+  const summary = asStr(pick(rawInput, "toolSummary", "ToolSummary"))?.trim();
+  const action = asStr(pick(rawInput, "toolAction", "ToolAction"))?.trim();
   const title =
     summary ||
     firstLine ||
+    action ||
     asStr(toolRun?.titlePrimary)?.trim() ||
     asStr(toolRun?.titleSecondary)?.trim() ||
     "Command Execution";
 
   const content: Record<string, unknown>[] = [];
-  // Prefer decoded field-28 output over empty; surface when non-empty.
+  // Prefer decoded field-28 output over empty; fall back to showing the command line.
   const output = commandResult?.output ?? "";
-  if (output.trim()) content.push(outputCodeBlock(output));
+  if (output.trim()) {
+    content.push(outputCodeBlock(output));
+  } else if (command?.trim()) {
+    content.push(codeBlock(command.trim()));
+  }
 
   // Prefer explicit Cwd from args; fall back to command-result cwd.
   const commandCwd =
@@ -427,8 +433,10 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     }
   }
 
-  // Attach structured exit when present (without dropping error rawOutput).
-  if (commandResult && typeof commandResult.exitCode === "number") {
+  // Attach structured exit when finished and present (without dropping error rawOutput).
+  const status = toolCallStatus(stepRow);
+  const finished = status === "completed" || status === "failed" || status === "cancelled";
+  if (commandResult && typeof commandResult.exitCode === "number" && finished) {
     const rawOut =
       update.rawOutput && typeof update.rawOutput === "object" && !Array.isArray(update.rawOutput)
         ? { ...(update.rawOutput as Record<string, unknown>) }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -428,10 +428,13 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
   }
 
   // Attach structured exit when present (without dropping error rawOutput).
-  if (commandResult && !stepRow.error) {
-    update.rawOutput = {
-      exitCode: commandResult.exitCode
-    };
+  if (commandResult && typeof commandResult.exitCode === "number") {
+    const rawOut =
+      update.rawOutput && typeof update.rawOutput === "object" && !Array.isArray(update.rawOutput)
+        ? { ...(update.rawOutput as Record<string, unknown>) }
+        : {};
+    rawOut.exitCode = commandResult.exitCode;
+    update.rawOutput = rawOut;
   }
   return update;
 }

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -231,6 +231,11 @@ export class Translator {
   }
 
   private handleAgentText(row: StepRow, out: SessionUpdate[]): void {
+    const thought = row.stepPayload.agentText?.thought;
+    if (thought) {
+      this.emitThought(thoughtChunk(thought, `agent-thought-${row.idx}`), out);
+    }
+
     const text = row.stepPayload.agentText?.text ?? "";
     const messageId = String(row.idx);
 

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -79,8 +79,8 @@ export class Translator {
   private readonly agentTextLengths = new Map<number, number>();
   // Streaming: thought messageId -> chars already emitted.
   private readonly thoughtTextLengths = new Map<string, number>();
-  // Stream + replay: last emitted snapshot keyed by step idx (tool progressive lifecycle).
-  private readonly toolSnapshots = new Map<number, string>();
+  // Stream + replay: last emitted snapshot keyed by tool call id / plan id (tool progressive lifecycle).
+  private readonly toolSnapshots = new Map<string, string>();
   // Stream + replay: last known file bodies from view_file / write_to_file (for diffs).
   private readonly fileContents: FileContentCache = new Map();
   // Replay: buffered consecutive agent-text parts, flushed at boundaries.
@@ -173,9 +173,10 @@ export class Translator {
 
     if (kind === "plan" || kind === "plan_update" || kind === "plan_removed") {
       const snapshot = updateSnapshot(update);
-      const previous = this.toolSnapshots.get(stepIdx);
+      const key = typeof raw.planId === "string" && raw.planId ? `plan:${raw.planId}` : `plan:${stepIdx}`;
+      const previous = this.toolSnapshots.get(key);
       if (previous === snapshot) return;
-      this.toolSnapshots.set(stepIdx, snapshot);
+      this.toolSnapshots.set(key, snapshot);
       out.push(update);
       return;
     }
@@ -186,16 +187,18 @@ export class Translator {
     }
 
     const snapshot = updateSnapshot(update);
-    const previous = this.toolSnapshots.get(stepIdx);
+    const toolId = typeof raw.toolCallId === "string" && raw.toolCallId.trim() ? raw.toolCallId.trim() : undefined;
+    const key = toolId ? `tool:${toolId}` : `step:${stepIdx}`;
+    const previous = this.toolSnapshots.get(key);
     if (previous === undefined) {
-      this.toolSnapshots.set(stepIdx, snapshot);
+      this.toolSnapshots.set(key, snapshot);
       // First sight always uses create shape; v2 boundary may rewrite to upsert.
       out.push({ ...raw, sessionUpdate: "tool_call" } as SessionUpdate);
       return;
     }
     if (previous === snapshot) return;
 
-    this.toolSnapshots.set(stepIdx, snapshot);
+    this.toolSnapshots.set(key, snapshot);
     out.push(asToolCallUpdate(update));
   }
 

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -30,11 +30,32 @@ export type { UpdateContext } from "./tool-call-updates.js";
  */
 const LIFECYCLE_STEP_TYPES = new Set<number>([90, 98, 101]);
 
-/** Step type 15 — a chunk of the agent's streamed text message. */
-function agentUpdate(stepRow: StepRow): SessionUpdate {
+/** Step type 15 — a chunk of the agent's streamed text message (+ optional thought). */
+function agentUpdate(stepRow: StepRow): SessionUpdate | SessionUpdate[] {
+  const text = stepRow.stepPayload.agentText?.text ?? "";
+  const thought = stepRow.stepPayload.agentText?.thought;
+
+  if (thought) {
+    const updates: SessionUpdate[] = [
+      {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: thought },
+        messageId: `agent-thought-${stepRow.idx}`
+      }
+    ];
+    if (text) {
+      updates.push({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text },
+        messageId: String(stepRow.idx)
+      });
+    }
+    return updates;
+  }
+
   return {
     sessionUpdate: "agent_message_chunk",
-    content: { type: "text", text: stepRow.stepPayload.agentText?.text ?? "" },
+    content: { type: "text", text },
     messageId: String(stepRow.idx)
   };
 }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1478,11 +1478,11 @@ describe("ACP v2 (experimental draft)", () => {
       status: "completed"
     });
     const content = expanded[1].content as Array<Record<string, unknown>>;
-    expect(content[0]).toEqual({ type: "terminal", terminalId });
+    expect(content.some((item) => item.type === "terminal")).toBe(false);
     expect(content.some((item) => item.type === "content")).toBe(true);
   });
 
-  it("emits in-progress terminal_update without exitStatus", () => {
+  it("emits in-progress terminal_update with terminal content block", () => {
     const update = {
       sessionUpdate: "tool_call",
       toolCallId: "cmd-2",
@@ -1505,6 +1505,32 @@ describe("ACP v2 (experimental draft)", () => {
       status: "in_progress",
       content: [{ type: "terminal", terminalId: terminalIdForToolCall("cmd-2") }]
     });
+  });
+
+  it("drops terminal content block on completed or failed status to prevent lookup of evicted terminals", () => {
+    const updateWithTerminal = {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "cmd-3",
+      title: "git status",
+      kind: "execute",
+      status: "completed",
+      rawInput: { CommandLine: "git status" },
+      content: [
+        { type: "terminal", terminalId: terminalIdForToolCall("cmd-3") },
+        { type: "content", content: { type: "text", text: "working tree clean" } }
+      ]
+    } as SessionUpdate;
+
+    const [terminal, tool] = expandSessionUpdateToV2(updateWithTerminal) as Array<Record<string, unknown>>;
+    expect(terminal).toMatchObject({
+      sessionUpdate: "terminal_update",
+      terminalId: terminalIdForToolCall("cmd-3"),
+      command: "git status",
+      exitStatus: {}
+    });
+    expect(tool.content).toEqual([
+      { type: "content", content: { type: "text", text: "working tree clean" } }
+    ]);
   });
 });
 

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -20,7 +20,7 @@ import {
 import { configFromEnv, type AgyCliConfig, type PtyFactory, type SpawnFactory } from "../src/agy/cli.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
-import { expandSessionUpdateToV2, sessionUpdateToV1, sessionUpdateToV2 } from "../src/acp/session/update-wire.js";
+import { createTerminalOutputTracker, expandSessionUpdateToV2, sessionUpdateToV1, sessionUpdateToV2 } from "../src/acp/session/update-wire.js";
 import { terminalIdForToolCall } from "../src/acp/terminal/index.js";
 import type { SessionConfigOption, SessionUpdate } from "@agentclientprotocol/sdk";
 
@@ -1545,6 +1545,60 @@ describe("ACP v2 (experimental draft)", () => {
       terminal_info: { terminal_id: terminalIdForToolCall("cmd-failed") },
       terminal_exit: { exit_code: 1 }
     });
+  });
+
+  it("handles terminal output buffer reset / truncation", () => {
+    const tracker = createTerminalOutputTracker();
+    const step1 = {
+      sessionUpdate: "tool_call",
+      toolCallId: "cmd-reset",
+      title: "run",
+      kind: "execute",
+      status: "in_progress",
+      rawInput: { CommandLine: "run" },
+      content: [
+        { type: "content", kind: "output", content: { type: "text", text: "```\nLong initial log text\n```" } }
+      ]
+    } as unknown as SessionUpdate;
+
+    const v1First = sessionUpdateToV1(step1, tracker) as Record<string, unknown>;
+    const metaFirst = v1First._meta as Record<string, Record<string, string>>;
+    expect(metaFirst.terminal_output.data).toBe(Buffer.from("Long initial log text", "utf8").toString("base64"));
+
+    // Simulate upstream reset to shorter output
+    const step2 = {
+      ...step1,
+      content: [
+        { type: "content", kind: "output", content: { type: "text", text: "```\nReset\n```" } }
+      ]
+    } as unknown as SessionUpdate;
+
+    const v1Second = sessionUpdateToV1(step2, tracker) as Record<string, unknown>;
+    const metaSecond = v1Second._meta as Record<string, Record<string, string>>;
+    expect(metaSecond.terminal_output.data).toBe(Buffer.from("Reset", "utf8").toString("base64"));
+  });
+
+  it("bounds terminal output tracker size to prevent unbounded memory growth", () => {
+    const tracker = createTerminalOutputTracker();
+    // Fill tracker beyond MAX_TERMINAL_TRACKER_SIZE (500)
+    for (let i = 0; i < 505; i++) {
+      const step = {
+        sessionUpdate: "tool_call",
+        toolCallId: `cmd-orphan-${i}`,
+        title: "run",
+        kind: "execute",
+        status: "in_progress",
+        rawInput: { CommandLine: "run" },
+        content: [
+          { type: "content", kind: "output", content: { type: "text", text: "```\noutput\n```" } }
+        ]
+      } as unknown as SessionUpdate;
+      sessionUpdateToV1(step, tracker);
+    }
+    expect(tracker.size).toBeLessThanOrEqual(500);
+    // Oldest entries like cmd-orphan-0 should have been evicted
+    expect(tracker.has(terminalIdForToolCall("cmd-orphan-0"))).toBe(false);
+    expect(tracker.has(terminalIdForToolCall("cmd-orphan-504"))).toBe(true);
   });
 
   it("drops terminal content block on completed or failed status to prevent lookup of evicted terminals", () => {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1565,7 +1565,7 @@ describe("ACP v2 (experimental draft)", () => {
     const metaFirst = v1First._meta as Record<string, Record<string, string>>;
     expect(metaFirst.terminal_output.data).toBe(Buffer.from("Long initial log text", "utf8").toString("base64"));
 
-    // Simulate upstream reset to shorter output
+    // Simulate upstream reset to shorter output (terminal_output is append-only, so do not append chunk)
     const step2 = {
       ...step1,
       content: [
@@ -1575,7 +1575,7 @@ describe("ACP v2 (experimental draft)", () => {
 
     const v1Second = sessionUpdateToV1(step2, tracker) as Record<string, unknown>;
     const metaSecond = v1Second._meta as Record<string, Record<string, string>>;
-    expect(metaSecond.terminal_output.data).toBe(Buffer.from("Reset", "utf8").toString("base64"));
+    expect(metaSecond.terminal_output).toBeUndefined();
   });
 
   it("bounds terminal output tracker size to prevent unbounded memory growth", () => {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1517,9 +1517,9 @@ describe("ACP v2 (experimental draft)", () => {
       rawInput: { CommandLine: "npm run test" },
       rawOutput: { exitCode: 0 },
       content: [
-        { type: "content", content: { type: "text", text: "```\nPASS test/a.test.ts\n```" } }
+        { type: "content", kind: "output", content: { type: "text", text: "```\nPASS test/a.test.ts\n```" } }
       ]
-    } as SessionUpdate;
+    } as unknown as SessionUpdate;
 
     const v1 = sessionUpdateToV1(update) as Record<string, unknown>;
     const terminalId = terminalIdForToolCall("cmd-v1");
@@ -1527,6 +1527,23 @@ describe("ACP v2 (experimental draft)", () => {
       terminal_info: { terminal_id: terminalId },
       terminal_output: { data: Buffer.from("PASS test/a.test.ts", "utf8").toString("base64") },
       terminal_exit: { exit_code: 0 }
+    });
+  });
+
+  it("emits fallback terminal_exit on finished v1 execute steps without exitCode", () => {
+    const update = {
+      sessionUpdate: "tool_call",
+      toolCallId: "cmd-failed",
+      title: "bad command",
+      kind: "execute",
+      status: "failed",
+      rawInput: { CommandLine: "bad command" }
+    } as SessionUpdate;
+
+    const v1 = sessionUpdateToV1(update) as Record<string, unknown>;
+    expect(v1._meta).toEqual({
+      terminal_info: { terminal_id: terminalIdForToolCall("cmd-failed") },
+      terminal_exit: { exit_code: 1 }
     });
   });
 });

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1506,6 +1506,29 @@ describe("ACP v2 (experimental draft)", () => {
       content: [{ type: "terminal", terminalId: terminalIdForToolCall("cmd-2") }]
     });
   });
+
+  it("embeds _meta.terminal_* on v1 execute tool calls", () => {
+    const update = {
+      sessionUpdate: "tool_call",
+      toolCallId: "cmd-v1",
+      title: "npm run test",
+      kind: "execute",
+      status: "completed",
+      rawInput: { CommandLine: "npm run test" },
+      rawOutput: { exitCode: 0 },
+      content: [
+        { type: "content", content: { type: "text", text: "```\nPASS test/a.test.ts\n```" } }
+      ]
+    } as SessionUpdate;
+
+    const v1 = sessionUpdateToV1(update) as Record<string, unknown>;
+    const terminalId = terminalIdForToolCall("cmd-v1");
+    expect(v1._meta).toEqual({
+      terminal_info: { terminal_id: terminalId },
+      terminal_output: { data: Buffer.from("PASS test/a.test.ts", "utf8").toString("base64") },
+      terminal_exit: { exit_code: 0 }
+    });
+  });
 });
 
 const TEST_MODELS_OUTPUT =

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -250,6 +250,32 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("preserves permission panel visibility when intervening non-marker PTY data arrives before applying permission response", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "permission-intervening-pty");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const result = session.prompt("go", async () => {}, async () => {
+      // Simulate stray terminal output / ANSI codes arriving while user is reviewing prompt
+      pty.emitData("\x1b[?25hstray output");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "permission-intervening-pty.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 100);
+      return "agy-allow-once";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    expect(pty.writes).toEqual(["\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("accepts an idle marker emitted after the DB write but before the next poll", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -289,6 +289,40 @@ describe("Translator", () => {
     expect(body).toContain("README.md");
   });
 
+  it("does not attach exitCode in rawOutput for pending run_command steps", () => {
+    const db = createConversationDb(dir, "conv-exec-pending");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 9,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({
+          command: "gh issue view",
+          cwd: "/path/to/cwd",
+          exitCode: 0
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-exec-pending")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as {
+      sessionUpdate: string;
+      kind: string;
+      status: string;
+      rawOutput?: { exitCode?: number };
+    };
+    expect(update.sessionUpdate).toBe("tool_call");
+    expect(update.kind).toBe("execute");
+    expect(update.status).toBe("pending");
+    expect(update.rawOutput).toBeUndefined();
+  });
+
   it("surfaces web search query metadata from field 42", () => {
     const db = createConversationDb(dir, "conv-web-search");
     insertStep(db, {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -284,7 +284,7 @@ describe("Translator", () => {
     };
     expect(update.sessionUpdate).toBe("tool_call");
     expect(update.kind).toBe("execute");
-    expect(update.rawOutput).toMatchObject({ exitCode: 0, output: "README.md\n" });
+    expect(update.rawOutput).toMatchObject({ exitCode: 0 });
     const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
     expect(body).toContain("README.md");
   });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -58,6 +58,27 @@ describe("ConversationDb", () => {
     expect(rows[1].stepPayload.toolRun?.call?.rawInputJson).toBe('{"CommandLine":"echo hi"}');
   });
 
+  it("decodes agent text thinking/reasoning (tag 3) from step type 15 payload", () => {
+    const db = createConversationDb(dir, "conv-thought-step15");
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      stepPayload: encodeStepPayload({
+        agentText: { text: "Result: 309524", thought: "Calculating 347 * 892..." }
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-thought-step15");
+    expect(conn).not.toBeNull();
+    const rows = conn!.readAfter(0);
+    conn!.close();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].stepPayload.agentText?.text).toBe("Result: 309524");
+    expect(rows[0].stepPayload.agentText?.thought).toBe("Calculating 347 * 892...");
+  });
+
   it("returns null for a missing conversation", () => {
     expect(ConversationDb.open(dir, "does-not-exist")).toBeNull();
   });
@@ -243,6 +264,56 @@ describe("Translator", () => {
     const conn2 = ConversationDb.open(dir, "conv-thought")!;
     expect(translator.translate(conn2.readAfter(0))).toHaveLength(0);
     conn2.close();
+  });
+
+  it("emits agent_thought_chunk for step type 15 carrying thought payload in streaming and replay modes", () => {
+    const db = createConversationDb(dir, "conv-agent-thought-stream");
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      stepPayload: encodeStepPayload({
+        agentText: { text: "Final output", thought: "Thinking deeply..." }
+      })
+    });
+    db.close();
+
+    // Stream mode
+    const connStream = ConversationDb.open(dir, "conv-agent-thought-stream")!;
+    const streamTranslator = new Translator({ mode: "stream", skipNarration: false });
+    const streamUpdates = streamTranslator.translate(connStream.readAfter(0));
+    connStream.close();
+
+    expect(streamUpdates).toEqual([
+      {
+        sessionUpdate: "agent_thought_chunk",
+        messageId: "agent-thought-1",
+        content: { type: "text", text: "Thinking deeply..." }
+      },
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "Final output" }
+      }
+    ]);
+
+    // Replay mode
+    const connReplay = ConversationDb.open(dir, "conv-agent-thought-stream")!;
+    const replayTranslator = new Translator({ mode: "replay", skipNarration: false });
+    const replayUpdates = replayTranslator.translate(connReplay.readAfter(-1));
+    connReplay.close();
+
+    expect(replayUpdates).toEqual([
+      {
+        sessionUpdate: "agent_thought_chunk",
+        messageId: "agent-thought-1",
+        content: { type: "text", text: "Thinking deeply..." }
+      },
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "Final output" }
+      }
+    ]);
   });
 
 

--- a/tests/fixtures/step-encoder.ts
+++ b/tests/fixtures/step-encoder.ts
@@ -30,9 +30,15 @@ export function encodeToolRun(run: { call?: Uint8Array; titlePrimary?: string; t
   return w.finish();
 }
 
-export function encodeAgentText(text: string): Uint8Array {
+export function encodeAgentText(text: string | { text?: string; thought?: string }, thought?: string): Uint8Array {
   const w = new BinaryWriter();
-  w.tag(1, 2).string(text);
+  if (typeof text === "object") {
+    if (text.text) w.tag(1, 2).string(text.text);
+    if (text.thought) w.tag(3, 2).string(text.thought);
+  } else {
+    if (text) w.tag(1, 2).string(text);
+    if (thought) w.tag(3, 2).string(thought);
+  }
   return w.finish();
 }
 
@@ -166,7 +172,7 @@ export function encodePermissions(info: { kind?: string; value?: string; decisio
 
 export function encodeStepPayload(opts: {
   toolRun?: Uint8Array;
-  agentText?: string;
+  agentText?: string | { text?: string; thought?: string } | Uint8Array;
   titleUpdate?: string;
   userPrompt?: string;
   commandResult?: Uint8Array;
@@ -180,7 +186,10 @@ export function encodeStepPayload(opts: {
   if (opts.grepSearch) submessage(w, 13, opts.grepSearch);
   if (opts.viewFile) submessage(w, 14, opts.viewFile);
   if (opts.userPrompt !== undefined) submessage(w, 19, encodeUserPrompt(opts.userPrompt));
-  if (opts.agentText !== undefined) submessage(w, 20, encodeAgentText(opts.agentText));
+  if (opts.agentText !== undefined) {
+    const bytes = opts.agentText instanceof Uint8Array ? opts.agentText : encodeAgentText(opts.agentText);
+    submessage(w, 20, bytes);
+  }
   if (opts.commandResult) submessage(w, 28, opts.commandResult);
   if (opts.titleUpdate !== undefined) submessage(w, 30, encodeTitleUpdate(opts.titleUpdate));
   if (opts.urlContent) submessage(w, 40, opts.urlContent);


### PR DESCRIPTION
## Summary
Release v0.3.4

### Added
- Emit `agent_thought_chunk` notifications in ACP v2 when step 15 carries a thought payload (tag 3), enabling clients like Zed to render model thinking content. (#30)
- Embed terminal metadata (`_meta.terminal`) on ACP v1 `execute` tool call updates. (#28)

### Fixed
- Preserve permission panel visibility when intervening non-marker PTY data arrives before applying permission response in the interactive CLI session adapter.
- Fix duplicated command line and output in `run_command` tool updates by preferring `toolSummary`/`toolAction` for titles and extracting output from the primary content block. (#27)
- Drop terminal content blocks when an `execute` tool call is no longer `in_progress`, resolving `session/update` errors referencing evicted terminals. (#29)
- Strip internal `kind` attributes from content items, emit incremental terminal output bytes, and bound tracker memory size per turn. (#28)
- Deduplicate tool call updates by keying tool call snapshots with `toolCallId`. (#28)
- Preserve `commandResult.exitCode` in `rawOutput` on failed execute steps, making `exitCode` optional on `CommandResult` instead of defaulting to zero. (#28)

## Verification
- Ran `npx vitest run`: 157 tests passed across 10 test suites.