### PR TITLE
Support ACP v2 progressive streaming (terminal_output_chunk and tool_call_content_chunk)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,13 +134,13 @@ differs or is incomplete.
 - [x] [`terminal_update`](https://agentclientprotocol.com/rfds/v2/terminal-output): agent-owned execute terminals + `type: "terminal"` embeds (DB snapshots)
 - [x] [`plan_update`](https://agentclientprotocol.com/protocol/v2/agent-plan): brain plans ([`markdown`](https://agentclientprotocol.com/rfds/v2/plan-variants) preferred, else `items`); no `plan_removed`
 - [x] [`available_commands_update`](https://agentclientprotocol.com/protocol/v2/slash-commands): same curated list + config intercept as v1
+- [x] [`terminal_output_chunk`](https://agentclientprotocol.com/rfds/v2/terminal-output): incremental output while a command is actively running
+- [x] [`tool_call_content_chunk`](https://agentclientprotocol.com/protocol/v2/schema#toolcallcontentchunk): progressive tool call output and content updates
+- [x] [`replayFrom`](https://agentclientprotocol.com/rfds/v2/session-resume-replay): replay cursors (`start`, `message`, `step`, `tool_call`)
 
 ### High priority
 
-- [ ] [`replayFrom`](https://agentclientprotocol.com/rfds/v2/session-resume-replay): richer cursors beyond `{ "type": "start" }` when the draft stabilizes incremental replay
 - [ ] [`elicitation/create`](https://agentclientprotocol.com/rfds/elicitation): multi-select / free-text `ask_question` (+ `elicitation/complete`; today: fail closed)
-- [ ] [`terminal_output_chunk`](https://agentclientprotocol.com/rfds/v2/terminal-output): incremental output while a command is still running (today: full snapshot when field 28 is present)
-- [ ] [`tool_call_content_chunk`](https://agentclientprotocol.com/protocol/v2/schema#toolcallcontentchunk): progressive tool content while a call is running (today: only on `tool_call_update` snapshots)
 - [ ] [`mcpServers`](https://agentclientprotocol.com/rfds/mcp-over-acp): honor session servers, advertise `capabilities.session.mcp`, route `mcp/*` when agy can consume them
 - [ ] [`session/request_permission`](https://agentclientprotocol.com/rfds/v2/permission-requests): expand bridge to remaining agy menus once TUI channels are verified
 

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -282,8 +282,9 @@ export class AcpAgent {
         conversationId: string,
         cwd: string,
         emit: (update: v1.SessionUpdate) => Promise<void>,
-        replayFrom?: unknown
-      ) => this.replayConversation(session, conversationId, cwd, emit, replayFrom)
+        replayFrom?: unknown,
+        v2UserMessageIdsByStep?: Record<string, string>
+      ) => this.replayConversation(session, conversationId, cwd, emit, replayFrom, v2UserMessageIdsByStep)
     };
   }
 
@@ -418,9 +419,18 @@ export class AcpAgent {
     conversationId: string,
     cwd: string,
     emit: (update: v1.SessionUpdate) => Promise<void>,
-    replayFrom?: unknown
+    replayFrom?: unknown,
+    v2UserMessageIdsByStep?: Record<string, string>
   ): Promise<void> {
-    return replayConversation(this.#replayCache, session, conversationId, cwd, emit, replayFrom);
+    return replayConversation(
+      this.#replayCache,
+      session,
+      conversationId,
+      cwd,
+      emit,
+      replayFrom,
+      v2UserMessageIdsByStep
+    );
   }
 
   private requireSession(sessionId: string): SessionState {

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -277,8 +277,9 @@ export class AcpAgent {
         session: SessionState,
         conversationId: string,
         cwd: string,
-        emit: (update: v1.SessionUpdate) => Promise<void>
-      ) => this.replayConversation(session, conversationId, cwd, emit)
+        emit: (update: v1.SessionUpdate) => Promise<void>,
+        replayFrom?: unknown
+      ) => this.replayConversation(session, conversationId, cwd, emit, replayFrom)
     };
   }
 
@@ -410,9 +411,10 @@ export class AcpAgent {
     session: SessionState,
     conversationId: string,
     cwd: string,
-    emit: (update: v1.SessionUpdate) => Promise<void>
+    emit: (update: v1.SessionUpdate) => Promise<void>,
+    replayFrom?: unknown
   ): Promise<void> {
-    return replayConversation(this.#replayCache, session, conversationId, cwd, emit);
+    return replayConversation(this.#replayCache, session, conversationId, cwd, emit, replayFrom);
   }
 
   private requireSession(sessionId: string): SessionState {

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -218,9 +218,12 @@ async function runV2PromptTurn(
     });
   };
 
-  const userMsgIdx = Math.max(session.agy.lastStepIdx + 1, (session.lastUserMsgIdx ?? -1) + 1);
-  session.lastUserMsgIdx = userMsgIdx;
-  const userMessageId = String(userMsgIdx);
+  const parsedSlash = parseSlashCommand(promptText);
+  const slashResult = parsedSlash ? interpretSlashCommand(parsedSlash) : null;
+  const userMessageId =
+    slashResult && slashResult.kind !== "pass"
+      ? `slash-${randomUUID()}`
+      : String(Math.max(0, session.agy.lastStepIdx + 1));
   try {
     signal.throwIfAborted();
 

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -218,7 +218,9 @@ async function runV2PromptTurn(
     });
   };
 
-  const userMessageId = String(Math.max(0, session.agy.lastStepIdx + 1));
+  const userMsgIdx = Math.max(session.agy.lastStepIdx + 1, (session.lastUserMsgIdx ?? -1) + 1);
+  session.lastUserMsgIdx = userMsgIdx;
+  const userMessageId = String(userMsgIdx);
   try {
     signal.throwIfAborted();
 

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -22,7 +22,7 @@ import { MODEL_CONFIG_ID } from "./config-options.js";
 import { MODE_CONFIG_ID } from "./modes.js";
 import { requestPermissionV1, requestPermissionV2 } from "./request-permission.js";
 import type { SessionState } from "./types.js";
-import { createTerminalOutputTracker, expandSessionUpdateToV2, sessionUpdateToV1 } from "./update-wire.js";
+import { createTerminalOutputTracker, createToolCallContentTracker, expandSessionUpdateToV2, sessionUpdateToV1 } from "./update-wire.js";
 
 export interface PromptTurnDeps {
   requireSession(sessionId: string): SessionState;
@@ -254,8 +254,10 @@ async function runV2PromptTurn(
     signal.addEventListener("abort", cancelPrompt, { once: true });
 
     try {
+      const terminalTracker = createTerminalOutputTracker();
+      const toolContentTracker = createToolCallContentTracker();
       const outcome = await session.agy.prompt(promptText, async (update) => {
-        for (const v2Update of expandSessionUpdateToV2(update)) {
+        for (const v2Update of expandSessionUpdateToV2(update, terminalTracker, toolContentTracker)) {
           await notify(v2Update);
         }
       }, async (toolCall, { toolName }) => {

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -218,7 +218,7 @@ async function runV2PromptTurn(
     });
   };
 
-  const userMessageId = randomUUID();
+  const userMessageId = String(Math.max(0, session.agy.lastStepIdx + 1));
   try {
     signal.throwIfAborted();
 

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -223,7 +223,7 @@ async function runV2PromptTurn(
   const userMessageId =
     slashResult && slashResult.kind !== "pass"
       ? `slash-${randomUUID()}`
-      : String(Math.max(0, session.agy.lastStepIdx + 1));
+      : `user-${randomUUID()}`;
   try {
     signal.throwIfAborted();
 
@@ -265,14 +265,26 @@ async function runV2PromptTurn(
     try {
       const terminalTracker = createTerminalOutputTracker();
       const toolContentTracker = createToolCallContentTracker();
-      const outcome = await session.agy.prompt(promptText, async (update) => {
-        for (const v2Update of expandSessionUpdateToV2(update, terminalTracker, toolContentTracker)) {
-          await notify(v2Update);
+      const outcome = await (async () => {
+        try {
+          return await session.agy.prompt(promptText, async (update) => {
+            for (const v2Update of expandSessionUpdateToV2(update, terminalTracker, toolContentTracker)) {
+              await notify(v2Update);
+            }
+          }, async (toolCall, { toolName, questionIndex }) => {
+            const elicitationCap = deps.clientElicitationV2?.(client);
+            return requestPermissionV2(client, params.sessionId, toolCall, toolName, signal, questionIndex, elicitationCap);
+          }, undefined, deps.clientElicitationV2?.(client));
+        } finally {
+          const userStepIdxs = session.agy.lastPromptUserStepIdxs;
+          if (userStepIdxs.length > 1) {
+            throw new Error(`Expected at most one user step for a prompt, observed: ${userStepIdxs.join(", ")}`);
+          }
+          if (userStepIdxs.length === 1) {
+            session.v2UserMessageIdsByStep[String(userStepIdxs[0])] = userMessageId;
+          }
         }
-      }, async (toolCall, { toolName, questionIndex }) => {
-        const elicitationCap = deps.clientElicitationV2?.(client);
-        return requestPermissionV2(client, params.sessionId, toolCall, toolName, signal, questionIndex, elicitationCap);
-      }, undefined, deps.clientElicitationV2?.(client));
+      })();
       await deps.persistSession(params.sessionId, session);
 
       const stopReason =

--- a/src/acp/session/resume.ts
+++ b/src/acp/session/resume.ts
@@ -32,7 +32,8 @@ export interface ResumeSessionDeps {
     session: SessionState,
     conversationId: string,
     cwd: string,
-    emit: (update: v1.SessionUpdate) => Promise<void>
+    emit: (update: v1.SessionUpdate) => Promise<void>,
+    replayFrom?: unknown
   ): Promise<void>;
 }
 
@@ -56,7 +57,7 @@ export async function handleResumeSessionV1(
 }
 
 /**
- * v2 `session/resume`: optional `replayFrom: { type: "start" }` replaces v1
+ * v2 `session/resume`: optional `replayFrom` cursor replaces v1
  * `session/load`. Omitting `replayFrom` reattaches without history.
  */
 export async function handleResumeSessionV2(
@@ -75,18 +76,21 @@ export async function handleResumeSessionV2(
 
   const replayFrom = params.replayFrom ?? null;
   if (replayFrom != null) {
-    if (replayFrom.type !== "start") {
-      throw new Error(`Unsupported replay cursor: ${String((replayFrom as { type?: string }).type)}`);
-    }
     if (stored.conversationId) {
-      await deps.replayConversation(session, stored.conversationId, cwd, async (update) => {
-        for (const v2Update of expandSessionUpdateToV2(update)) {
-          await client.notify(v2.methods.client.session.update, {
-            sessionId: params.sessionId,
-            update: v2Update
-          });
-        }
-      });
+      await deps.replayConversation(
+        session,
+        stored.conversationId,
+        cwd,
+        async (update) => {
+          for (const v2Update of expandSessionUpdateToV2(update)) {
+            await client.notify(v2.methods.client.session.update, {
+              sessionId: params.sessionId,
+              update: v2Update
+            });
+          }
+        },
+        replayFrom
+      );
     }
   }
 

--- a/src/acp/session/resume.ts
+++ b/src/acp/session/resume.ts
@@ -19,7 +19,7 @@ import { sessionConfigOptionsV1, sessionConfigOptionsV2 } from "./config-options
 import { sessionModeState } from "./modes.js";
 import type { StoredSession } from "./store.js";
 import type { SessionState } from "./types.js";
-import { expandSessionUpdateToV2 } from "./update-wire.js";
+import { createTerminalOutputTracker, createToolCallContentTracker, expandSessionUpdateToV2 } from "./update-wire.js";
 
 export interface ResumeSessionDeps {
   requireAuthenticated(cwd?: string): Promise<void>;
@@ -77,12 +77,14 @@ export async function handleResumeSessionV2(
   const replayFrom = params.replayFrom ?? null;
   if (replayFrom != null) {
     if (stored.conversationId) {
+      const terminalTracker = createTerminalOutputTracker();
+      const toolContentTracker = createToolCallContentTracker();
       await deps.replayConversation(
         session,
         stored.conversationId,
         cwd,
         async (update) => {
-          for (const v2Update of expandSessionUpdateToV2(update)) {
+          for (const v2Update of expandSessionUpdateToV2(update, terminalTracker, toolContentTracker)) {
             await client.notify(v2.methods.client.session.update, {
               sessionId: params.sessionId,
               update: v2Update

--- a/src/acp/session/resume.ts
+++ b/src/acp/session/resume.ts
@@ -33,7 +33,8 @@ export interface ResumeSessionDeps {
     conversationId: string,
     cwd: string,
     emit: (update: v1.SessionUpdate) => Promise<void>,
-    replayFrom?: unknown
+    replayFrom?: unknown,
+    v2UserMessageIdsByStep?: Record<string, string>
   ): Promise<void>;
 }
 
@@ -91,7 +92,8 @@ export async function handleResumeSessionV2(
             });
           }
         },
-        replayFrom
+        replayFrom,
+        session.v2UserMessageIdsByStep
       );
     }
   }

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -151,16 +151,19 @@ export function persistSession(
   return store.persist(sessionId, sessionRecord(session));
 }
 
-function getUpdateStepIdx(u: v1.SessionUpdate): number | undefined {
+function getUpdateStepRange(u: v1.SessionUpdate): { stepIdx: number; endStepIdx: number } | undefined {
   const rec = u as unknown as Record<string, unknown>;
   const meta = rec._meta as Record<string, unknown> | undefined;
-  if (typeof meta?.stepIdx === "number") return meta.stepIdx;
-  if (typeof rec.stepIdx === "number") return rec.stepIdx;
-  if (typeof rec.messageId === "string") {
+  let startIdx: number | undefined;
+  if (typeof meta?.stepIdx === "number") startIdx = meta.stepIdx;
+  else if (typeof rec.stepIdx === "number") startIdx = rec.stepIdx;
+  else if (typeof rec.messageId === "string") {
     const parsed = parseInt(rec.messageId, 10);
-    if (!isNaN(parsed)) return parsed;
+    if (!isNaN(parsed)) startIdx = parsed;
   }
-  return undefined;
+  if (startIdx == null) return undefined;
+  const endIdx = typeof meta?.endStepIdx === "number" ? meta.endStepIdx : startIdx;
+  return { stepIdx: startIdx, endStepIdx: endIdx };
 }
 
 export function filterUpdatesForReplayFrom(
@@ -194,8 +197,8 @@ export function filterUpdatesForReplayFrom(
         : undefined;
     if (targetIdx == null) return updates;
     const index = updates.findIndex((u) => {
-      const stepIdx = getUpdateStepIdx(u);
-      return stepIdx != null && stepIdx >= targetIdx;
+      const range = getUpdateStepRange(u);
+      return range != null && range.endStepIdx >= targetIdx;
     });
     return index >= 0 ? updates.slice(index) : [];
   }

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -151,6 +151,18 @@ export function persistSession(
   return store.persist(sessionId, sessionRecord(session));
 }
 
+function getUpdateStepIdx(u: v1.SessionUpdate): number | undefined {
+  const rec = u as unknown as Record<string, unknown>;
+  const meta = rec._meta as Record<string, unknown> | undefined;
+  if (typeof meta?.stepIdx === "number") return meta.stepIdx;
+  if (typeof rec.stepIdx === "number") return rec.stepIdx;
+  if (typeof rec.messageId === "string") {
+    const parsed = parseInt(rec.messageId, 10);
+    if (!isNaN(parsed)) return parsed;
+  }
+  return undefined;
+}
+
 export function filterUpdatesForReplayFrom(
   updates: v1.SessionUpdate[],
   replayFrom: Record<string, unknown>
@@ -182,10 +194,8 @@ export function filterUpdatesForReplayFrom(
         : undefined;
     if (targetIdx == null) return updates;
     const index = updates.findIndex((u) => {
-      const rec = u as unknown as Record<string, unknown>;
-      const stepIdxStr = typeof rec.messageId === "string" ? rec.messageId : undefined;
-      const stepNum = stepIdxStr != null ? parseInt(stepIdxStr, 10) : NaN;
-      return !isNaN(stepNum) && stepNum >= targetIdx;
+      const stepIdx = getUpdateStepIdx(u);
+      return stepIdx != null && stepIdx >= targetIdx;
     });
     return index >= 0 ? updates.slice(index) : [];
   }

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -151,21 +151,78 @@ export function persistSession(
   return store.persist(sessionId, sessionRecord(session));
 }
 
+export function filterUpdatesForReplayFrom(
+  updates: v1.SessionUpdate[],
+  replayFrom: Record<string, unknown>
+): v1.SessionUpdate[] {
+  const type = String(replayFrom.type ?? "").toLowerCase();
+
+  if (type === "start") {
+    return updates;
+  }
+
+  if (type === "message") {
+    const targetId = typeof replayFrom.messageId === "string" ? replayFrom.messageId : undefined;
+    if (!targetId) return updates;
+    const index = updates.findIndex((u) => {
+      const rec = u as unknown as Record<string, unknown>;
+      return rec.messageId === targetId;
+    });
+    return index >= 0 ? updates.slice(index) : [];
+  }
+
+  if (type === "step" || type === "step_idx" || type === "stepidx") {
+    const targetIdx =
+      typeof replayFrom.stepIdx === "number"
+        ? replayFrom.stepIdx
+        : typeof replayFrom.index === "number"
+        ? replayFrom.index
+        : typeof replayFrom.idx === "number"
+        ? replayFrom.idx
+        : undefined;
+    if (targetIdx == null) return updates;
+    const index = updates.findIndex((u) => {
+      const rec = u as unknown as Record<string, unknown>;
+      const stepIdxStr = typeof rec.messageId === "string" ? rec.messageId : undefined;
+      const stepNum = stepIdxStr != null ? parseInt(stepIdxStr, 10) : NaN;
+      return !isNaN(stepNum) && stepNum >= targetIdx;
+    });
+    return index >= 0 ? updates.slice(index) : [];
+  }
+
+  if (type === "tool_call" || type === "toolcall") {
+    const targetId = typeof replayFrom.toolCallId === "string" ? replayFrom.toolCallId : undefined;
+    if (!targetId) return updates;
+    const index = updates.findIndex((u) => {
+      const rec = u as unknown as Record<string, unknown>;
+      return rec.toolCallId === targetId;
+    });
+    return index >= 0 ? updates.slice(index) : [];
+  }
+
+  throw new Error(`Unsupported replay cursor: ${String(replayFrom.type)}`);
+}
+
 /** Replay a persisted conversation's session updates (used by `session/load` and
- *  `session/resume` with `replayFrom: { type: "start" }`). */
+ *  `session/resume` with `replayFrom`). */
 export async function replayConversation(
   replayCache: ReplayCache,
   session: SessionState,
   conversationId: string,
   cwd: string,
-  emit: (update: v1.SessionUpdate) => Promise<void>
+  emit: (update: v1.SessionUpdate) => Promise<void>,
+  replayFrom?: unknown
 ): Promise<void> {
   const replay = replayCache.get(session.agy.config.conversationsDir, conversationId, {
     skipNarration: false,
     cwd
   });
   if (!replay) return;
-  for (const update of replay.updates) {
+  const updates =
+    replayFrom != null
+      ? filterUpdatesForReplayFrom(replay.updates, replayFrom as Record<string, unknown>)
+      : replay.updates;
+  for (const update of updates) {
     await emit(update);
   }
 }

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -179,11 +179,15 @@ export function filterUpdatesForReplayFrom(
   if (type === "message") {
     const targetId = typeof replayFrom.messageId === "string" ? replayFrom.messageId : undefined;
     if (!targetId) return updates;
+    const targetNum = parseInt(targetId, 10);
     const index = updates.findIndex((u) => {
       const rec = u as unknown as Record<string, unknown>;
       if (rec.messageId === targetId) return true;
       const range = getUpdateStepRange(u);
-      return range != null && String(range.stepIdx) === targetId;
+      if (range != null && !isNaN(targetNum)) {
+        return range.stepIdx <= targetNum && targetNum <= range.endStepIdx;
+      }
+      return false;
     });
     return index >= 0 ? updates.slice(index) : [];
   }

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -181,7 +181,9 @@ export function filterUpdatesForReplayFrom(
     if (!targetId) return updates;
     const index = updates.findIndex((u) => {
       const rec = u as unknown as Record<string, unknown>;
-      return rec.messageId === targetId;
+      if (rec.messageId === targetId) return true;
+      const range = getUpdateStepRange(u);
+      return range != null && String(range.stepIdx) === targetId;
     });
     return index >= 0 ? updates.slice(index) : [];
   }

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -184,7 +184,7 @@ export function filterUpdatesForReplayFrom(
       const rec = u as unknown as Record<string, unknown>;
       if (rec.messageId === targetId) return true;
       const range = getUpdateStepRange(u);
-      if (range != null && !isNaN(targetNum)) {
+      if (rec.sessionUpdate === "agent_message_chunk" && range != null && !isNaN(targetNum)) {
         return range.stepIdx <= targetNum && targetNum <= range.endStepIdx;
       }
       return false;

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -54,7 +54,8 @@ export async function buildSession(
     catalog,
     selectedBaseModel: selection.baseModel,
     selectedReasoningEffort: selection.reasoningEffort,
-    activePrompt: false
+    activePrompt: false,
+    v2UserMessageIdsByStep: { ...(stored?.v2UserMessageIdsByStep ?? {}) }
   };
 }
 
@@ -139,6 +140,7 @@ export function sessionRecord(session: SessionState): StoredSession {
     model: session.selectedBaseModel,
     reasoningEffort: session.selectedReasoningEffort,
     mode: session.agy.config.mode,
+    v2UserMessageIdsByStep: session.v2UserMessageIdsByStep,
     updatedAt: new Date().toISOString()
   };
 }
@@ -230,20 +232,39 @@ export async function replayConversation(
   conversationId: string,
   cwd: string,
   emit: (update: v1.SessionUpdate) => Promise<void>,
-  replayFrom?: unknown
+  replayFrom?: unknown,
+  v2UserMessageIdsByStep?: Record<string, string>
 ): Promise<void> {
   const replay = replayCache.get(session.agy.config.conversationsDir, conversationId, {
     skipNarration: false,
     cwd
   });
   if (!replay) return;
+  const replayUpdates = v2UserMessageIdsByStep
+    ? remapV2UserMessageIds(replay.updates, v2UserMessageIdsByStep)
+    : replay.updates;
   const updates =
     replayFrom != null
-      ? filterUpdatesForReplayFrom(replay.updates, replayFrom as Record<string, unknown>)
-      : replay.updates;
+      ? filterUpdatesForReplayFrom(replayUpdates, replayFrom as Record<string, unknown>)
+      : replayUpdates;
   for (const update of updates) {
     await emit(update);
   }
+}
+
+function remapV2UserMessageIds(
+  updates: v1.SessionUpdate[],
+  messageIdsByStep: Record<string, string>
+): v1.SessionUpdate[] {
+  return updates.map((update) => {
+    const raw = update as unknown as Record<string, unknown>;
+    if (raw.sessionUpdate !== "user_message_chunk") return update;
+    const meta = raw._meta as Record<string, unknown> | undefined;
+    const messageId = typeof meta?.stepIdx === "number"
+      ? messageIdsByStep[String(meta.stepIdx)]
+      : undefined;
+    return messageId ? ({ ...raw, messageId } as unknown as v1.SessionUpdate) : update;
+  });
 }
 
 function dedupe(values: string[]): string[] {

--- a/src/acp/session/store.ts
+++ b/src/acp/session/store.ts
@@ -34,6 +34,8 @@ export interface StoredSession {
   reasoningEffort: string;
   /** Matches ACP config option `mode` (`default` | `accept-edits` | `plan`). Absent on older store files. */
   mode?: string;
+  /** Stable v2 user-message IDs keyed by their persisted agy step index. */
+  v2UserMessageIdsByStep: Record<string, string>;
   updatedAt: string;
 }
 
@@ -151,8 +153,18 @@ function normalizeStoredSession(raw: LegacyStoredSession): StoredSession {
     model: raw.model ?? raw.modelId ?? "",
     reasoningEffort: raw.reasoningEffort ?? raw.reasoningEffect ?? "",
     mode: raw.mode,
+    v2UserMessageIdsByStep: normalizeMessageIdMap(raw.v2UserMessageIdsByStep),
     updatedAt: raw.updatedAt ?? new Date(0).toISOString()
   };
+}
+
+function normalizeMessageIdMap(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      ([stepIdx, messageId]) => /^\d+$/.test(stepIdx) && typeof messageId === "string" && messageId.length > 0
+    )
+  ) as Record<string, string>;
 }
 
 function optional(value: string | undefined): string | undefined {

--- a/src/acp/session/types.ts
+++ b/src/acp/session/types.ts
@@ -16,6 +16,4 @@ export interface SessionState {
   activePrompt: boolean;
   /** Active v2 prompt-turn abort controller, if any. */
   promptAbort?: AbortController;
-  /** Last assigned user message index in this session. */
-  lastUserMsgIdx?: number;
 }

--- a/src/acp/session/types.ts
+++ b/src/acp/session/types.ts
@@ -14,6 +14,8 @@ export interface SessionState {
   selectedBaseModel: string;
   selectedReasoningEffort: string;
   activePrompt: boolean;
+  /** Stable v2 user-message IDs keyed by their persisted agy step index. */
+  v2UserMessageIdsByStep: Record<string, string>;
   /** Active v2 prompt-turn abort controller, if any. */
   promptAbort?: AbortController;
 }

--- a/src/acp/session/types.ts
+++ b/src/acp/session/types.ts
@@ -16,4 +16,6 @@ export interface SessionState {
   activePrompt: boolean;
   /** Active v2 prompt-turn abort controller, if any. */
   promptAbort?: AbortController;
+  /** Last assigned user message index in this session. */
+  lastUserMsgIdx?: number;
 }

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -366,9 +366,6 @@ export function expandSessionUpdateToV2(
     meta.status === "completed" ||
     meta.status === "failed" ||
     meta.status === "cancelled";
-  if (finished) {
-    terminalTracker.delete(meta.terminalId);
-  }
 
   const tool = sessionUpdateToV2(update) as unknown as Record<string, unknown>;
   tool.content = withTerminalContent(tool.content, meta.terminalId, meta.status);

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -121,13 +121,13 @@ function cleanContentItem(item: unknown): unknown {
   return item;
 }
 
-export type TerminalOutputTracker = Map<string, number>;
+export type TerminalOutputTracker = Map<string, string>;
 export type ToolCallContentTracker = Map<string, number>;
 
 const MAX_TERMINAL_TRACKER_SIZE = 500;
 
 export function createTerminalOutputTracker(): TerminalOutputTracker {
-  return new Map<string, number>();
+  return new Map<string, string>();
 }
 
 export function createToolCallContentTracker(): ToolCallContentTracker {
@@ -144,10 +144,10 @@ export function resetTerminalOutputTracker(): void {
   defaultToolCallContentTracker.clear();
 }
 
-function setTrackedOutputLength(
+function setTrackedOutput(
   tracker: TerminalOutputTracker,
   terminalId: string,
-  length: number
+  output: string
 ): void {
   if (!tracker.has(terminalId) && tracker.size >= MAX_TERMINAL_TRACKER_SIZE) {
     const oldestKey = tracker.keys().next().value;
@@ -155,7 +155,7 @@ function setTrackedOutputLength(
       tracker.delete(oldestKey);
     }
   }
-  tracker.set(terminalId, length);
+  tracker.set(terminalId, output);
 }
 
 function setTrackedToolContentCount(
@@ -199,15 +199,15 @@ export function sessionUpdateToV1(
         };
         metaObj.terminal_info = { terminal_id: meta.terminalId };
         if (meta.output != null && meta.output.length > 0) {
-          const prevLen = tracker.get(meta.terminalId) ?? 0;
-          if (meta.output.length > prevLen) {
-            const newChunk = meta.output.slice(prevLen);
+          const previousOutput = tracker.get(meta.terminalId) ?? "";
+          if (meta.output.startsWith(previousOutput) && meta.output.length > previousOutput.length) {
+            const newChunk = meta.output.slice(previousOutput.length);
             metaObj.terminal_output = { data: Buffer.from(newChunk, "utf8").toString("base64") };
-            setTrackedOutputLength(tracker, meta.terminalId, meta.output.length);
-          } else if (meta.output.length < prevLen) {
+            setTrackedOutput(tracker, meta.terminalId, meta.output);
+          } else if (meta.output !== previousOutput) {
             // terminal_output in ACP v1 is append-only. Do not append a reset snapshot
-            // to an existing terminal stream; update tracked length for future chunks.
-            setTrackedOutputLength(tracker, meta.terminalId, meta.output.length);
+            // to an existing terminal stream; track the replacement for future chunks.
+            setTrackedOutput(tracker, meta.terminalId, meta.output);
           }
         }
         const finished =
@@ -344,18 +344,22 @@ export function expandSessionUpdateToV2(
     return processV2ToolContentChunks(v2Update, toolContentTracker);
   }
 
-  const prevLen = terminalTracker.get(meta.terminalId) ?? 0;
+  const previousOutput = terminalTracker.get(meta.terminalId) ?? "";
   let terminalChunk: V2SessionUpdate | null = null;
-  if (meta.output != null && meta.output.length > prevLen) {
-    const newChunk = meta.output.slice(prevLen);
-    setTrackedOutputLength(terminalTracker, meta.terminalId, meta.output.length);
+  if (
+    meta.output != null &&
+    meta.output.startsWith(previousOutput) &&
+    meta.output.length > previousOutput.length
+  ) {
+    const newChunk = meta.output.slice(previousOutput.length);
+    setTrackedOutput(terminalTracker, meta.terminalId, meta.output);
     terminalChunk = {
       sessionUpdate: "terminal_output_chunk",
       terminalId: meta.terminalId,
       data: Buffer.from(newChunk, "utf8").toString("base64")
     } as V2SessionUpdate;
-  } else if (meta.output != null && meta.output.length < prevLen) {
-    setTrackedOutputLength(terminalTracker, meta.terminalId, meta.output.length);
+  } else if (meta.output != null && meta.output !== previousOutput) {
+    setTrackedOutput(terminalTracker, meta.terminalId, meta.output);
   }
 
   const finished =
@@ -452,4 +456,3 @@ function processV2ToolContentChunks(
   updates.push(v2Update);
   return updates;
 }
-

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -370,13 +370,32 @@ export function expandSessionUpdateToV2(
   tool.content = withTerminalContent(tool.content, meta.terminalId, meta.status);
   const toolV2Updates = processV2ToolContentChunks(tool as V2SessionUpdate, toolContentTracker);
 
-  // Omit output snapshot from terminal_update when terminal_output_chunk is emitted
-  // so output bytes are not sent twice to the client.
-  const terminalUpdate = terminalUpdateForExecute(meta, { includeOutput: !terminalChunk });
-  const updates: V2SessionUpdate[] = [terminalUpdate];
-  if (terminalChunk) {
+  const hasExitStatus = finished || typeof meta.exitCode === "number";
+  const updates: V2SessionUpdate[] = [];
+
+  if (terminalChunk && hasExitStatus) {
+    // When newly observed terminal output arrives at process completion,
+    // emit start metadata first, then the output chunk, then exitStatus.
+    // This prevents clients from evicting/closing the terminal before reading the chunk.
+    const startTerminalUpdate = terminalUpdateForExecute(meta, {
+      includeOutput: false,
+      includeExitStatus: false
+    });
+    const exitTerminalUpdate = terminalUpdateForExecute(meta, {
+      includeOutput: false,
+      includeExitStatus: true
+    });
+    updates.push(startTerminalUpdate);
     updates.push(terminalChunk);
+    updates.push(exitTerminalUpdate);
+  } else {
+    const terminalUpdate = terminalUpdateForExecute(meta, { includeOutput: !terminalChunk });
+    updates.push(terminalUpdate);
+    if (terminalChunk) {
+      updates.push(terminalChunk);
+    }
   }
+
   updates.push(...toolV2Updates);
 
   return updates;
@@ -399,14 +418,13 @@ function processV2ToolContentChunks(
   const contentItems = Array.isArray(raw.content)
     ? (raw.content as Record<string, unknown>[])
     : [];
-  const prevCount = toolContentTracker.get(toolCallId) ?? 0;
 
   const finished =
     raw.status === "completed" ||
     raw.status === "failed" ||
     raw.status === "cancelled";
 
-  if (prevCount === 0) {
+  if (!toolContentTracker.has(toolCallId)) {
     setTrackedToolContentCount(toolContentTracker, toolCallId, contentItems.length);
     if (finished) {
       toolContentTracker.delete(toolCallId);
@@ -414,6 +432,7 @@ function processV2ToolContentChunks(
     return [v2Update];
   }
 
+  const prevCount = toolContentTracker.get(toolCallId)!;
   const updates: V2SessionUpdate[] = [];
   if (contentItems.length > prevCount) {
     for (let i = prevCount; i < contentItems.length; i++) {

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -122,6 +122,7 @@ function cleanContentItem(item: unknown): unknown {
 }
 
 export type TerminalOutputTracker = Map<string, number>;
+export type ToolCallContentTracker = Map<string, number>;
 
 const MAX_TERMINAL_TRACKER_SIZE = 500;
 
@@ -129,10 +130,18 @@ export function createTerminalOutputTracker(): TerminalOutputTracker {
   return new Map<string, number>();
 }
 
+export function createToolCallContentTracker(): ToolCallContentTracker {
+  return new Map<string, number>();
+}
+
 const defaultTerminalOutputTracker = createTerminalOutputTracker();
+const defaultV2TerminalOutputTracker = createTerminalOutputTracker();
+const defaultToolCallContentTracker = createToolCallContentTracker();
 
 export function resetTerminalOutputTracker(): void {
   defaultTerminalOutputTracker.clear();
+  defaultV2TerminalOutputTracker.clear();
+  defaultToolCallContentTracker.clear();
 }
 
 function setTrackedOutputLength(
@@ -147,6 +156,20 @@ function setTrackedOutputLength(
     }
   }
   tracker.set(terminalId, length);
+}
+
+function setTrackedToolContentCount(
+  tracker: ToolCallContentTracker,
+  toolCallId: string,
+  count: number
+): void {
+  if (!tracker.has(toolCallId) && tracker.size >= MAX_TERMINAL_TRACKER_SIZE) {
+    const oldestKey = tracker.keys().next().value;
+    if (oldestKey !== undefined) {
+      tracker.delete(oldestKey);
+    }
+  }
+  tracker.set(toolCallId, count);
 }
 
 /** Identity cast for the v1 wire format (builders already emit v1 shapes). */
@@ -305,18 +328,106 @@ function planToV2(raw: Record<string, unknown>): V2SessionUpdate {
 
 /**
  * Expand one v1-shaped update into one or more v2 session updates.
- * Execute tools produce `terminal_update` then `tool_call_update` with a
- * display-only `{ type: "terminal", terminalId }` content block.
+ * Execute tools produce `terminal_update`, optional `terminal_output_chunk`,
+ * and `tool_call_update` with a display-only `{ type: "terminal", terminalId }`
+ * content block. Progressive tool call updates emit `tool_call_content_chunk`.
  */
-export function expandSessionUpdateToV2(update: V1SessionUpdate): V2SessionUpdate[] {
+export function expandSessionUpdateToV2(
+  update: V1SessionUpdate,
+  terminalTracker: TerminalOutputTracker = defaultV2TerminalOutputTracker,
+  toolContentTracker: ToolCallContentTracker = defaultToolCallContentTracker
+): V2SessionUpdate[] {
   const meta = executeTerminalMeta(update);
+
   if (!meta) {
-    return [sessionUpdateToV2(update)];
+    const v2Update = sessionUpdateToV2(update);
+    return processV2ToolContentChunks(v2Update, toolContentTracker);
+  }
+
+  const prevLen = terminalTracker.get(meta.terminalId) ?? 0;
+  let terminalChunk: V2SessionUpdate | null = null;
+  if (meta.output != null && meta.output.length > prevLen) {
+    const newChunk = meta.output.slice(prevLen);
+    setTrackedOutputLength(terminalTracker, meta.terminalId, meta.output.length);
+    terminalChunk = {
+      sessionUpdate: "terminal_output_chunk",
+      terminalId: meta.terminalId,
+      data: Buffer.from(newChunk, "utf8").toString("base64")
+    } as V2SessionUpdate;
+  } else if (meta.output != null && meta.output.length < prevLen) {
+    setTrackedOutputLength(terminalTracker, meta.terminalId, meta.output.length);
+  }
+
+  const finished =
+    meta.status === "completed" ||
+    meta.status === "failed" ||
+    meta.status === "cancelled";
+  if (finished) {
+    terminalTracker.delete(meta.terminalId);
   }
 
   const tool = sessionUpdateToV2(update) as unknown as Record<string, unknown>;
   tool.content = withTerminalContent(tool.content, meta.terminalId, meta.status);
+  const toolV2Updates = processV2ToolContentChunks(tool as V2SessionUpdate, toolContentTracker);
 
-  return [terminalUpdateForExecute(meta), tool as V2SessionUpdate];
+  const updates: V2SessionUpdate[] = [terminalUpdateForExecute(meta)];
+  if (terminalChunk) {
+    updates.push(terminalChunk);
+  }
+  updates.push(...toolV2Updates);
+
+  return updates;
+}
+
+function processV2ToolContentChunks(
+  v2Update: V2SessionUpdate,
+  toolContentTracker: ToolCallContentTracker
+): V2SessionUpdate[] {
+  const raw = v2Update as unknown as Record<string, unknown>;
+  if (
+    raw.sessionUpdate !== "tool_call_update" ||
+    typeof raw.toolCallId !== "string" ||
+    !raw.toolCallId
+  ) {
+    return [v2Update];
+  }
+
+  const toolCallId = raw.toolCallId;
+  const contentItems = Array.isArray(raw.content)
+    ? (raw.content as Record<string, unknown>[])
+    : [];
+  const prevCount = toolContentTracker.get(toolCallId) ?? 0;
+
+  const finished =
+    raw.status === "completed" ||
+    raw.status === "failed" ||
+    raw.status === "cancelled";
+
+  if (prevCount === 0) {
+    setTrackedToolContentCount(toolContentTracker, toolCallId, contentItems.length);
+    if (finished) {
+      toolContentTracker.delete(toolCallId);
+    }
+    return [v2Update];
+  }
+
+  const updates: V2SessionUpdate[] = [];
+  if (contentItems.length > prevCount) {
+    for (let i = prevCount; i < contentItems.length; i++) {
+      updates.push({
+        sessionUpdate: "tool_call_content_chunk",
+        toolCallId,
+        content: contentItems[i]
+      } as V2SessionUpdate);
+    }
+    setTrackedToolContentCount(toolContentTracker, toolCallId, contentItems.length);
+  }
+
+  if (finished) {
+    toolContentTracker.delete(toolCallId);
+  }
+
+  updates.push(v2Update);
+  return updates;
 }
 

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -370,7 +370,10 @@ export function expandSessionUpdateToV2(
   tool.content = withTerminalContent(tool.content, meta.terminalId, meta.status);
   const toolV2Updates = processV2ToolContentChunks(tool as V2SessionUpdate, toolContentTracker);
 
-  const updates: V2SessionUpdate[] = [terminalUpdateForExecute(meta)];
+  // Omit output snapshot from terminal_update when terminal_output_chunk is emitted
+  // so output bytes are not sent twice to the client.
+  const terminalUpdate = terminalUpdateForExecute(meta, { includeOutput: !terminalChunk });
+  const updates: V2SessionUpdate[] = [terminalUpdate];
   if (terminalChunk) {
     updates.push(terminalChunk);
   }

--- a/src/acp/terminal/index.ts
+++ b/src/acp/terminal/index.ts
@@ -122,14 +122,17 @@ function utf8ToBase64(text: string): string {
  * command metadata. Output is a full replacement snapshot (not live PTY bytes);
  * mid-command streaming only appears if agy persists partial field-28 results.
  */
-export function terminalUpdateForExecute(meta: ExecuteTerminalMeta): V2SessionUpdate {
+export function terminalUpdateForExecute(
+  meta: ExecuteTerminalMeta,
+  options?: { includeOutput?: boolean }
+): V2SessionUpdate {
   const update: Record<string, unknown> = {
     sessionUpdate: "terminal_update",
     terminalId: meta.terminalId
   };
   if (meta.command) update.command = meta.command;
   if (meta.cwd) update.cwd = meta.cwd;
-  if (meta.output != null && meta.output.length > 0) {
+  if (options?.includeOutput !== false && meta.output != null && meta.output.length > 0) {
     update.output = { data: utf8ToBase64(meta.output) };
   }
 

--- a/src/acp/terminal/index.ts
+++ b/src/acp/terminal/index.ts
@@ -124,7 +124,7 @@ function utf8ToBase64(text: string): string {
  */
 export function terminalUpdateForExecute(
   meta: ExecuteTerminalMeta,
-  options?: { includeOutput?: boolean }
+  options?: { includeOutput?: boolean; includeExitStatus?: boolean }
 ): V2SessionUpdate {
   const update: Record<string, unknown> = {
     sessionUpdate: "terminal_update",
@@ -136,18 +136,20 @@ export function terminalUpdateForExecute(
     update.output = { data: utf8ToBase64(meta.output) };
   }
 
-  const finished =
-    meta.status === "completed" ||
-    meta.status === "failed" ||
-    meta.status === "cancelled";
-  if (finished) {
-    const exitStatus: Record<string, unknown> = {};
-    if (typeof meta.exitCode === "number") exitStatus.exitCode = meta.exitCode;
-    if (meta.status === "cancelled" && meta.exitCode == null) exitStatus.signal = "SIGINT";
-    update.exitStatus = exitStatus;
-  } else if (typeof meta.exitCode === "number") {
-    // Exit code without a terminal status still marks the process as exited.
-    update.exitStatus = { exitCode: meta.exitCode };
+  if (options?.includeExitStatus !== false) {
+    const finished =
+      meta.status === "completed" ||
+      meta.status === "failed" ||
+      meta.status === "cancelled";
+    if (finished) {
+      const exitStatus: Record<string, unknown> = {};
+      if (typeof meta.exitCode === "number") exitStatus.exitCode = meta.exitCode;
+      if (meta.status === "cancelled" && meta.exitCode == null) exitStatus.signal = "SIGINT";
+      update.exitStatus = exitStatus;
+    } else if (typeof meta.exitCode === "number") {
+      // Exit code without a terminal status still marks the process as exited.
+      update.exitStatus = { exitCode: meta.exitCode };
+    }
   }
 
   return update as V2SessionUpdate;

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -164,6 +164,7 @@ export class AgyCliSession {
   #extraPath: string | undefined;
   #conversationId: string | null = null;
   #lastStepIdx = -1;
+  #lastPromptUserStepIdxs: number[] = [];
   readonly config: AgyCliConfig;
   readonly spawnProcess: SpawnFactory;
   readonly ptyFactory?: PtyFactory;
@@ -190,6 +191,11 @@ export class AgyCliSession {
   /** Highest conversation-database step idx already delivered to the ACP client. */
   get lastStepIdx(): number {
     return this.#lastStepIdx;
+  }
+
+  /** Type-14 user rows observed during the most recent prompt invocation. */
+  get lastPromptUserStepIdxs(): readonly number[] {
+    return this.#lastPromptUserStepIdxs;
   }
 
   /** Seed the conversation binding from persisted state (for session/load and session/resume). */
@@ -285,6 +291,7 @@ export class AgyCliSession {
     fsBridge?: ClientFileSystem,
     elicitationCap?: ClientElicitationCapability
   ): Promise<PromptOutcome> {
+    this.#lastPromptUserStepIdxs = [];
     if (this.config.interactivePermissions) {
       if (!onPermission) throw new Error("interactive permissions require a permission callback");
       return this.runInteractivePrompt(prompt, onUpdate, onPermission, fsBridge, elicitationCap);
@@ -555,6 +562,7 @@ export class AgyCliSession {
     } finally {
       this.#conversationId = poller.conversationId ?? this.#conversationId;
       this.#lastStepIdx = Math.max(this.#lastStepIdx, poller.lastStepIdx);
+      this.#lastPromptUserStepIdxs = poller.userStepIdxs;
       poller.close();
       if (this.#cancelled && !failed) await this.stopPty();
       this.#cancelTurn = undefined;
@@ -656,9 +664,6 @@ export class AgyCliSession {
         if (attempt < TRAILING_POLL_ATTEMPTS - 1) await sleep(TRAILING_POLL_DELAY_MS);
       }
 
-      this.#conversationId = poller.conversationId;
-      this.#lastStepIdx = poller.lastStepIdx;
-
       if (exitCode && !this.#cancelled) {
         const stderr = Buffer.concat(stderrChunks).toString("utf8");
         throw new AgyCliError(
@@ -671,6 +676,9 @@ export class AgyCliSession {
 
       return { stopReason: this.#cancelled ? "cancelled" : "end_turn" };
     } finally {
+      this.#conversationId = poller.conversationId ?? this.#conversationId;
+      this.#lastStepIdx = Math.max(this.#lastStepIdx, poller.lastStepIdx);
+      this.#lastPromptUserStepIdxs = poller.userStepIdxs;
       poller.close();
       if (this.#process === child) {
         this.#process = undefined;

--- a/src/agy/db/replay.ts
+++ b/src/agy/db/replay.ts
@@ -1,9 +1,9 @@
-// Full conversation-history replay for session/load, with an incremental cache.
+// Full conversation-history replay for session/load, with a validated cache.
 //
-// agy conversation DBs are append-only, so replays are cached per conversation
-// and validated by file (mtime, size). On a cache hit the result is returned
-// without touching SQLite; when the file has merely grown, only the new tail of
-// steps is read and translated, then appended to the cached updates.
+// Replays are cached per conversation and validated by file (mtime, size). On
+// an exact cache hit the result is returned without touching SQLite. Any file
+// change triggers a full rebuild so replay message grouping and mutable step
+// snapshots do not depend on prior cache state.
 
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { ConversationDb, type DbStat, statConversation } from "./database.js";
@@ -42,7 +42,7 @@ function buildReplay(dir: string, id: string, opts: ReplayOptions): ReplayResult
 
 /**
  * Replays conversations into ACP updates, caching results so repeat loads of an
- * unchanged (or merely-extended) conversation are cheap.
+ * unchanged conversation are cheap.
  */
 export class ReplayCache {
   private readonly cache: Lru<string, CacheEntry>;
@@ -64,11 +64,6 @@ export class ReplayCache {
       if (entry.stat.mtimeMs === stat.mtimeMs && entry.stat.size === stat.size) {
         return { updates: entry.updates, maxIdx: entry.maxIdx };
       }
-      // Append path: file grew — translate only the new tail.
-      if (stat.size >= entry.stat.size) {
-        const appended = this.appendTail(dir, id, opts, entry, stat);
-        if (appended) return appended;
-      }
     }
 
     // Full (re)build.
@@ -76,37 +71,6 @@ export class ReplayCache {
     if (!built) return null;
     this.store(id, built, stat, opts);
     return built;
-  }
-
-  /** Read steps past the cached high-water mark and append their translation. */
-  private appendTail(
-    dir: string,
-    id: string,
-    opts: ReplayOptions,
-    entry: CacheEntry,
-    stat: DbStat
-  ): ReplayResult | null {
-    const conn = ConversationDb.open(dir, id);
-    if (!conn) return null;
-    try {
-      const newRows = conn.readAfter(entry.maxIdx);
-      if (newRows.length === 0) {
-        // Touched but no new steps (e.g. WAL checkpoint); just refresh the stat.
-        const refreshed: ReplayResult = { updates: entry.updates, maxIdx: entry.maxIdx };
-        this.store(id, refreshed, stat, opts);
-        return refreshed;
-      }
-      const translator = new Translator({ mode: "replay", ...opts });
-      const tail = translator.translate(newRows);
-      const result: ReplayResult = {
-        updates: entry.updates.concat(tail),
-        maxIdx: Math.max(entry.maxIdx, translator.lastStepIdx)
-      };
-      this.store(id, result, stat, opts);
-      return result;
-    } finally {
-      conn.close();
-    }
   }
 
   private store(id: string, result: ReplayResult, stat: DbStat, opts: ReplayOptions): void {

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -49,6 +49,7 @@ export class StreamPoller {
   private failedDataVersionAttempts = 0;
   private rowSnapshot = "";
   private readonly activePending = new Map<string, PendingInteraction>();
+  private readonly observedUserStepIdxs = new Set<number>();
 
   constructor(private readonly opts: StreamOptions) {
     this.boundId = opts.conversationId;
@@ -69,6 +70,11 @@ export class StreamPoller {
 
   get hadUpdates(): boolean {
     return this.translator.hadUpdates;
+  }
+
+  /** User-prompt rows observed during this prompt-scoped polling session. */
+  get userStepIdxs(): number[] {
+    return [...this.observedUserStepIdxs];
   }
 
   /** Newly observed status-9 tool calls from the most recent poll. */
@@ -110,6 +116,9 @@ export class StreamPoller {
     if (this.dataVersion === dataVersion) return [];
 
     const rows = this.db.readAfter(this.opts.baseStepIdx);
+    for (const row of rows) {
+      if (row.stepType === 14) this.observedUserStepIdxs.add(row.idx);
+    }
     if (!rows.hasDecodeError) {
       this.dataVersion = dataVersion;
       this.failedDataVersion = null;

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -45,13 +45,14 @@ export function toolCallId(stepRow: StepRow): string {
 }
 
 /** Map agy's step `status` column to an ACP tool_call status.
- *  2 = in progress, 3 = completed, 6 = cancelled/aborted, 7 = failed,
+ *  1/2 = active/in progress, 3 = completed, 6 = cancelled/aborted, 7 = failed,
  *  9 = generic RequestedInteraction (represented as pending for inspection).
  *  `cancelled` is ACP v2; v1 clients map it to `failed` at the protocol boundary. */
 function toolCallStatus(stepRow: StepRow): "pending" | "in_progress" | "completed" | "failed" | "cancelled" {
   switch (stepRow.status) {
     case 9:
       return "pending";
+    case 1:
     case 2:
       return "in_progress";
     case 6:

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -97,6 +97,8 @@ export class Translator {
   private readonly pendingAgentParts: string[] = [];
   // Replay: message id for the current buffered agent-text group.
   private pendingAgentMessageId: string | null = null;
+  private pendingAgentStartStepIdx: number | null = null;
+  private pendingAgentEndStepIdx: number | null = null;
 
   private _lastTitle: string | null = null;
   private _lastStepIdx = -1;
@@ -258,7 +260,9 @@ export class Translator {
       if (text.length > 0) {
         if (this.pendingAgentMessageId === null) {
           this.pendingAgentMessageId = messageId;
+          this.pendingAgentStartStepIdx = row.idx;
         }
+        this.pendingAgentEndStepIdx = row.idx;
         this.pendingAgentParts.push(text);
       }
       return;
@@ -280,8 +284,23 @@ export class Translator {
       ? filterNarration(this.pendingAgentParts)
       : this.pendingAgentParts.join("\n");
     const messageId = this.pendingAgentMessageId ?? "agent";
+    const startStepIdx = this.pendingAgentStartStepIdx;
+    const endStepIdx = this.pendingAgentEndStepIdx;
     this.pendingAgentParts.length = 0;
     this.pendingAgentMessageId = null;
-    if (text && text.length > 0) out.push(agentChunk(text, messageId));
+    this.pendingAgentStartStepIdx = null;
+    this.pendingAgentEndStepIdx = null;
+    if (text && text.length > 0) {
+      const chunk = agentChunk(text, messageId);
+      if (startStepIdx != null) {
+        const stamped = withStepMeta(chunk, startStepIdx);
+        if (endStepIdx != null && endStepIdx > startStepIdx) {
+          ((stamped as unknown as Record<string, unknown>)._meta as Record<string, unknown>).endStepIdx = endStepIdx;
+        }
+        out.push(stamped);
+      } else {
+        out.push(chunk);
+      }
+    }
   }
 }

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -4,8 +4,8 @@
 // stream (step type 15):
 //
 //   - streaming emits the newly-appended slice each poll (text grows in place
-//     at a fixed idx), and re-emits tool steps as `tool_call_update` when their
-//     status/content snapshot changes;
+//     at a fixed idx), keeps consecutive text rows under one message id, and
+//     re-emits tool steps as `tool_call_update` when their status/content snapshot changes;
 //   - replay buffers consecutive agent-text parts and flushes them as one
 //     message at each boundary, applying narration filtering across the group.
 //
@@ -119,19 +119,33 @@ export class Translator {
   /** Translate a batch of rows into ordered ACP updates, advancing state. */
   translate(rows: StepRow[]): SessionUpdate[] {
     const out: SessionUpdate[] = [];
-    for (const row of rows) this.translateRow(row, out);
+    let streamingAgentMessageId: string | null = null;
+    for (const row of rows) {
+      if (this.opts.mode === "stream") {
+        if (row.stepType === 15) {
+          streamingAgentMessageId ??= String(row.idx);
+        } else {
+          streamingAgentMessageId = null;
+        }
+      }
+      this.translateRow(row, out, streamingAgentMessageId);
+    }
     // Replay groups agent text per batch; a batch ends a message boundary.
     if (this.opts.mode === "replay") this.flushAgentBuffer(out);
     if (out.length > 0) this._hadUpdates = true;
     return out;
   }
 
-  private translateRow(row: StepRow, out: SessionUpdate[]): void {
+  private translateRow(
+    row: StepRow,
+    out: SessionUpdate[],
+    streamingAgentMessageId: string | null
+  ): void {
     this._lastStepIdx = Math.max(this._lastStepIdx, row.idx);
 
     switch (row.stepType) {
       case 15: // agent text chunk
-        this.handleAgentText(row, out);
+        this.handleAgentText(row, out, streamingAgentMessageId);
         return;
 
       case 23: // conversation title (+ optional think narration)
@@ -247,14 +261,18 @@ export class Translator {
     this.emitThought(row.idx, thoughtChunk(narration, `title-thought-${row.idx}`), out);
   }
 
-  private handleAgentText(row: StepRow, out: SessionUpdate[]): void {
+  private handleAgentText(
+    row: StepRow,
+    out: SessionUpdate[],
+    streamingAgentMessageId: string | null
+  ): void {
     const thought = row.stepPayload.agentText?.thought;
     if (thought) {
       this.emitThought(row.idx, thoughtChunk(thought, `agent-thought-${row.idx}`), out);
     }
 
     const text = row.stepPayload.agentText?.text ?? "";
-    const messageId = String(row.idx);
+    const messageId = streamingAgentMessageId ?? String(row.idx);
 
     if (this.opts.mode === "replay") {
       if (text.length > 0) {

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -120,16 +120,22 @@ export class Translator {
   translate(rows: StepRow[]): SessionUpdate[] {
     const out: SessionUpdate[] = [];
     let streamingAgentMessageId: string | null = null;
+    let streamingHasVisibleText = false;
     for (const row of rows) {
+      let streamingNeedsSeparator = false;
       if (this.opts.mode === "stream") {
         if (row.stepType === 15) {
           const text = row.stepPayload.agentText?.text ?? "";
           if (text.length > 0) streamingAgentMessageId ??= String(row.idx);
+          const visible = text.length > 0 && !(this.opts.skipNarration && isNarration(text));
+          streamingNeedsSeparator = visible && streamingHasVisibleText;
+          if (visible) streamingHasVisibleText = true;
         } else {
           streamingAgentMessageId = null;
+          streamingHasVisibleText = false;
         }
       }
-      this.translateRow(row, out, streamingAgentMessageId);
+      this.translateRow(row, out, streamingAgentMessageId, streamingNeedsSeparator);
     }
     // Replay groups agent text per batch; a batch ends a message boundary.
     if (this.opts.mode === "replay") this.flushAgentBuffer(out);
@@ -140,13 +146,14 @@ export class Translator {
   private translateRow(
     row: StepRow,
     out: SessionUpdate[],
-    streamingAgentMessageId: string | null
+    streamingAgentMessageId: string | null,
+    streamingNeedsSeparator: boolean
   ): void {
     this._lastStepIdx = Math.max(this._lastStepIdx, row.idx);
 
     switch (row.stepType) {
       case 15: // agent text chunk
-        this.handleAgentText(row, out, streamingAgentMessageId);
+        this.handleAgentText(row, out, streamingAgentMessageId, streamingNeedsSeparator);
         return;
 
       case 23: // conversation title (+ optional think narration)
@@ -265,7 +272,8 @@ export class Translator {
   private handleAgentText(
     row: StepRow,
     out: SessionUpdate[],
-    streamingAgentMessageId: string | null
+    streamingAgentMessageId: string | null,
+    streamingNeedsSeparator: boolean
   ): void {
     const thought = row.stepPayload.agentText?.thought;
     if (thought) {
@@ -294,7 +302,9 @@ export class Translator {
     this.agentTextLengths.set(row.idx, text.length);
     if (this.opts.skipNarration && isNarration(text)) return;
     const delta = text.slice(emitted);
-    if (delta.length > 0) out.push(agentChunk(delta, messageId));
+    if (delta.length > 0) {
+      out.push(agentChunk(emitted === 0 && streamingNeedsSeparator ? `\n${delta}` : delta, messageId));
+    }
   }
 
   private flushAgentBuffer(out: SessionUpdate[]): void {

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -123,7 +123,8 @@ export class Translator {
     for (const row of rows) {
       if (this.opts.mode === "stream") {
         if (row.stepType === 15) {
-          streamingAgentMessageId ??= String(row.idx);
+          const text = row.stepPayload.agentText?.text ?? "";
+          if (text.length > 0) streamingAgentMessageId ??= String(row.idx);
         } else {
           streamingAgentMessageId = null;
         }

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -67,6 +67,16 @@ function updateSnapshot(update: SessionUpdate): string {
   });
 }
 
+function withStepMeta(update: SessionUpdate, stepIdx: number): SessionUpdate {
+  const raw = update as unknown as Record<string, unknown>;
+  const meta = (raw._meta as Record<string, unknown> | undefined) ?? {};
+  if (meta.stepIdx === stepIdx) return update;
+  return {
+    ...raw,
+    _meta: { ...meta, stepIdx }
+  } as unknown as SessionUpdate;
+}
+
 function asToolCallUpdate(update: SessionUpdate): SessionUpdate {
   return {
     ...(update as object),
@@ -171,35 +181,37 @@ export class Translator {
       return;
     }
 
+    const stamped = withStepMeta(update, stepIdx);
+
     if (kind === "plan" || kind === "plan_update" || kind === "plan_removed") {
-      const snapshot = updateSnapshot(update);
+      const snapshot = updateSnapshot(stamped);
       const key = typeof raw.planId === "string" && raw.planId ? `plan:${raw.planId}` : `plan:${stepIdx}`;
       const previous = this.toolSnapshots.get(key);
       if (previous === snapshot) return;
       this.toolSnapshots.set(key, snapshot);
-      out.push(update);
+      out.push(stamped);
       return;
     }
 
     if (kind !== "tool_call" && kind !== "tool_call_update") {
-      out.push(update);
+      out.push(stamped);
       return;
     }
 
-    const snapshot = updateSnapshot(update);
+    const snapshot = updateSnapshot(stamped);
     const toolId = typeof raw.toolCallId === "string" && raw.toolCallId.trim() ? raw.toolCallId.trim() : undefined;
     const key = toolId ? `tool:${toolId}` : `step:${stepIdx}`;
     const previous = this.toolSnapshots.get(key);
     if (previous === undefined) {
       this.toolSnapshots.set(key, snapshot);
       // First sight always uses create shape; v2 boundary may rewrite to upsert.
-      out.push({ ...raw, sessionUpdate: "tool_call" } as SessionUpdate);
+      out.push({ ...(stamped as object), sessionUpdate: "tool_call" } as SessionUpdate);
       return;
     }
     if (previous === snapshot) return;
 
     this.toolSnapshots.set(key, snapshot);
-    out.push(asToolCallUpdate(update));
+    out.push(asToolCallUpdate(stamped));
   }
 
   private emitThought(update: SessionUpdate, out: SessionUpdate[]): void {

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -177,7 +177,7 @@ export class Translator {
     const kind = raw.sessionUpdate;
 
     if (kind === "agent_thought_chunk") {
-      this.emitThought(update, out);
+      this.emitThought(stepIdx, update, out);
       return;
     }
 
@@ -214,7 +214,7 @@ export class Translator {
     out.push(asToolCallUpdate(stamped));
   }
 
-  private emitThought(update: SessionUpdate, out: SessionUpdate[]): void {
+  private emitThought(stepIdx: number, update: SessionUpdate, out: SessionUpdate[]): void {
     const raw = update as unknown as Record<string, unknown>;
     const content = raw.content as { type?: string; text?: string } | undefined;
     const text = typeof content?.text === "string" ? content.text : "";
@@ -226,7 +226,7 @@ export class Translator {
     if (text.length <= emitted) return;
     this.thoughtTextLengths.set(messageId, text.length);
     const delta = text.slice(emitted);
-    if (delta.length > 0) out.push(thoughtChunk(delta, messageId));
+    if (delta.length > 0) out.push(withStepMeta(thoughtChunk(delta, messageId), stepIdx));
   }
 
   private handleTitle(row: StepRow, out: SessionUpdate[]): void {
@@ -235,20 +235,20 @@ export class Translator {
     const currentTitle = blocks?.shift() || null;
     if (currentTitle !== this._lastTitle) {
       this._lastTitle = currentTitle;
-      out.push({ sessionUpdate: "session_info_update", title: currentTitle });
+      out.push(withStepMeta({ sessionUpdate: "session_info_update", title: currentTitle } as SessionUpdate, row.idx));
     }
 
     const narration = blocks?.filter((b) => b.trim().length > 0).join("\n\n") ?? "";
     if (!narration) return;
 
     // Title-attached "Think" narration is real agent thought, not a tool card.
-    this.emitThought(thoughtChunk(narration, `title-thought-${row.idx}`), out);
+    this.emitThought(row.idx, thoughtChunk(narration, `title-thought-${row.idx}`), out);
   }
 
   private handleAgentText(row: StepRow, out: SessionUpdate[]): void {
     const thought = row.stepPayload.agentText?.thought;
     if (thought) {
-      this.emitThought(thoughtChunk(thought, `agent-thought-${row.idx}`), out);
+      this.emitThought(row.idx, thoughtChunk(thought, `agent-thought-${row.idx}`), out);
     }
 
     const text = row.stepPayload.agentText?.text ?? "";

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1712,6 +1712,23 @@ describe("ACP v2 (experimental draft)", () => {
 
     expect(filterUpdatesForReplayFrom(updates, { type: "step", stepIdx: 2 })).toEqual([updates[1], updates[2]]);
 
+    const mergedUpdates = [
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "merged 1 and 2" },
+        _meta: { stepIdx: 1, endStepIdx: 2 }
+      },
+      {
+        sessionUpdate: "tool_call",
+        toolCallId: "call-3",
+        title: "run",
+        _meta: { stepIdx: 3 }
+      }
+    ] as SessionUpdate[];
+
+    expect(filterUpdatesForReplayFrom(mergedUpdates, { type: "step", stepIdx: 2 })).toEqual(mergedUpdates);
+
     expect(filterUpdatesForReplayFrom(updates, { type: "tool_call", toolCallId: "call-1" })).toEqual([
       updates[1],
       updates[2]

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1528,6 +1528,7 @@ describe("ACP v2 (experimental draft)", () => {
     const res1 = expandSessionUpdateToV2(update1, termTracker, toolTracker) as Array<Record<string, unknown>>;
     expect(res1).toHaveLength(3);
     expect(res1[0]).toMatchObject({ sessionUpdate: "terminal_update", command: "make" });
+    expect(res1[0].output).toBeUndefined();
     expect(res1[1]).toEqual({
       sessionUpdate: "terminal_output_chunk",
       terminalId: terminalIdForToolCall("stream-cmd"),
@@ -1548,6 +1549,7 @@ describe("ACP v2 (experimental draft)", () => {
     const res2 = expandSessionUpdateToV2(update2, termTracker, toolTracker) as Array<Record<string, unknown>>;
     expect(res2).toHaveLength(3);
     expect(res2[0]).toMatchObject({ sessionUpdate: "terminal_update", exitStatus: { exitCode: 0 } });
+    expect(res2[0].output).toBeUndefined();
     expect(res2[1]).toEqual({
       sessionUpdate: "terminal_output_chunk",
       terminalId: terminalIdForToolCall("stream-cmd"),
@@ -1598,15 +1600,15 @@ describe("ACP v2 (experimental draft)", () => {
   it("filters updates for replayFrom cursors", () => {
     const updates = [
       { sessionUpdate: "agent_message_chunk", messageId: "1", content: { type: "text", text: "one" } },
-      { sessionUpdate: "tool_call", toolCallId: "call-1", title: "read" },
-      { sessionUpdate: "agent_message_chunk", messageId: "2", content: { type: "text", text: "two" } }
+      { sessionUpdate: "tool_call", toolCallId: "call-1", title: "read", _meta: { stepIdx: 2 } },
+      { sessionUpdate: "agent_message_chunk", messageId: "3", content: { type: "text", text: "two" } }
     ] as SessionUpdate[];
 
     expect(filterUpdatesForReplayFrom(updates, { type: "start" })).toEqual(updates);
 
-    expect(filterUpdatesForReplayFrom(updates, { type: "message", messageId: "2" })).toEqual([updates[2]]);
+    expect(filterUpdatesForReplayFrom(updates, { type: "message", messageId: "3" })).toEqual([updates[2]]);
 
-    expect(filterUpdatesForReplayFrom(updates, { type: "step", stepIdx: 2 })).toEqual([updates[2]]);
+    expect(filterUpdatesForReplayFrom(updates, { type: "step", stepIdx: 2 })).toEqual([updates[1], updates[2]]);
 
     expect(filterUpdatesForReplayFrom(updates, { type: "tool_call", toolCallId: "call-1" })).toEqual([
       updates[1],

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -20,7 +20,8 @@ import {
 import { configFromEnv, type AgyCliConfig, type PtyFactory, type SpawnFactory } from "../src/agy/cli.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
-import { createTerminalOutputTracker, expandSessionUpdateToV2, sessionUpdateToV1, sessionUpdateToV2 } from "../src/acp/session/update-wire.js";
+import { createTerminalOutputTracker, createToolCallContentTracker, expandSessionUpdateToV2, sessionUpdateToV1, sessionUpdateToV2 } from "../src/acp/session/update-wire.js";
+import { filterUpdatesForReplayFrom } from "../src/acp/session/setup.js";
 import { terminalIdForToolCall } from "../src/acp/terminal/index.js";
 import type { SessionConfigOption, SessionUpdate } from "@agentclientprotocol/sdk";
 
@@ -1457,7 +1458,7 @@ describe("ACP v2 (experimental draft)", () => {
     } as SessionUpdate;
 
     const expanded = expandSessionUpdateToV2(update) as Array<Record<string, unknown>>;
-    expect(expanded).toHaveLength(2);
+    expect(expanded).toHaveLength(3);
 
     const terminalId = terminalIdForToolCall("cmd-1");
     expect(expanded[0]).toMatchObject({
@@ -1467,17 +1468,20 @@ describe("ACP v2 (experimental draft)", () => {
       cwd: "/repo",
       exitStatus: { exitCode: 0 }
     });
-    expect((expanded[0].output as { data?: string })?.data).toBe(
-      Buffer.from("README.md\n", "utf8").toString("base64")
-    );
 
-    expect(expanded[1]).toMatchObject({
+    expect(expanded[1]).toEqual({
+      sessionUpdate: "terminal_output_chunk",
+      terminalId,
+      data: Buffer.from("README.md\n", "utf8").toString("base64")
+    });
+
+    expect(expanded[2]).toMatchObject({
       sessionUpdate: "tool_call_update",
       toolCallId: "cmd-1",
       kind: "execute",
       status: "completed"
     });
-    const content = expanded[1].content as Array<Record<string, unknown>>;
+    const content = expanded[2].content as Array<Record<string, unknown>>;
     expect(content.some((item) => item.type === "terminal")).toBe(false);
     expect(content.some((item) => item.type === "content")).toBe(true);
   });
@@ -1505,6 +1509,113 @@ describe("ACP v2 (experimental draft)", () => {
       status: "in_progress",
       content: [{ type: "terminal", terminalId: terminalIdForToolCall("cmd-2") }]
     });
+  });
+
+  it("emits terminal_output_chunk for incremental command output bytes", () => {
+    const termTracker = createTerminalOutputTracker();
+    const toolTracker = createToolCallContentTracker();
+
+    const update1 = {
+      sessionUpdate: "tool_call",
+      toolCallId: "stream-cmd",
+      title: "build",
+      kind: "execute",
+      status: "in_progress",
+      rawInput: { CommandLine: "make" },
+      rawOutput: { output: "compiling step 1\n" }
+    } as unknown as SessionUpdate;
+
+    const res1 = expandSessionUpdateToV2(update1, termTracker, toolTracker) as Array<Record<string, unknown>>;
+    expect(res1).toHaveLength(3);
+    expect(res1[0]).toMatchObject({ sessionUpdate: "terminal_update", command: "make" });
+    expect(res1[1]).toEqual({
+      sessionUpdate: "terminal_output_chunk",
+      terminalId: terminalIdForToolCall("stream-cmd"),
+      data: Buffer.from("compiling step 1\n", "utf8").toString("base64")
+    });
+    expect(res1[2]).toMatchObject({ sessionUpdate: "tool_call_update", toolCallId: "stream-cmd" });
+
+    const update2 = {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "stream-cmd",
+      title: "build",
+      kind: "execute",
+      status: "completed",
+      rawInput: { CommandLine: "make" },
+      rawOutput: { exitCode: 0, output: "compiling step 1\ncompiling step 2\n" }
+    } as unknown as SessionUpdate;
+
+    const res2 = expandSessionUpdateToV2(update2, termTracker, toolTracker) as Array<Record<string, unknown>>;
+    expect(res2).toHaveLength(3);
+    expect(res2[0]).toMatchObject({ sessionUpdate: "terminal_update", exitStatus: { exitCode: 0 } });
+    expect(res2[1]).toEqual({
+      sessionUpdate: "terminal_output_chunk",
+      terminalId: terminalIdForToolCall("stream-cmd"),
+      data: Buffer.from("compiling step 2\n", "utf8").toString("base64")
+    });
+    expect(res2[2]).toMatchObject({ sessionUpdate: "tool_call_update", status: "completed" });
+  });
+
+  it("emits tool_call_content_chunk when new content items are appended", () => {
+    const termTracker = createTerminalOutputTracker();
+    const toolTracker = createToolCallContentTracker();
+
+    const update1 = {
+      sessionUpdate: "tool_call",
+      toolCallId: "tc-progress",
+      title: "fetch data",
+      kind: "fetch",
+      status: "in_progress",
+      content: [{ type: "content", content: { type: "text", text: "Part 1" } }]
+    } as unknown as SessionUpdate;
+
+    const res1 = expandSessionUpdateToV2(update1, termTracker, toolTracker) as Array<Record<string, unknown>>;
+    expect(res1).toHaveLength(1);
+    expect(res1[0]).toMatchObject({ sessionUpdate: "tool_call_update", toolCallId: "tc-progress" });
+
+    const update2 = {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tc-progress",
+      title: "fetch data",
+      kind: "fetch",
+      status: "completed",
+      content: [
+        { type: "content", content: { type: "text", text: "Part 1" } },
+        { type: "content", content: { type: "text", text: "Part 2" } }
+      ]
+    } as unknown as SessionUpdate;
+
+    const res2 = expandSessionUpdateToV2(update2, termTracker, toolTracker) as Array<Record<string, unknown>>;
+    expect(res2).toHaveLength(2);
+    expect(res2[0]).toEqual({
+      sessionUpdate: "tool_call_content_chunk",
+      toolCallId: "tc-progress",
+      content: { type: "content", content: { type: "text", text: "Part 2" } }
+    });
+    expect(res2[1]).toMatchObject({ sessionUpdate: "tool_call_update", status: "completed" });
+  });
+
+  it("filters updates for replayFrom cursors", () => {
+    const updates = [
+      { sessionUpdate: "agent_message_chunk", messageId: "1", content: { type: "text", text: "one" } },
+      { sessionUpdate: "tool_call", toolCallId: "call-1", title: "read" },
+      { sessionUpdate: "agent_message_chunk", messageId: "2", content: { type: "text", text: "two" } }
+    ] as SessionUpdate[];
+
+    expect(filterUpdatesForReplayFrom(updates, { type: "start" })).toEqual(updates);
+
+    expect(filterUpdatesForReplayFrom(updates, { type: "message", messageId: "2" })).toEqual([updates[2]]);
+
+    expect(filterUpdatesForReplayFrom(updates, { type: "step", stepIdx: 2 })).toEqual([updates[2]]);
+
+    expect(filterUpdatesForReplayFrom(updates, { type: "tool_call", toolCallId: "call-1" })).toEqual([
+      updates[1],
+      updates[2]
+    ]);
+
+    expect(() => filterUpdatesForReplayFrom(updates, { type: "invalid_cursor" })).toThrow(
+      "Unsupported replay cursor: invalid_cursor"
+    );
   });
 
   it("embeds _meta.terminal_* on v1 execute tool calls", () => {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1729,6 +1729,7 @@ describe("ACP v2 (experimental draft)", () => {
 
     expect(filterUpdatesForReplayFrom(mergedUpdates, { type: "step", stepIdx: 2 })).toEqual(mergedUpdates);
     expect(filterUpdatesForReplayFrom(mergedUpdates, { type: "message", messageId: "1" })).toEqual(mergedUpdates);
+    expect(filterUpdatesForReplayFrom(mergedUpdates, { type: "message", messageId: "2" })).toEqual(mergedUpdates);
 
     expect(filterUpdatesForReplayFrom(updates, { type: "tool_call", toolCallId: "call-1" })).toEqual([
       updates[1],

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1597,6 +1597,61 @@ describe("ACP v2 (experimental draft)", () => {
     expect(res2[1]).toMatchObject({ sessionUpdate: "tool_call_update", status: "completed" });
   });
 
+  it("isolates progressive trackers across separate sessions with identical toolCallIds", () => {
+    const sessionATermTracker = createTerminalOutputTracker();
+    const sessionAToolTracker = createToolCallContentTracker();
+    const sessionBTermTracker = createTerminalOutputTracker();
+    const sessionBToolTracker = createToolCallContentTracker();
+
+    const updateA1 = {
+      sessionUpdate: "tool_call",
+      toolCallId: "shared-cmd",
+      title: "run",
+      kind: "execute",
+      status: "in_progress",
+      rawInput: { CommandLine: "run" },
+      rawOutput: { output: "session A output prefix\n" }
+    } as unknown as SessionUpdate;
+
+    const resA1 = expandSessionUpdateToV2(updateA1, sessionATermTracker, sessionAToolTracker) as Array<Record<string, unknown>>;
+    expect(resA1[1]).toMatchObject({
+      sessionUpdate: "terminal_output_chunk",
+      data: Buffer.from("session A output prefix\n", "utf8").toString("base64")
+    });
+
+    const updateB1 = {
+      sessionUpdate: "tool_call",
+      toolCallId: "shared-cmd",
+      title: "run",
+      kind: "execute",
+      status: "in_progress",
+      rawInput: { CommandLine: "run" },
+      rawOutput: { output: "B\n" }
+    } as unknown as SessionUpdate;
+
+    const resB1 = expandSessionUpdateToV2(updateB1, sessionBTermTracker, sessionBToolTracker) as Array<Record<string, unknown>>;
+    expect(resB1[1]).toMatchObject({
+      sessionUpdate: "terminal_output_chunk",
+      data: Buffer.from("B\n", "utf8").toString("base64")
+    });
+
+    const updateA2 = {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "shared-cmd",
+      title: "run",
+      kind: "execute",
+      status: "completed",
+      rawInput: { CommandLine: "run" },
+      rawOutput: { exitCode: 0, output: "session A output prefix\nsession A output suffix\n" }
+    } as unknown as SessionUpdate;
+
+    const resA2 = expandSessionUpdateToV2(updateA2, sessionATermTracker, sessionAToolTracker) as Array<Record<string, unknown>>;
+    expect(resA2[1]).toMatchObject({
+      sessionUpdate: "terminal_output_chunk",
+      data: Buffer.from("session A output suffix\n", "utf8").toString("base64")
+    });
+  });
+
   it("filters updates for replayFrom cursors", () => {
     const updates = [
       { sessionUpdate: "agent_message_chunk", messageId: "1", content: { type: "text", text: "one" } },

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1728,6 +1728,7 @@ describe("ACP v2 (experimental draft)", () => {
     ] as SessionUpdate[];
 
     expect(filterUpdatesForReplayFrom(mergedUpdates, { type: "step", stepIdx: 2 })).toEqual(mergedUpdates);
+    expect(filterUpdatesForReplayFrom(mergedUpdates, { type: "message", messageId: "1" })).toEqual(mergedUpdates);
 
     expect(filterUpdatesForReplayFrom(updates, { type: "tool_call", toolCallId: "call-1" })).toEqual([
       updates[1],

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1618,6 +1618,33 @@ describe("ACP v2 (experimental draft)", () => {
     expect(res2[3]).toMatchObject({ sessionUpdate: "tool_call_update", status: "completed" });
   });
 
+  it("uses a terminal output snapshot when new output does not extend the previous snapshot", () => {
+    const termTracker = createTerminalOutputTracker();
+    const toolTracker = createToolCallContentTracker();
+    const update = (output: string) => ({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "rewritten-output",
+      title: "build",
+      kind: "execute",
+      status: "in_progress",
+      rawInput: { CommandLine: "make" },
+      rawOutput: { output }
+    } as unknown as SessionUpdate);
+
+    expandSessionUpdateToV2(update("abc"), termTracker, toolTracker);
+    const replaced = expandSessionUpdateToV2(
+      update("XYZ12"),
+      termTracker,
+      toolTracker
+    ) as Array<Record<string, unknown>>;
+
+    expect(replaced.some((item) => item.sessionUpdate === "terminal_output_chunk")).toBe(false);
+    expect(replaced[0]).toMatchObject({
+      sessionUpdate: "terminal_update",
+      output: { data: Buffer.from("XYZ12", "utf8").toString("base64") }
+    });
+  });
+
   it("emits tool_call_content_chunk when new content items are appended to a previously empty tool call", () => {
     const termTracker = createTerminalOutputTracker();
     const toolTracker = createToolCallContentTracker();

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1780,6 +1780,24 @@ describe("ACP v2 (experimental draft)", () => {
     expect(filterUpdatesForReplayFrom(mergedUpdates, { type: "message", messageId: "1" })).toEqual(mergedUpdates);
     expect(filterUpdatesForReplayFrom(mergedUpdates, { type: "message", messageId: "2" })).toEqual(mergedUpdates);
 
+    const thoughtAndAnswer = [
+      {
+        sessionUpdate: "agent_thought_chunk",
+        messageId: "agent-thought-4",
+        content: { type: "text", text: "thinking" },
+        _meta: { stepIdx: 4 }
+      },
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "4",
+        content: { type: "text", text: "answer" },
+        _meta: { stepIdx: 4 }
+      }
+    ] as SessionUpdate[];
+    expect(filterUpdatesForReplayFrom(thoughtAndAnswer, { type: "message", messageId: "4" })).toEqual([
+      thoughtAndAnswer[1]
+    ]);
+
     expect(filterUpdatesForReplayFrom(updates, { type: "tool_call", toolCallId: "call-1" })).toEqual([
       updates[1],
       updates[2]

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1722,6 +1722,33 @@ describe("ACP v2 (experimental draft)", () => {
     });
   });
 
+  it("retains terminal output progress when a completed row grows after first sight", () => {
+    const termTracker = createTerminalOutputTracker();
+    const toolTracker = createToolCallContentTracker();
+    const update = (output: string) => ({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "late-completed-output",
+      title: "build",
+      kind: "execute",
+      status: "completed",
+      rawInput: { CommandLine: "make" },
+      rawOutput: { exitCode: 0, output }
+    } as unknown as SessionUpdate);
+
+    expandSessionUpdateToV2(update("abc"), termTracker, toolTracker);
+    const grown = expandSessionUpdateToV2(
+      update("abcdef"),
+      termTracker,
+      toolTracker
+    ) as Array<Record<string, unknown>>;
+
+    expect(grown[1]).toEqual({
+      sessionUpdate: "terminal_output_chunk",
+      terminalId: terminalIdForToolCall("late-completed-output"),
+      data: Buffer.from("def", "utf8").toString("base64")
+    });
+  });
+
   it("emits tool_call_content_chunk when new content items are appended to a previously empty tool call", () => {
     const termTracker = createTerminalOutputTracker();
     const toolTracker = createToolCallContentTracker();

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1458,16 +1458,16 @@ describe("ACP v2 (experimental draft)", () => {
     } as SessionUpdate;
 
     const expanded = expandSessionUpdateToV2(update) as Array<Record<string, unknown>>;
-    expect(expanded).toHaveLength(3);
+    expect(expanded).toHaveLength(4);
 
     const terminalId = terminalIdForToolCall("cmd-1");
     expect(expanded[0]).toMatchObject({
       sessionUpdate: "terminal_update",
       terminalId,
       command: "ls",
-      cwd: "/repo",
-      exitStatus: { exitCode: 0 }
+      cwd: "/repo"
     });
+    expect(expanded[0].exitStatus).toBeUndefined();
 
     expect(expanded[1]).toEqual({
       sessionUpdate: "terminal_output_chunk",
@@ -1476,12 +1476,18 @@ describe("ACP v2 (experimental draft)", () => {
     });
 
     expect(expanded[2]).toMatchObject({
+      sessionUpdate: "terminal_update",
+      terminalId,
+      exitStatus: { exitCode: 0 }
+    });
+
+    expect(expanded[3]).toMatchObject({
       sessionUpdate: "tool_call_update",
       toolCallId: "cmd-1",
       kind: "execute",
       status: "completed"
     });
-    const content = expanded[2].content as Array<Record<string, unknown>>;
+    const content = expanded[3].content as Array<Record<string, unknown>>;
     expect(content.some((item) => item.type === "terminal")).toBe(false);
     expect(content.some((item) => item.type === "content")).toBe(true);
   });
@@ -1547,15 +1553,56 @@ describe("ACP v2 (experimental draft)", () => {
     } as unknown as SessionUpdate;
 
     const res2 = expandSessionUpdateToV2(update2, termTracker, toolTracker) as Array<Record<string, unknown>>;
-    expect(res2).toHaveLength(3);
-    expect(res2[0]).toMatchObject({ sessionUpdate: "terminal_update", exitStatus: { exitCode: 0 } });
-    expect(res2[0].output).toBeUndefined();
+    expect(res2).toHaveLength(4);
+    expect(res2[0]).toMatchObject({ sessionUpdate: "terminal_update" });
+    expect(res2[0].exitStatus).toBeUndefined();
     expect(res2[1]).toEqual({
       sessionUpdate: "terminal_output_chunk",
       terminalId: terminalIdForToolCall("stream-cmd"),
       data: Buffer.from("compiling step 2\n", "utf8").toString("base64")
     });
-    expect(res2[2]).toMatchObject({ sessionUpdate: "tool_call_update", status: "completed" });
+    expect(res2[2]).toMatchObject({
+      sessionUpdate: "terminal_update",
+      terminalId: terminalIdForToolCall("stream-cmd"),
+      exitStatus: { exitCode: 0 }
+    });
+    expect(res2[3]).toMatchObject({ sessionUpdate: "tool_call_update", status: "completed" });
+  });
+
+  it("emits tool_call_content_chunk when new content items are appended to a previously empty tool call", () => {
+    const termTracker = createTerminalOutputTracker();
+    const toolTracker = createToolCallContentTracker();
+
+    const update1 = {
+      sessionUpdate: "tool_call",
+      toolCallId: "tc-empty-init",
+      title: "fetch data",
+      kind: "fetch",
+      status: "in_progress",
+      content: []
+    } as unknown as SessionUpdate;
+
+    const res1 = expandSessionUpdateToV2(update1, termTracker, toolTracker) as Array<Record<string, unknown>>;
+    expect(res1).toHaveLength(1);
+    expect(res1[0]).toMatchObject({ sessionUpdate: "tool_call_update", toolCallId: "tc-empty-init" });
+
+    const update2 = {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tc-empty-init",
+      title: "fetch data",
+      kind: "fetch",
+      status: "completed",
+      content: [{ type: "content", content: { type: "text", text: "Late Data" } }]
+    } as unknown as SessionUpdate;
+
+    const res2 = expandSessionUpdateToV2(update2, termTracker, toolTracker) as Array<Record<string, unknown>>;
+    expect(res2).toHaveLength(2);
+    expect(res2[0]).toEqual({
+      sessionUpdate: "tool_call_content_chunk",
+      toolCallId: "tc-empty-init",
+      content: { type: "content", content: { type: "text", text: "Late Data" } }
+    });
+    expect(res2[1]).toMatchObject({ sessionUpdate: "tool_call_update", status: "completed" });
   });
 
   it("emits tool_call_content_chunk when new content items are appended", () => {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1302,6 +1302,55 @@ describe("ACP v2 (experimental draft)", () => {
     });
   });
 
+  it("keeps curated slash command IDs out of the DB step namespace", async () => {
+    await withConversationsDir(async (dir) => {
+      const updates: Array<Record<string, unknown>> = [];
+      const client = acpV2.client({ name: "test-client" }).onNotification(
+        acpV2.methods.client.session.update,
+        (ctx) => {
+          updates.push(ctx.params.update as Record<string, unknown>);
+        }
+      );
+      const connection = client.connect(
+        createAcpV2App({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess: spawnAgyWritingConversation(dir, "conv-v2-slash-id", [
+            { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "hi" }) }
+          ])
+        })
+      );
+      try {
+        await connection.agent.request(acpV2.methods.agent.initialize, {
+          protocolVersion: 2,
+          info: { name: "test-client", version: "0.0.0" },
+          capabilities: {}
+        });
+        const session = await connection.agent.request(acpV2.methods.agent.session.new, {
+          cwd: "/repo"
+        });
+
+        await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "/plan" }]
+        });
+        await waitFor(() => updates.some((u) => u.sessionUpdate === "state_update" && u.state === "idle"));
+        const slashMessage = updates.find((u) => u.sessionUpdate === "user_message");
+        expect(slashMessage?.messageId).toMatch(/^slash-[0-9a-f-]{36}$/);
+
+        updates.length = 0;
+        await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "hi" }]
+        });
+        await waitFor(() => updates.some((u) => u.sessionUpdate === "state_update" && u.state === "idle"));
+        const ordinaryMessage = updates.find((u) => u.sessionUpdate === "user_message");
+        expect(ordinaryMessage?.messageId).toBe("0");
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
   it("replays history on session/resume with replayFrom start", async () => {
     await withConversationsDir(async (dir) => {
       const appOptions = {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1344,29 +1344,96 @@ describe("ACP v2 (experimental draft)", () => {
         });
         await waitFor(() => updates.some((u) => u.sessionUpdate === "state_update" && u.state === "idle"));
         const ordinaryMessage = updates.find((u) => u.sessionUpdate === "user_message");
-        expect(ordinaryMessage?.messageId).toBe("0");
+        expect(ordinaryMessage?.messageId).toMatch(/^user-[0-9a-f-]{36}$/);
+        expect(ordinaryMessage?.messageId).not.toBe(slashMessage?.messageId);
       } finally {
         connection.close();
       }
     });
   });
 
-  it("replays history on session/resume with replayFrom start", async () => {
+  it("does not reuse a v2 user message ID after a prompt fails before persistence", async () => {
+    await withConversationsDir(async (dir) => {
+      let promptAttempts = 0;
+      const spawnProcess = ((_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        promptAttempts++;
+        if (promptAttempts === 1) {
+          return new FakeProcess([], { exitCode: 1, stderr: "prompt failed" });
+        }
+        const db = createConversationDb(dir, "conv-v2-after-failure");
+        insertStep(db, {
+          idx: 7,
+          stepType: 14,
+          stepPayload: encodeStepPayload({ userPrompt: "second prompt" })
+        });
+        db.close();
+        return new FakeProcess([]);
+      }) as unknown as SpawnFactory;
+      const updates: Array<Record<string, unknown>> = [];
+      const client = acpV2.client({ name: "test-client" }).onNotification(
+        acpV2.methods.client.session.update,
+        (ctx) => {
+          updates.push(ctx.params.update as Record<string, unknown>);
+        }
+      );
+      const connection = client.connect(
+        createAcpV2App({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(acpV2.methods.agent.initialize, {
+          protocolVersion: 2,
+          info: { name: "test-client", version: "0.0.0" },
+          capabilities: {}
+        });
+        const session = await connection.agent.request(acpV2.methods.agent.session.new, { cwd: "/repo" });
+
+        await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "first prompt" }]
+        });
+        await waitFor(() => updates.some((u) => u.sessionUpdate === "state_update" && u.state === "idle"));
+        const failedMessageId = updates.find((u) => u.sessionUpdate === "user_message")?.messageId;
+        await new Promise((resolve) => setImmediate(resolve));
+
+        updates.length = 0;
+        await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "second prompt" }]
+        });
+        await waitFor(() => updates.some((u) => u.sessionUpdate === "state_update" && u.state === "idle"));
+        const persistedMessageId = updates.find((u) => u.sessionUpdate === "user_message")?.messageId;
+
+        expect(failedMessageId).toMatch(/^user-[0-9a-f-]{36}$/);
+        expect(persistedMessageId).toMatch(/^user-[0-9a-f-]{36}$/);
+        expect(persistedMessageId).not.toBe(failedMessageId);
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  it("replays a persisted v2 user message from its live message ID", async () => {
     await withConversationsDir(async (dir) => {
       const appOptions = {
         env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
         spawnProcess: spawnAgyWritingConversation(dir, "conv-v2-replay", [
+          { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "hi" }) },
           { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "prior turn" }) }
         ])
       };
 
       let sessionId: string;
+      let liveUserMessageId: string;
       {
-        const updates: unknown[] = [];
+        const updates: Array<Record<string, unknown>> = [];
         const client = acpV2.client({ name: "test-client" }).onNotification(
           acpV2.methods.client.session.update,
           (ctx) => {
-            updates.push(ctx.params.update);
+            updates.push(ctx.params.update as Record<string, unknown>);
           }
         );
         const connection = client.connect(createAcpV2App(appOptions));
@@ -1385,7 +1452,11 @@ describe("ACP v2 (experimental draft)", () => {
             prompt: [{ type: "text", text: "hi" }]
           });
           // Drain the async turn so the conversation binding is persisted.
-          await waitFor(() => updates.some((u) => (u as { state?: string }).state === "idle"));
+          await waitFor(() => updates.some((u) => u.state === "idle"));
+          liveUserMessageId = String(
+            updates.find((u) => u.sessionUpdate === "user_message")?.messageId
+          );
+          expect(liveUserMessageId).toMatch(/^user-[0-9a-f-]{36}$/);
         } finally {
           connection.close();
         }
@@ -1409,8 +1480,14 @@ describe("ACP v2 (experimental draft)", () => {
           await connection.agent.request(acpV2.methods.agent.session.resume, {
             sessionId,
             cwd: "/repo",
-            replayFrom: { type: "start" }
+            replayFrom: { type: "message", messageId: liveUserMessageId }
           });
+          expect(updates).toContainEqual(
+            expect.objectContaining({
+              sessionUpdate: "user_message_chunk",
+              messageId: liveUserMessageId
+            })
+          );
           expect(updates).toContainEqual(
             expect.objectContaining({
               sessionUpdate: "agent_message_chunk",

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -138,7 +138,7 @@ describe("Translator", () => {
   it("uses one message id for consecutive agent-text rows in streaming and replay", () => {
     const db = createConversationDb(dir, "conv-stream-message-group");
     insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "Hello" }) });
-    insertStep(db, { idx: 2, stepType: 15, stepPayload: encodeStepPayload({ agentText: " world" }) });
+    insertStep(db, { idx: 2, stepType: 15, stepPayload: encodeStepPayload({ agentText: "world" }) });
     db.close();
 
     const streamConn = ConversationDb.open(dir, "conv-stream-message-group")!;
@@ -146,9 +146,17 @@ describe("Translator", () => {
       streamConn.readAfter(-1)
     );
     streamConn.close();
-    expect(streamUpdates).toMatchObject([
-      { sessionUpdate: "agent_message_chunk", messageId: "1" },
-      { sessionUpdate: "agent_message_chunk", messageId: "1" }
+    expect(streamUpdates).toEqual([
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "Hello" }
+      },
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "\nworld" }
+      }
     ]);
 
     const replayConn = ConversationDb.open(dir, "conv-stream-message-group")!;
@@ -156,8 +164,13 @@ describe("Translator", () => {
       replayConn.readAfter(-1)
     );
     replayConn.close();
-    expect(replayUpdates).toMatchObject([
-      { sessionUpdate: "agent_message_chunk", messageId: "1" }
+    expect(replayUpdates).toEqual([
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "Hello\nworld" },
+        _meta: { stepIdx: 1, endStepIdx: 2 }
+      }
     ]);
   });
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1134,7 +1134,7 @@ describe("StreamPoller", () => {
 });
 
 describe("ReplayCache", () => {
-  it("serves a cache hit without re-reading the file, and appends only the new tail on growth", () => {
+  it("serves unchanged cache hits and rebuilds grouped messages after growth", () => {
     const db = createConversationDb(dir, "conv-5");
     insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "Hello" }) });
 
@@ -1149,8 +1149,32 @@ describe("ReplayCache", () => {
     db.close();
 
     const grown = cache.get(dir, "conv-5", { skipNarration: false });
-    expect(grown?.updates).toHaveLength(2);
+    expect(grown?.updates).toEqual([
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "Hello\n world" },
+        _meta: { stepIdx: 1, endStepIdx: 2 }
+      }
+    ]);
     expect(grown?.maxIdx).toBe(2);
+  });
+
+  it("rebuilds cached replay after an in-place step update", () => {
+    const db = createConversationDb(dir, "conv-replay-mutation");
+    insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "partial" }) });
+
+    const cache = new ReplayCache(8);
+    expect(cache.get(dir, "conv-replay-mutation", { skipNarration: false })?.updates).toMatchObject([
+      { content: { text: "partial" } }
+    ]);
+
+    updateStepPayload(db, 1, encodeStepPayload({ agentText: "complete result" }));
+    db.close();
+
+    expect(cache.get(dir, "conv-replay-mutation", { skipNarration: false })?.updates).toMatchObject([
+      { content: { text: "complete result" } }
+    ]);
   });
 
   it("returns null for a missing conversation", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -221,6 +221,29 @@ describe("Translator", () => {
     db.close();
   });
 
+  it("maps active step status 1 to in_progress tool status", () => {
+    const db = createConversationDb(dir, "conv-status-1");
+    const call = encodeToolCall({ callId: "active-1", namePrimary: "run_command", rawInputJson: '{"CommandLine":"echo active"}' });
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 1, // active
+      stepPayload: encodeStepPayload({ toolRun: encodeToolRun({ call }) })
+    });
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const conn = ConversationDb.open(dir, "conv-status-1")!;
+    const res = translator.translate(conn.readAfter(0));
+    expect(res).toMatchObject([
+      {
+        sessionUpdate: "tool_call",
+        toolCallId: "active-1",
+        status: "in_progress"
+      }
+    ]);
+    conn.close();
+    db.close();
+  });
+
   it("maps permission-pending status 9 and dedupes its transition", () => {
     const db = createConversationDb(dir, "conv-pending");
     const payload = encodeStepPayload({ toolRun: encodeToolRun({ call: encodeToolCall({ callId: "p1", namePrimary: "run_command", rawInputJson: "{}" }) }) });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -252,11 +252,12 @@ describe("Translator", () => {
     conn.close();
 
     expect(updates).toEqual([
-      { sessionUpdate: "session_info_update", title: "My session" },
+      { sessionUpdate: "session_info_update", title: "My session", _meta: { stepIdx: 1 } },
       {
         sessionUpdate: "agent_thought_chunk",
         messageId: "title-thought-1",
-        content: { type: "text", text: "I will inspect the repo structure first." }
+        content: { type: "text", text: "I will inspect the repo structure first." },
+        _meta: { stepIdx: 1 }
       }
     ]);
 
@@ -287,7 +288,8 @@ describe("Translator", () => {
       {
         sessionUpdate: "agent_thought_chunk",
         messageId: "agent-thought-1",
-        content: { type: "text", text: "Thinking deeply..." }
+        content: { type: "text", text: "Thinking deeply..." },
+        _meta: { stepIdx: 1 }
       },
       {
         sessionUpdate: "agent_message_chunk",
@@ -306,7 +308,8 @@ describe("Translator", () => {
       {
         sessionUpdate: "agent_thought_chunk",
         messageId: "agent-thought-1",
-        content: { type: "text", text: "Thinking deeply..." }
+        content: { type: "text", text: "Thinking deeply..." },
+        _meta: { stepIdx: 1 }
       },
       {
         sessionUpdate: "agent_message_chunk",
@@ -786,6 +789,43 @@ describe("Translator", () => {
         sessionUpdate: "agent_message_chunk",
         messageId: "1",
         content: { type: "text", text: "Hello\n world" }
+      }
+    ]);
+  });
+
+  it("stamps _meta.stepIdx on title and thought updates", () => {
+    const db = createConversationDb(dir, "conv-stamped");
+    insertStep(db, { idx: 10, stepType: 23, stepPayload: encodeStepPayload({ titleUpdate: "My Title\n\nTitle narration" }) });
+    insertStep(db, { idx: 11, stepType: 15, stepPayload: encodeStepPayload({ agentText: { text: "Done", thought: "Thinking..." } }) });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-stamped")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toEqual([
+      {
+        sessionUpdate: "session_info_update",
+        title: "My Title",
+        _meta: { stepIdx: 10 }
+      },
+      {
+        sessionUpdate: "agent_thought_chunk",
+        messageId: "title-thought-10",
+        content: { type: "text", text: "Title narration" },
+        _meta: { stepIdx: 10 }
+      },
+      {
+        sessionUpdate: "agent_thought_chunk",
+        messageId: "agent-thought-11",
+        content: { type: "text", text: "Thinking..." },
+        _meta: { stepIdx: 11 }
+      },
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "11",
+        content: { type: "text", text: "Done" }
       }
     ]);
   });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -314,7 +314,8 @@ describe("Translator", () => {
       {
         sessionUpdate: "agent_message_chunk",
         messageId: "1",
-        content: { type: "text", text: "Final output" }
+        content: { type: "text", text: "Final output" },
+        _meta: { stepIdx: 1 }
       }
     ]);
   });
@@ -788,12 +789,13 @@ describe("Translator", () => {
       {
         sessionUpdate: "agent_message_chunk",
         messageId: "1",
-        content: { type: "text", text: "Hello\n world" }
+        content: { type: "text", text: "Hello\n world" },
+        _meta: { stepIdx: 1, endStepIdx: 2 }
       }
     ]);
   });
 
-  it("stamps _meta.stepIdx on title and thought updates", () => {
+  it("stamps _meta.stepIdx on title, thought, and agent text updates", () => {
     const db = createConversationDb(dir, "conv-stamped");
     insertStep(db, { idx: 10, stepType: 23, stepPayload: encodeStepPayload({ titleUpdate: "My Title\n\nTitle narration" }) });
     insertStep(db, { idx: 11, stepType: 15, stepPayload: encodeStepPayload({ agentText: { text: "Done", thought: "Thinking..." } }) });
@@ -825,7 +827,8 @@ describe("Translator", () => {
       {
         sessionUpdate: "agent_message_chunk",
         messageId: "11",
-        content: { type: "text", text: "Done" }
+        content: { type: "text", text: "Done" },
+        _meta: { stepIdx: 11 }
       }
     ]);
   });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -135,6 +135,32 @@ describe("Translator", () => {
     db.close();
   });
 
+  it("uses one message id for consecutive agent-text rows in streaming and replay", () => {
+    const db = createConversationDb(dir, "conv-stream-message-group");
+    insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "Hello" }) });
+    insertStep(db, { idx: 2, stepType: 15, stepPayload: encodeStepPayload({ agentText: " world" }) });
+    db.close();
+
+    const streamConn = ConversationDb.open(dir, "conv-stream-message-group")!;
+    const streamUpdates = new Translator({ mode: "stream", skipNarration: false }).translate(
+      streamConn.readAfter(-1)
+    );
+    streamConn.close();
+    expect(streamUpdates).toMatchObject([
+      { sessionUpdate: "agent_message_chunk", messageId: "1" },
+      { sessionUpdate: "agent_message_chunk", messageId: "1" }
+    ]);
+
+    const replayConn = ConversationDb.open(dir, "conv-stream-message-group")!;
+    const replayUpdates = new Translator({ mode: "replay", skipNarration: false }).translate(
+      replayConn.readAfter(-1)
+    );
+    replayConn.close();
+    expect(replayUpdates).toMatchObject([
+      { sessionUpdate: "agent_message_chunk", messageId: "1" }
+    ]);
+  });
+
   it("dedupes unchanged tool-call steps across repeated polls in stream mode", () => {
     const db = createConversationDb(dir, "conv-3");
     insertStep(db, {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -161,6 +161,44 @@ describe("Translator", () => {
     ]);
   });
 
+  it("starts a streaming message group at the first row containing answer text", () => {
+    const db = createConversationDb(dir, "conv-stream-thought-first");
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      stepPayload: encodeStepPayload({ agentText: { thought: "Thinking" } })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      stepPayload: encodeStepPayload({ agentText: "Answer" })
+    });
+    db.close();
+
+    const streamConn = ConversationDb.open(dir, "conv-stream-thought-first")!;
+    const streamUpdates = new Translator({ mode: "stream", skipNarration: false }).translate(
+      streamConn.readAfter(-1)
+    );
+    streamConn.close();
+    expect(streamUpdates).toContainEqual({
+      sessionUpdate: "agent_message_chunk",
+      messageId: "2",
+      content: { type: "text", text: "Answer" }
+    });
+
+    const replayConn = ConversationDb.open(dir, "conv-stream-thought-first")!;
+    const replayUpdates = new Translator({ mode: "replay", skipNarration: false }).translate(
+      replayConn.readAfter(-1)
+    );
+    replayConn.close();
+    expect(replayUpdates).toContainEqual({
+      sessionUpdate: "agent_message_chunk",
+      messageId: "2",
+      content: { type: "text", text: "Answer" },
+      _meta: { stepIdx: 2 }
+    });
+  });
+
   it("dedupes unchanged tool-call steps across repeated polls in stream mode", () => {
     const db = createConversationDb(dir, "conv-3");
     insertStep(db, {


### PR DESCRIPTION
## Description

Implement progressive streaming notifications and cursor tracking for experimental draft ACP v2:
- `terminal_output_chunk`: Stream incremental stdout/stderr bytes as notifications while commands are actively running.
- `tool_call_content_chunk`: Stream progressive tool call output and content updates as they arrive from `agy`'s poller during execution.
- `replayFrom`: Enhance session resume replay cursor tracking to support `start`, `message`, `step`/`step_idx`, and `tool_call` cursors.

## Related Issues

Closes #35

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [x] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed