### PR TITLE
Expand interactive tool bridging for multi-select and multi-question ask_question dialogs

### DIFF
--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -139,8 +139,8 @@ export async function handlePromptV1(
         sessionId: params.sessionId,
         update: sessionUpdateToV1(update, tracker)
       });
-    }, async (toolCall, { toolName }) => {
-      return requestPermissionV1(client, params.sessionId, toolCall, toolName, signal);
+    }, async (toolCall, { toolName, questionIndex }) => {
+      return requestPermissionV1(client, params.sessionId, toolCall, toolName, signal, questionIndex);
     }, deps.clientFileSystemV1(client, params.sessionId));
     await deps.persistSession(params.sessionId, session);
     return {
@@ -258,8 +258,8 @@ async function runV2PromptTurn(
         for (const v2Update of expandSessionUpdateToV2(update)) {
           await notify(v2Update);
         }
-      }, async (toolCall, { toolName }) => {
-        return requestPermissionV2(client, params.sessionId, toolCall, toolName, signal);
+      }, async (toolCall, { toolName, questionIndex }) => {
+        return requestPermissionV2(client, params.sessionId, toolCall, toolName, signal, questionIndex);
       });
       await deps.persistSession(params.sessionId, session);
 

--- a/src/acp/session/request-permission.ts
+++ b/src/acp/session/request-permission.ts
@@ -6,7 +6,7 @@ import * as v1 from "@agentclientprotocol/sdk";
 import type { AgentContext as V1AgentContext, SessionUpdate as V1SessionUpdate } from "@agentclientprotocol/sdk";
 import * as v2 from "@agentclientprotocol/sdk/experimental/v2";
 import type { AgentContext as V2AgentContext } from "@agentclientprotocol/sdk/experimental/v2";
-import { permissionOptions, type PermissionChoice } from "../tool-calls/permissions.js";
+import { permissionOptions, parseAskQuestion, type PermissionChoice } from "../tool-calls/permissions.js";
 import { expandSessionUpdateToV2, sessionUpdateToV2 } from "./update-wire.js";
 
 /** v1 `session/request_permission`: race the request against turn cancellation. */
@@ -15,7 +15,8 @@ export async function requestPermissionV1(
   sessionId: string,
   toolCall: V1SessionUpdate,
   toolName: string | undefined,
-  signal: AbortSignal | undefined
+  signal: AbortSignal | undefined,
+  questionIndex?: number
 ): Promise<PermissionChoice | "cancelled"> {
   if (signal?.aborted) return "cancelled";
   const { sessionUpdate: _discriminator, ...requestToolCall } = toolCall as unknown as Record<string, unknown>;
@@ -23,7 +24,7 @@ export async function requestPermissionV1(
     client.request(v1.methods.client.session.requestPermission, {
       sessionId,
       toolCall: requestToolCall as v1.ToolCallUpdate,
-      options: permissionOptions(toolCall, toolName)
+      options: permissionOptions(toolCall, toolName, questionIndex)
     }),
     signal
   );
@@ -36,7 +37,8 @@ export async function requestPermissionV2(
   sessionId: string,
   toolCall: V1SessionUpdate,
   toolName: string | undefined,
-  signal: AbortSignal
+  signal: AbortSignal,
+  questionIndex?: number
 ): Promise<PermissionChoice | "cancelled"> {
   if (signal.aborted) return "cancelled";
   const expanded = expandSessionUpdateToV2(toolCall);
@@ -45,12 +47,23 @@ export async function requestPermissionV2(
     return kind === "tool_call_update" || kind === "tool_call";
   }) ?? sessionUpdateToV2(toolCall)) as unknown as Record<string, unknown>;
   const { sessionUpdate: _discriminator, ...requestToolCall } = converted;
+
+  let title = String(requestToolCall.title ?? "Permission required");
+  if (toolName === "ask_question") {
+    const ask = parseAskQuestion(toolCall);
+    const qIdx = questionIndex ?? 0;
+    if (ask && ask.questions.length > 1 && qIdx < ask.questions.length) {
+      const q = ask.questions[qIdx];
+      title = `[Question ${qIdx + 1}/${ask.questions.length}] ${q.question || title}`;
+    }
+  }
+
   const response = await racePermissionCancellation(
     client.request(v2.methods.client.session.requestPermission, {
       sessionId,
-      title: String(requestToolCall.title ?? "Permission required"),
+      title,
       subject: { type: "tool_call", toolCall: requestToolCall as v2.ToolCallUpdate },
-      options: permissionOptions(toolCall, toolName)
+      options: permissionOptions(toolCall, toolName, questionIndex)
     }),
     signal
   );
@@ -72,8 +85,7 @@ function selectedPermission(response: unknown, signal?: AbortSignal): Permission
     id === "agy-allow-conversation" ||
     id === "agy-allow-settings" ||
     id === "agy-reject-once" ||
-    id === "agy-q-skip" ||
-    /^agy-q-\d+$/.test(id)
+    id.startsWith("agy-q-")
   ) {
     return id;
   }

--- a/src/acp/session/request-permission.ts
+++ b/src/acp/session/request-permission.ts
@@ -28,7 +28,7 @@ export async function requestPermissionV1(
   if (signal?.aborted) return "cancelled";
 
   if (toolName === "ask_question" && clientElicitation?.form) {
-    const elicitationParams = buildElicitationRequestFromAskQuestion(toolCall, sessionId);
+    const elicitationParams = buildElicitationRequestFromAskQuestion(toolCall, sessionId, questionIndex);
     if (elicitationParams) {
       const response = (await racePermissionCancellation(
         client.request(v1.methods.client.elicitation.create, elicitationParams as any),
@@ -40,7 +40,7 @@ export async function requestPermissionV1(
         return "agy-q-skip";
       }
       if (response.action === "accept") {
-        const encoded = encodeElicitationKeys(toolCall, response.content);
+        const encoded = encodeElicitationKeys(toolCall, response.content, questionIndex);
         return encoded ? `pty-keys:${encoded}` : "agy-q-skip";
       }
       return "cancelled";
@@ -84,7 +84,7 @@ export async function requestPermissionV2(
   if (signal.aborted) return "cancelled";
 
   if (toolName === "ask_question" && clientElicitation?.form) {
-    const elicitationParams = buildElicitationRequestFromAskQuestion(toolCall, sessionId);
+    const elicitationParams = buildElicitationRequestFromAskQuestion(toolCall, sessionId, questionIndex);
     if (elicitationParams) {
       const response = (await racePermissionCancellation(
         client.request(v2.methods.client.elicitation.create, elicitationParams as any),
@@ -96,7 +96,7 @@ export async function requestPermissionV2(
         return "agy-q-skip";
       }
       if (response.action === "accept") {
-        const encoded = encodeElicitationKeys(toolCall, response.content);
+        const encoded = encodeElicitationKeys(toolCall, response.content, questionIndex);
         return encoded ? `pty-keys:${encoded}` : "agy-q-skip";
       }
       return "cancelled";

--- a/src/acp/session/request-permission.ts
+++ b/src/acp/session/request-permission.ts
@@ -20,10 +20,21 @@ export async function requestPermissionV1(
 ): Promise<PermissionChoice | "cancelled"> {
   if (signal?.aborted) return "cancelled";
   const { sessionUpdate: _discriminator, ...requestToolCall } = toolCall as unknown as Record<string, unknown>;
+  const toolCallPayload = { ...requestToolCall };
+  if (toolName === "ask_question") {
+    const ask = parseAskQuestion(toolCall);
+    const qIdx = questionIndex ?? 0;
+    if (ask && ask.questions.length > 1 && qIdx < ask.questions.length) {
+      const q = ask.questions[qIdx];
+      const origTitle = String(toolCallPayload.title ?? "Question");
+      toolCallPayload.title = `[Question ${qIdx + 1}/${ask.questions.length}] ${q.question || origTitle}`;
+    }
+  }
+
   const response = await racePermissionCancellation(
     client.request(v1.methods.client.session.requestPermission, {
       sessionId,
-      toolCall: requestToolCall as v1.ToolCallUpdate,
+      toolCall: toolCallPayload as v1.ToolCallUpdate,
       options: permissionOptions(toolCall, toolName, questionIndex)
     }),
     signal

--- a/src/acp/session/request-permission.ts
+++ b/src/acp/session/request-permission.ts
@@ -24,10 +24,11 @@ export async function requestPermissionV1(
   if (toolName === "ask_question") {
     const ask = parseAskQuestion(toolCall);
     const qIdx = questionIndex ?? 0;
-    if (ask && ask.questions.length > 1 && qIdx < ask.questions.length) {
+    if (ask && qIdx < ask.questions.length) {
       const q = ask.questions[qIdx];
       const origTitle = String(toolCallPayload.title ?? "Question");
-      toolCallPayload.title = `[Question ${qIdx + 1}/${ask.questions.length}] ${q.question || origTitle}`;
+      const qText = q.question || origTitle;
+      toolCallPayload.title = ask.questions.length > 1 ? `[Question ${qIdx + 1}/${ask.questions.length}] ${qText}` : qText;
     }
   }
 

--- a/src/acp/tool-calls/elicitation.ts
+++ b/src/acp/tool-calls/elicitation.ts
@@ -132,9 +132,11 @@ export function parseAskQuestionFull(toolCall: SessionUpdate): AskQuestionPayloa
 }
 
 /** Build elicitation/create params for an ask_question tool call. */
+/** Build elicitation/create params for an ask_question tool call. */
 export function buildElicitationRequestFromAskQuestion(
   toolCall: SessionUpdate,
-  sessionId: string
+  sessionId: string,
+  questionIndex = 0
 ): ElicitationCreateRequestParams | null {
   const parsed = parseAskQuestionFull(toolCall);
   if (!parsed || parsed.items.length === 0) return null;
@@ -142,41 +144,40 @@ export function buildElicitationRequestFromAskQuestion(
   const raw = toolCall as unknown as Record<string, unknown>;
   const toolCallId = typeof raw.toolCallId === "string" ? raw.toolCallId : undefined;
 
+  const qIdx = questionIndex >= 0 && questionIndex < parsed.items.length ? questionIndex : 0;
+  const item = parsed.items[qIdx];
   const properties: Record<string, unknown> = {};
   const required: string[] = [];
 
-  for (let i = 0; i < parsed.items.length; i++) {
-    const item = parsed.items[i];
-    const key = `q${i}`;
-    required.push(key);
+  const key = `q${qIdx}`;
+  required.push(key);
 
-    if (item.options.length > 0 && !item.multiSelect) {
-      properties[key] = {
-        type: "string",
-        title: item.question,
-        oneOf: item.options.map((opt) => ({ const: opt, title: opt }))
-      };
-    } else if (item.options.length > 0 && item.multiSelect) {
-      properties[key] = {
-        type: "array",
-        title: item.question,
-        items: {
-          anyOf: item.options.map((opt) => ({ const: opt, title: opt }))
-        }
-      };
-    } else {
-      // Free-text input
-      properties[key] = {
-        type: "string",
-        title: item.question
-      };
-    }
+  if (item.options.length > 0 && !item.multiSelect) {
+    properties[key] = {
+      type: "string",
+      title: item.question,
+      oneOf: item.options.map((opt) => ({ const: opt, title: opt }))
+    };
+  } else if (item.options.length > 0 && item.multiSelect) {
+    properties[key] = {
+      type: "array",
+      title: item.question,
+      items: {
+        anyOf: item.options.map((opt) => ({ const: opt, title: opt }))
+      }
+    };
+  } else {
+    // Free-text input
+    properties[key] = {
+      type: "string",
+      title: item.question
+    };
   }
 
   const message =
-    parsed.items.length === 1
-      ? parsed.items[0].question
-      : parsed.question || "Please answer the following questions";
+    parsed.items.length > 1
+      ? `[Question ${qIdx + 1}/${parsed.items.length}] ${item.question}`
+      : item.question;
 
   return {
     sessionId,
@@ -194,72 +195,67 @@ export function buildElicitationRequestFromAskQuestion(
 /** Convert user elicitation submission into PTY keys for ask_question. */
 export function encodeElicitationKeys(
   toolCall: SessionUpdate,
-  content?: Record<string, unknown>
+  content?: Record<string, unknown>,
+  questionIndex = 0
 ): string | null {
   if (!content) return "\x1b";
 
   const parsed = parseAskQuestionFull(toolCall);
   if (!parsed || parsed.items.length === 0) return null;
 
-  let allKeys = "";
+  const qIdx = questionIndex >= 0 && questionIndex < parsed.items.length ? questionIndex : 0;
+  const item = parsed.items[qIdx];
+  const key = `q${qIdx}`;
+  const val = content[key] ?? content[item.question] ?? content["q0"] ?? content["q"];
 
-  for (let i = 0; i < parsed.items.length; i++) {
-    const item = parsed.items[i];
-    const key = `q${i}`;
-    const val = content[key] ?? content[item.question];
+  if (val == null) return "\x1b";
 
-    if (val == null) {
-      allKeys += "\x1b";
-      continue;
+  if (item.options.length > 0 && !item.multiSelect) {
+    const strVal = String(val).trim();
+    let index = item.options.findIndex((opt) => opt === strVal);
+    if (index === -1) {
+      const num = Number(strVal);
+      if (!isNaN(num) && num >= 0 && num < item.options.length) {
+        index = num;
+      }
     }
-
-    if (item.options.length > 0 && !item.multiSelect) {
-      const strVal = String(val).trim();
-      let index = item.options.findIndex((opt) => opt === strVal);
-      if (index === -1) {
-        const num = Number(strVal);
-        if (!isNaN(num) && num >= 0 && num < item.options.length) {
-          index = num;
-        }
-      }
-      if (index >= 0) {
-        allKeys += `${"\x1b[B".repeat(index)}\r`;
-      } else {
-        allKeys += `${strVal}\r`;
-      }
-    } else if (item.options.length > 0 && item.multiSelect) {
-      const selected = Array.isArray(val) ? val.map(String) : [String(val)];
-      const selectedIndices = new Set<number>();
-      for (const sel of selected) {
-        const idx = item.options.findIndex((opt) => opt === sel.trim());
-        if (idx >= 0) selectedIndices.add(idx);
-        else {
-          const num = Number(sel);
-          if (!isNaN(num) && num >= 0 && num < item.options.length) {
-            selectedIndices.add(num);
-          }
-        }
-      }
-
-      if (selectedIndices.size === 0) {
-        allKeys += "\r";
-      } else {
-        const maxIdx = Math.max(...selectedIndices);
-        for (let k = 0; k <= maxIdx; k++) {
-          if (selectedIndices.has(k)) {
-            allKeys += " ";
-          }
-          if (k < maxIdx) {
-            allKeys += "\x1b[B";
-          }
-        }
-        allKeys += "\r";
-      }
+    if (index >= 0) {
+      return `${"\x1b[B".repeat(index)}\r`;
     } else {
-      const textVal = String(val);
-      allKeys += `${textVal}\r`;
+      return `${strVal}\r`;
     }
-  }
+  } else if (item.options.length > 0 && item.multiSelect) {
+    const selected = Array.isArray(val) ? val.map(String) : [String(val)];
+    const selectedIndices = new Set<number>();
+    for (const sel of selected) {
+      const idx = item.options.findIndex((opt) => opt === sel.trim());
+      if (idx >= 0) selectedIndices.add(idx);
+      else {
+        const num = Number(sel);
+        if (!isNaN(num) && num >= 0 && num < item.options.length) {
+          selectedIndices.add(num);
+        }
+      }
+    }
 
-  return allKeys || "\r";
+    if (selectedIndices.size === 0) {
+      return "\r";
+    } else {
+      let keys = "";
+      const maxIdx = Math.max(...selectedIndices);
+      for (let k = 0; k <= maxIdx; k++) {
+        if (selectedIndices.has(k)) {
+          keys += " ";
+        }
+        if (k < maxIdx) {
+          keys += "\x1b[B";
+        }
+      }
+      keys += "\r";
+      return keys;
+    }
+  } else {
+    const textVal = String(val);
+    return `${textVal}\r`;
+  }
 }

--- a/src/acp/tool-calls/permissions.ts
+++ b/src/acp/tool-calls/permissions.ts
@@ -16,11 +16,18 @@ export interface PermissionMenuOption {
   name: string;
 }
 
-export interface AskQuestionPayload {
+export interface AskQuestionPrompt {
   question: string;
   options: string[];
   multiSelect: boolean;
+}
+
+export interface AskQuestionPayload {
+  questions: AskQuestionPrompt[];
   questionCount: number;
+  question: string;
+  options: string[];
+  multiSelect: boolean;
 }
 
 /**
@@ -48,7 +55,7 @@ export function isEditToolCall(toolCall: SessionUpdate): boolean {
   return false;
 }
 
-/** True when this status-9 tool can be bridged (permission menu or single-select MCQ). */
+/** True when this status-9 tool can be bridged (permission menu or ask_question MCQ). */
 export function canBridgeInteraction(toolName: string, toolCall?: SessionUpdate): boolean {
   if (isBridgeablePermissionTool(toolName)) return true;
   if (toolName !== "ask_question" || !toolCall) return false;
@@ -56,9 +63,9 @@ export function canBridgeInteraction(toolName: string, toolCall?: SessionUpdate)
   return ask != null && isBridgeableAskQuestion(ask);
 }
 
-/** Single-select, single-question ask_question is safe to map to PTY keys. */
+/** ask_question is safe to bridge when it has non-empty options for all questions. */
 export function isBridgeableAskQuestion(ask: AskQuestionPayload): boolean {
-  return ask.questionCount === 1 && !ask.multiSelect && ask.options.length > 0;
+  return ask.questionCount > 0 && ask.questions.every((q) => q.options.length > 0);
 }
 
 /** Normalize client-selected option ids (standard ACP or legacy agy-*). */
@@ -99,17 +106,73 @@ export function permissionKeys(choice: PermissionChoice): string | null {
 export function interactionKeys(
   choice: PermissionChoice,
   toolName: string,
-  toolCall?: SessionUpdate
+  toolCall?: SessionUpdate,
+  questionIndex = 0
 ): string | null {
   if (toolName === "ask_question") {
-    if (choice === "agy-q-skip") return "\x1b"; // Esc — cancel / skip the modal
-    const match = /^agy-q-(\d+)$/.exec(choice);
-    if (!match || !toolCall) return null;
-    const index = Number(match[1]);
+    if (choice === "agy-q-skip" || choice.endsWith("-skip")) return "\x1b"; // Esc — cancel / skip modal
+    if (!toolCall) return null;
     const ask = parseAskQuestion(toolCall);
-    if (!ask || !isBridgeableAskQuestion(ask) || index < 0 || index >= ask.options.length) return null;
-    // First option is focused by default; Down N then Enter selects option N.
-    return `${"\x1b[B".repeat(index)}\r`;
+    if (!ask || !isBridgeableAskQuestion(ask)) return null;
+
+    let targetQIndex = questionIndex;
+    let rest = choice;
+
+    const qMatch = /^agy-q-q(\d+)-(.*)$/.exec(choice);
+    if (qMatch) {
+      targetQIndex = Number(qMatch[1]);
+      rest = `agy-q-${qMatch[2]}`;
+    }
+
+    if (targetQIndex < 0 || targetQIndex >= ask.questions.length) return null;
+    const q = ask.questions[targetQIndex];
+
+    const match = /^agy-q-(.*)$/.exec(rest);
+    if (!match) return null;
+    const spec = match[1];
+
+    if (spec === "skip") return "\x1b";
+
+    let selectedIndices: number[] = [];
+    if (spec === "all") {
+      selectedIndices = q.options.map((_, idx) => idx);
+    } else if (spec === "none" || spec === "submit") {
+      selectedIndices = [];
+    } else {
+      let rawSpec = spec;
+      if (rawSpec.startsWith("ms:") || rawSpec.startsWith("select:")) {
+        rawSpec = rawSpec.slice(rawSpec.indexOf(":") + 1);
+      }
+      const parts = rawSpec.split(/[,+]/).map((s) => s.trim()).filter(Boolean);
+      for (const p of parts) {
+        const num = Number(p);
+        if (Number.isInteger(num) && num >= 0 && num < q.options.length) {
+          selectedIndices.push(num);
+        } else {
+          return null;
+        }
+      }
+    }
+
+    if (!q.multiSelect) {
+      if (selectedIndices.length !== 1) return null;
+      const index = selectedIndices[0];
+      return `${"\x1b[B".repeat(index)}\r`;
+    } else {
+      const sorted = Array.from(new Set(selectedIndices)).sort((a, b) => a - b);
+      let currentPos = 0;
+      let keys = "";
+      for (const targetPos of sorted) {
+        const moves = targetPos - currentPos;
+        if (moves > 0) {
+          keys += "\x1b[B".repeat(moves);
+        }
+        keys += " ";
+        currentPos = targetPos;
+      }
+      keys += "\r";
+      return keys;
+    }
   }
 
   // Edit tools: map standard ACP allow/reject onto agy's 4-row menu.
@@ -145,41 +208,56 @@ function toolRawInput(toolCall: SessionUpdate): Record<string, unknown> {
 export function parseAskQuestion(toolCall: SessionUpdate): AskQuestionPayload | null {
   const input = toolRawInput(toolCall);
   const questionsRaw = input.questions ?? input.Questions;
-  const questions = Array.isArray(questionsRaw) ? questionsRaw : [];
+  const questionsList = Array.isArray(questionsRaw) ? questionsRaw : [];
+  if (questionsList.length === 0) return null;
+
+  const questions: AskQuestionPrompt[] = [];
+  for (let i = 0; i < questionsList.length; i++) {
+    const item = questionsList[i];
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const entry = item as Record<string, unknown>;
+    let question = pickString(entry, "question", "Question") ?? "";
+    if (!question && i === 0) {
+      question = String((toolCall as unknown as { title?: unknown }).title ?? "Question");
+    }
+    const optionsRaw = entry.options ?? entry.Options;
+    const optionsList = Array.isArray(optionsRaw) ? optionsRaw : [];
+    const options = optionsList
+      .map((opt) => {
+        if (typeof opt === "string") return opt.trim();
+        if (opt && typeof opt === "object" && !Array.isArray(opt)) {
+          return pickString(opt as Record<string, unknown>, "label", "Label", "text", "Text", "id", "Id") ?? "";
+        }
+        return "";
+      })
+      .filter(Boolean);
+    const multiSelect = Boolean(entry.is_multi_select ?? entry.isMultiSelect ?? entry.IsMultiSelect);
+    questions.push({
+      question,
+      options,
+      multiSelect
+    });
+  }
+
   if (questions.length === 0) return null;
 
-  const first = questions[0];
-  const entry = first && typeof first === "object" && !Array.isArray(first)
-    ? first as Record<string, unknown>
-    : {};
-  const question =
-    pickString(entry, "question", "Question") ??
-    String((toolCall as unknown as { title?: unknown }).title ?? "Question");
-  const optionsRaw = entry.options ?? entry.Options;
-  const optionsList = Array.isArray(optionsRaw) ? optionsRaw : [];
-  const options = optionsList
-    .map((opt) => {
-      if (typeof opt === "string") return opt.trim();
-      if (opt && typeof opt === "object" && !Array.isArray(opt)) {
-        return pickString(opt as Record<string, unknown>, "label", "Label", "text", "Text", "id", "Id") ?? "";
-      }
-      return "";
-    })
-    .filter(Boolean);
-  const multiSelect = Boolean(entry.is_multi_select ?? entry.isMultiSelect ?? entry.IsMultiSelect);
-
   return {
-    question,
-    options,
-    multiSelect,
-    questionCount: questions.length
+    questions,
+    questionCount: questions.length,
+    question: questions[0].question,
+    options: questions[0].options,
+    multiSelect: questions[0].multiSelect
   };
 }
 
 /** Build ACP permission options for the given pending tool interaction. */
-export function permissionOptions(toolCall: SessionUpdate, toolName?: string): PermissionMenuOption[] {
+export function permissionOptions(
+  toolCall: SessionUpdate,
+  toolName?: string,
+  questionIndex = 0
+): PermissionMenuOption[] {
   if (toolName === "ask_question") {
-    return askQuestionOptions(toolCall);
+    return askQuestionOptions(toolCall, questionIndex);
   }
 
   // agy's sandbox-bypass request (run a command / read a file outside the
@@ -291,17 +369,40 @@ function askPermissionOptions(toolCall: SessionUpdate): PermissionMenuOption[] {
   ];
 }
 
-function askQuestionOptions(toolCall: SessionUpdate): PermissionMenuOption[] {
+export function askQuestionOptions(toolCall: SessionUpdate, questionIndex = 0): PermissionMenuOption[] {
   const ask = parseAskQuestion(toolCall);
   if (!ask || !isBridgeableAskQuestion(ask)) {
     return [{ optionId: "agy-q-skip", kind: "reject_once", name: "Skip" }];
   }
-  const options: PermissionMenuOption[] = ask.options.map((name, index) => ({
-    optionId: `agy-q-${index}`,
+
+  const qIndex = questionIndex >= 0 && questionIndex < ask.questions.length ? questionIndex : 0;
+  const q = ask.questions[qIndex];
+  if (!q || q.options.length === 0) {
+    return [{ optionId: "agy-q-skip", kind: "reject_once", name: "Skip" }];
+  }
+
+  const prefix = ask.questions.length > 1 ? `agy-q-q${qIndex}-` : "agy-q-";
+
+  const options: PermissionMenuOption[] = q.options.map((name, index) => ({
+    optionId: `${prefix}${index}`,
     kind: "allow_once" as const,
     name
   }));
-  options.push({ optionId: "agy-q-skip", kind: "reject_once", name: "Skip" });
+
+  if (q.multiSelect) {
+    options.push({
+      optionId: `${prefix}all`,
+      kind: "allow_once" as const,
+      name: "Select All"
+    });
+    options.push({
+      optionId: `${prefix}none`,
+      kind: "allow_once" as const,
+      name: "Submit (None selected)"
+    });
+  }
+
+  options.push({ optionId: `${prefix}skip`, kind: "reject_once", name: "Skip" });
   return options;
 }
 

--- a/src/acp/tool-calls/permissions.ts
+++ b/src/acp/tool-calls/permissions.ts
@@ -407,7 +407,7 @@ export function askQuestionOptions(toolCall: SessionUpdate, questionIndex = 0): 
 
   const MAX_SUBSET_OPTIONS = 128;
 
-  if ((1 << n) <= MAX_SUBSET_OPTIONS) {
+  if (n <= 7) {
     const totalSubsets = 1 << n;
     for (let mask = 1; mask < totalSubsets; mask++) {
       const indices: number[] = [];

--- a/src/acp/tool-calls/permissions.ts
+++ b/src/acp/tool-calls/permissions.ts
@@ -68,9 +68,18 @@ export function canBridgeInteraction(
   return ask != null && isBridgeableAskQuestion(ask);
 }
 
+export const MAX_BRIDGABLE_MULTI_SELECT_OPTIONS = 6;
+
 /** ask_question is safe to bridge when it has non-empty options for all questions. */
 export function isBridgeableAskQuestion(ask: AskQuestionPayload): boolean {
-  return ask.questionCount > 0 && ask.questions.every((q) => q.options.length > 0);
+  return (
+    ask.questionCount > 0 &&
+    ask.questions.every((q) => {
+      if (q.options.length === 0) return false;
+      if (q.multiSelect && q.options.length > MAX_BRIDGABLE_MULTI_SELECT_OPTIONS) return false;
+      return true;
+    })
+  );
 }
 
 /** Normalize client-selected option ids (standard ACP or legacy agy-*). */

--- a/src/acp/tool-calls/permissions.ts
+++ b/src/acp/tool-calls/permissions.ts
@@ -396,7 +396,9 @@ export function askQuestionOptions(toolCall: SessionUpdate, questionIndex = 0): 
   const options: PermissionMenuOption[] = [];
   const n = q.options.length;
 
-  if (n <= 4) {
+  const MAX_SUBSET_OPTIONS = 128;
+
+  if ((1 << n) <= MAX_SUBSET_OPTIONS) {
     const totalSubsets = 1 << n;
     for (let mask = 1; mask < totalSubsets; mask++) {
       const indices: number[] = [];
@@ -424,22 +426,38 @@ export function askQuestionOptions(toolCall: SessionUpdate, questionIndex = 0): 
       }
     }
   } else {
-    for (let i = 0; i < n; i++) {
-      options.push({
-        optionId: `${prefix}${i}`,
-        kind: "allow_once" as const,
-        name: q.options[i]
-      });
-    }
-    for (let i = 0; i < n; i++) {
-      for (let j = i + 1; j < n; j++) {
-        options.push({
-          optionId: `${prefix}${i},${j}`,
-          kind: "allow_once" as const,
-          name: `${q.options[i]} + ${q.options[j]}`
-        });
+    function generateCombos(start: number, combo: number[], k: number) {
+      if (options.length >= MAX_SUBSET_OPTIONS - 3) return;
+      if (combo.length === k) {
+        const key = combo.join(",");
+        if (combo.length === 1) {
+          options.push({
+            optionId: `${prefix}${combo[0]}`,
+            kind: "allow_once" as const,
+            name: q.options[combo[0]]
+          });
+        } else {
+          options.push({
+            optionId: `${prefix}${key}`,
+            kind: "allow_once" as const,
+            name: combo.map((i) => q.options[i]).join(" + ")
+          });
+        }
+        return;
+      }
+      for (let i = start; i < n; i++) {
+        combo.push(i);
+        generateCombos(i + 1, combo, k);
+        combo.pop();
+        if (options.length >= MAX_SUBSET_OPTIONS - 3) break;
       }
     }
+
+    for (let k = 1; k < n; k++) {
+      generateCombos(0, [], k);
+      if (options.length >= MAX_SUBSET_OPTIONS - 3) break;
+    }
+
     options.push({
       optionId: `${prefix}all`,
       kind: "allow_once" as const,

--- a/src/acp/tool-calls/permissions.ts
+++ b/src/acp/tool-calls/permissions.ts
@@ -383,25 +383,75 @@ export function askQuestionOptions(toolCall: SessionUpdate, questionIndex = 0): 
 
   const prefix = ask.questions.length > 1 ? `agy-q-q${qIndex}-` : "agy-q-";
 
-  const options: PermissionMenuOption[] = q.options.map((name, index) => ({
-    optionId: `${prefix}${index}`,
-    kind: "allow_once" as const,
-    name
-  }));
+  if (!q.multiSelect) {
+    const options: PermissionMenuOption[] = q.options.map((name, index) => ({
+      optionId: `${prefix}${index}`,
+      kind: "allow_once" as const,
+      name
+    }));
+    options.push({ optionId: `${prefix}skip`, kind: "reject_once", name: "Skip" });
+    return options;
+  }
 
-  if (q.multiSelect) {
+  const options: PermissionMenuOption[] = [];
+  const n = q.options.length;
+
+  if (n <= 4) {
+    const totalSubsets = 1 << n;
+    for (let mask = 1; mask < totalSubsets; mask++) {
+      const indices: number[] = [];
+      for (let i = 0; i < n; i++) {
+        if ((mask & (1 << i)) !== 0) indices.push(i);
+      }
+      if (indices.length === 1) {
+        options.push({
+          optionId: `${prefix}${indices[0]}`,
+          kind: "allow_once" as const,
+          name: q.options[indices[0]]
+        });
+      } else if (indices.length === n) {
+        options.push({
+          optionId: `${prefix}all`,
+          kind: "allow_once" as const,
+          name: `Select All (${indices.map((i) => q.options[i]).join(" + ")})`
+        });
+      } else {
+        options.push({
+          optionId: `${prefix}${indices.join(",")}`,
+          kind: "allow_once" as const,
+          name: indices.map((i) => q.options[i]).join(" + ")
+        });
+      }
+    }
+  } else {
+    for (let i = 0; i < n; i++) {
+      options.push({
+        optionId: `${prefix}${i}`,
+        kind: "allow_once" as const,
+        name: q.options[i]
+      });
+    }
+    for (let i = 0; i < n; i++) {
+      for (let j = i + 1; j < n; j++) {
+        options.push({
+          optionId: `${prefix}${i},${j}`,
+          kind: "allow_once" as const,
+          name: `${q.options[i]} + ${q.options[j]}`
+        });
+      }
+    }
     options.push({
       optionId: `${prefix}all`,
       kind: "allow_once" as const,
       name: "Select All"
     });
-    options.push({
-      optionId: `${prefix}none`,
-      kind: "allow_once" as const,
-      name: "Submit (None selected)"
-    });
   }
 
+  options.push({
+    optionId: `${prefix}none`,
+    kind: "allow_once" as const,
+    name: "Submit (None selected)"
+  });
   options.push({ optionId: `${prefix}skip`, kind: "reject_once", name: "Skip" });
   return options;
 }

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -55,7 +55,7 @@ export interface PtyFactory {
 }
 export type PermissionCallback = (
   toolCall: SessionUpdate,
-  context: { toolName: string }
+  context: { toolName: string; questionIndex?: number }
 ) => Promise<PermissionChoice | "cancelled">;
 
 export interface SpawnOptions {
@@ -455,24 +455,47 @@ export class AgyCliSession {
               );
             }
 
-            const choice = await this.raceTurnCallback(
-              onPermission(toolCall, { toolName: interaction.toolName })
-            );
-            deadline = Date.now() + timeoutMs;
-            if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
-
-            const keys = interactionKeys(choice, interaction.toolName, toolCall);
-            if (keys == null) {
-              throw new AgyCliError(
-                `Unsupported permission choice '${choice}' for '${interaction.toolName}'`,
-                [this.config.agyPath],
-                null,
-                this.#ptyOutput
-              );
-            }
             if (interaction.toolName === "ask_question") {
-              this.#pty?.write(keys);
+              const ask = parseAskQuestion(toolCall);
+              const count = ask?.questions.length ?? 1;
+              for (let qIndex = 0; qIndex < count; qIndex++) {
+                const choice = await this.raceTurnCallback(
+                  onPermission(toolCall, { toolName: interaction.toolName, questionIndex: qIndex })
+                );
+                deadline = Date.now() + timeoutMs;
+                if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
+
+                const keys = interactionKeys(choice, interaction.toolName, toolCall, qIndex);
+                if (keys == null) {
+                  throw new AgyCliError(
+                    `Unsupported permission choice '${choice}' for '${interaction.toolName}'`,
+                    [this.config.agyPath],
+                    null,
+                    this.#ptyOutput
+                  );
+                }
+                this.#pty?.write(keys);
+                if (choice === "agy-q-skip" || choice.endsWith("-skip")) break;
+                if (qIndex < count - 1) {
+                  await sleep(50);
+                }
+              }
             } else {
+              const choice = await this.raceTurnCallback(
+                onPermission(toolCall, { toolName: interaction.toolName })
+              );
+              deadline = Date.now() + timeoutMs;
+              if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
+
+              const keys = interactionKeys(choice, interaction.toolName, toolCall);
+              if (keys == null) {
+                throw new AgyCliError(
+                  `Unsupported permission choice '${choice}' for '${interaction.toolName}'`,
+                  [this.config.agyPath],
+                  null,
+                  this.#ptyOutput
+                );
+              }
               if (!await this.writePermissionKeys(keys, deadline)) break;
             }
             gateMarkerCounts.set(id, this.#ptyPermissionMarkerCount);
@@ -1063,12 +1086,11 @@ function unsupportedInteractionDetail(toolName: string, toolCall: SessionUpdate)
   if (toolName === "ask_question") {
     const ask = parseAskQuestion(toolCall);
     if (!ask) return "ask_question payload could not be parsed";
-    if (ask.questionCount !== 1) return "only single-question ask_question menus can be bridged safely";
-    if (ask.multiSelect) return "multi-select ask_question is not bridged yet";
-    if (ask.options.length === 0) return "ask_question has no selectable options";
+    if (ask.questionCount === 0) return "ask_question has no questions";
+    if (ask.questions.some((q) => q.options.length === 0)) return "ask_question has a question with no selectable options";
     return "ask_question could not be bridged";
   }
-  return "only standard permission menus (run_command, ask_permission, file read/write) and single-select ask_question can be bridged safely";
+  return "only standard permission menus (run_command, ask_permission, file read/write) and ask_question can be bridged safely";
 }
 
 function isAgyStatusLine(line: string): boolean {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -240,23 +240,21 @@ describe("permission bridge", () => {
     expect(fiveOpts).toContainEqual({ optionId: "agy-q-0,2,4", kind: "allow_once", name: "A + C + E" });
     expect(interactionKeys("agy-q-0,2,4", "ask_question", fiveOptionCall)).toBe(" \x1b[B\x1b[B \x1b[B\x1b[B \r");
 
-    const thirtyOneCall = {
+    const sevenOptionCall = {
       sessionUpdate: "tool_call" as const,
-      toolCallId: "q31",
-      title: "31 option question",
+      toolCallId: "q7",
+      title: "7 option question",
       kind: "other" as const,
       status: "pending" as const,
       rawInput: {
         questions: [{
           question: "Select items",
-          options: Array.from({ length: 31 }, (_, i) => `Opt${i}`),
+          options: Array.from({ length: 7 }, (_, i) => `Opt${i}`),
           is_multi_select: true
         }]
       }
     };
-    const thirtyOneOpts = permissionOptions(thirtyOneCall, "ask_question");
-    expect(thirtyOneOpts.length).toBeGreaterThan(30);
-    expect(thirtyOneOpts).toContainEqual({ optionId: "agy-q-0", kind: "allow_once", name: "Opt0" });
+    expect(canBridgeInteraction("ask_question", sevenOptionCall)).toBe(false);
   });
 
   it("labels each v1 requestPermission toolCall title with the active question", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -26,6 +26,7 @@ import {
   permissionKeys,
   permissionOptions
 } from "../src/acp/tool-calls/permissions.js";
+import { requestPermissionV1 } from "../src/acp/session/request-permission.js";
 import { createConversationDb, insertStep, updateStep } from "./fixtures/conversation-db.js";
 import { encodePermissions, encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 
@@ -220,6 +221,51 @@ describe("permission bridge", () => {
     ]);
     expect(interactionKeys("agy-q-q0-1", "ask_question", multiQuestionCall, 0)).toBe("\x1b[B\r");
     expect(interactionKeys("agy-q-q1-0,1", "ask_question", multiQuestionCall, 1)).toBe(" \x1b[B \r");
+
+    const fiveOptionCall = {
+      sessionUpdate: "tool_call" as const,
+      toolCallId: "q5",
+      title: "Five option question",
+      kind: "other" as const,
+      status: "pending" as const,
+      rawInput: {
+        questions: [{
+          question: "Select items",
+          options: ["A", "B", "C", "D", "E"],
+          is_multi_select: true
+        }]
+      }
+    };
+    const fiveOpts = permissionOptions(fiveOptionCall, "ask_question");
+    expect(fiveOpts).toContainEqual({ optionId: "agy-q-0,2,4", kind: "allow_once", name: "A + C + E" });
+    expect(interactionKeys("agy-q-0,2,4", "ask_question", fiveOptionCall)).toBe(" \x1b[B\x1b[B \x1b[B\x1b[B \r");
+  });
+
+  it("labels each v1 requestPermission toolCall title with the active question", async () => {
+    let capturedTitle: string | undefined;
+    const mockClient = {
+      request: vi.fn().mockImplementation(async (_method, params) => {
+        capturedTitle = params.toolCall.title;
+        return { outcome: { outcome: "selected", optionId: "agy-q-q1-0" } };
+      })
+    };
+
+    const multiQCall = {
+      sessionUpdate: "tool_call" as const,
+      toolCallId: "q-multi",
+      title: "Initial question title",
+      kind: "other" as const,
+      status: "pending" as const,
+      rawInput: {
+        questions: [
+          { question: "First Question?", options: ["Opt1", "Opt2"] },
+          { question: "Second Question?", options: ["Opt3", "Opt4"] }
+        ]
+      }
+    };
+
+    await requestPermissionV1(mockClient as any, "s1", multiQCall, "ask_question", undefined, 1);
+    expect(capturedTitle).toBe("[Question 2/2] Second Question?");
   });
 
   it("bridges agy's ask_permission sandbox-bypass request as a command-style menu", () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -239,6 +239,24 @@ describe("permission bridge", () => {
     const fiveOpts = permissionOptions(fiveOptionCall, "ask_question");
     expect(fiveOpts).toContainEqual({ optionId: "agy-q-0,2,4", kind: "allow_once", name: "A + C + E" });
     expect(interactionKeys("agy-q-0,2,4", "ask_question", fiveOptionCall)).toBe(" \x1b[B\x1b[B \x1b[B\x1b[B \r");
+
+    const thirtyOneCall = {
+      sessionUpdate: "tool_call" as const,
+      toolCallId: "q31",
+      title: "31 option question",
+      kind: "other" as const,
+      status: "pending" as const,
+      rawInput: {
+        questions: [{
+          question: "Select items",
+          options: Array.from({ length: 31 }, (_, i) => `Opt${i}`),
+          is_multi_select: true
+        }]
+      }
+    };
+    const thirtyOneOpts = permissionOptions(thirtyOneCall, "ask_question");
+    expect(thirtyOneOpts.length).toBeGreaterThan(30);
+    expect(thirtyOneOpts).toContainEqual({ optionId: "agy-q-0", kind: "allow_once", name: "Opt0" });
   });
 
   it("labels each v1 requestPermission toolCall title with the active question", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -179,8 +179,11 @@ describe("permission bridge", () => {
     expect(permissionOptions(multiAskCall, "ask_question")).toEqual([
       { optionId: "agy-q-0", kind: "allow_once", name: "Auth" },
       { optionId: "agy-q-1", kind: "allow_once", name: "DB" },
+      { optionId: "agy-q-0,1", kind: "allow_once", name: "Auth + DB" },
       { optionId: "agy-q-2", kind: "allow_once", name: "Analytics" },
-      { optionId: "agy-q-all", kind: "allow_once", name: "Select All" },
+      { optionId: "agy-q-0,2", kind: "allow_once", name: "Auth + Analytics" },
+      { optionId: "agy-q-1,2", kind: "allow_once", name: "DB + Analytics" },
+      { optionId: "agy-q-all", kind: "allow_once", name: "Select All (Auth + DB + Analytics)" },
       { optionId: "agy-q-none", kind: "allow_once", name: "Submit (None selected)" },
       { optionId: "agy-q-skip", kind: "reject_once", name: "Skip" }
     ]);
@@ -211,7 +214,7 @@ describe("permission bridge", () => {
     expect(permissionOptions(multiQuestionCall, "ask_question", 1)).toEqual([
       { optionId: "agy-q-q1-0", kind: "allow_once", name: "Auth" },
       { optionId: "agy-q-q1-1", kind: "allow_once", name: "Logging" },
-      { optionId: "agy-q-q1-all", kind: "allow_once", name: "Select All" },
+      { optionId: "agy-q-q1-all", kind: "allow_once", name: "Select All (Auth + Logging)" },
       { optionId: "agy-q-q1-none", kind: "allow_once", name: "Submit (None selected)" },
       { optionId: "agy-q-q1-skip", kind: "reject_once", name: "Skip" }
     ]);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -160,6 +160,63 @@ describe("permission bridge", () => {
     expect(interactionKeys("agy-q-1", "ask_question", askCall)).toBe("\x1b[B\r");
     expect(interactionKeys("agy-q-2", "ask_question", askCall)).toBe("\x1b[B\x1b[B\r");
     expect(interactionKeys("agy-q-skip", "ask_question", askCall)).toBe("\x1b");
+
+    const multiAskCall = {
+      sessionUpdate: "tool_call" as const,
+      toolCallId: "q2",
+      title: "Pick multiple",
+      kind: "other" as const,
+      status: "pending" as const,
+      rawInput: {
+        questions: [{
+          question: "Which features?",
+          options: ["Auth", "DB", "Analytics"],
+          is_multi_select: true
+        }]
+      }
+    };
+    expect(canBridgeInteraction("ask_question", multiAskCall)).toBe(true);
+    expect(permissionOptions(multiAskCall, "ask_question")).toEqual([
+      { optionId: "agy-q-0", kind: "allow_once", name: "Auth" },
+      { optionId: "agy-q-1", kind: "allow_once", name: "DB" },
+      { optionId: "agy-q-2", kind: "allow_once", name: "Analytics" },
+      { optionId: "agy-q-all", kind: "allow_once", name: "Select All" },
+      { optionId: "agy-q-none", kind: "allow_once", name: "Submit (None selected)" },
+      { optionId: "agy-q-skip", kind: "reject_once", name: "Skip" }
+    ]);
+    expect(interactionKeys("agy-q-0,2", "ask_question", multiAskCall)).toBe(" \x1b[B\x1b[B \r");
+    expect(interactionKeys("agy-q-all", "ask_question", multiAskCall)).toBe(" \x1b[B \x1b[B \r");
+    expect(interactionKeys("agy-q-none", "ask_question", multiAskCall)).toBe("\r");
+    expect(interactionKeys("agy-q-skip", "ask_question", multiAskCall)).toBe("\x1b");
+
+    const multiQuestionCall = {
+      sessionUpdate: "tool_call" as const,
+      toolCallId: "q3",
+      title: "Wizard",
+      kind: "other" as const,
+      status: "pending" as const,
+      rawInput: {
+        questions: [
+          { question: "Env?", options: ["Dev", "Prod"], is_multi_select: false },
+          { question: "Features?", options: ["Auth", "Logging"], is_multi_select: true }
+        ]
+      }
+    };
+    expect(canBridgeInteraction("ask_question", multiQuestionCall)).toBe(true);
+    expect(permissionOptions(multiQuestionCall, "ask_question", 0)).toEqual([
+      { optionId: "agy-q-q0-0", kind: "allow_once", name: "Dev" },
+      { optionId: "agy-q-q0-1", kind: "allow_once", name: "Prod" },
+      { optionId: "agy-q-q0-skip", kind: "reject_once", name: "Skip" }
+    ]);
+    expect(permissionOptions(multiQuestionCall, "ask_question", 1)).toEqual([
+      { optionId: "agy-q-q1-0", kind: "allow_once", name: "Auth" },
+      { optionId: "agy-q-q1-1", kind: "allow_once", name: "Logging" },
+      { optionId: "agy-q-q1-all", kind: "allow_once", name: "Select All" },
+      { optionId: "agy-q-q1-none", kind: "allow_once", name: "Submit (None selected)" },
+      { optionId: "agy-q-q1-skip", kind: "reject_once", name: "Skip" }
+    ]);
+    expect(interactionKeys("agy-q-q0-1", "ask_question", multiQuestionCall, 0)).toBe("\x1b[B\r");
+    expect(interactionKeys("agy-q-q1-0,1", "ask_question", multiQuestionCall, 1)).toBe(" \x1b[B \r");
   });
 
   it("bridges agy's ask_permission sandbox-bypass request as a command-style menu", () => {
@@ -514,12 +571,12 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("fails closed for multi-select ask_question without writing keys", async () => {
+  it("bridges multi-select ask_question via PTY option keys", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const askInput = JSON.stringify({
       questions: [{
         question: "Pick many",
-        options: ["A", "B"],
+        options: ["A", "B", "C"],
         is_multi_select: true
       }]
     });
@@ -529,8 +586,53 @@ describe("permission bridge", () => {
       db.close();
     });
     const session = interactiveSession(dir, pty);
-    await expect(session.prompt("go", async () => {}, async () => "agy-q-0")).rejects.toThrow(/multi-select ask_question/);
-    expect(pty.writes).toEqual([]);
+    const result = session.prompt("go", async () => {}, async () => {
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "ask-multi.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 50);
+      return "agy-q-0,2";
+    });
+    expect((await result).stopReason).toBe("end_turn");
+    expect(pty.writes).toEqual([" \x1b[B\x1b[B \r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("bridges multi-question ask_question sequences via PTY option keys", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const askInput = JSON.stringify({
+      questions: [
+        { question: "Q1", options: ["X", "Y"], is_multi_select: false },
+        { question: "Q2", options: ["M", "N"], is_multi_select: true }
+      ]
+    });
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "ask-seq");
+      insertStep(db, pendingToolRow("ask_question", askInput, 138));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const choices = ["agy-q-q0-1", "agy-q-q1-0,1"];
+    let qCount = 0;
+    const result = session.prompt("go", async () => {}, async (_call, context) => {
+      expect(context.questionIndex).toBe(qCount);
+      const choice = choices[qCount++];
+      if (qCount === 2) {
+        setTimeout(async () => {
+          const db = new (await import("better-sqlite3")).default(path.join(dir, "ask-seq.db"));
+          updateStep(db, 1, { status: 3 });
+          insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+          db.close();
+          pty.emitData("? for shortcuts");
+        }, 100);
+      }
+      return choice;
+    });
+    expect((await result).stopReason).toBe("end_turn");
+    expect(pty.writes).toEqual(["\x1b[B\r", " \x1b[B \r"]);
+    await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
 

--- a/tests/elicitation.test.ts
+++ b/tests/elicitation.test.ts
@@ -162,6 +162,31 @@ describe("AskQuestion Payload Parsing & Elicitation Requests", () => {
       }
     });
   });
+
+  it("builds form elicitation request per questionIndex for multi-question dialogs", () => {
+    const multiQCall: SessionUpdate = {
+      sessionUpdate: "tool_call",
+      toolCallId: "tc_mq",
+      title: "Wizard",
+      rawInput: {
+        questions: [
+          { question: "Env?", options: ["Dev", "Prod"], is_multi_select: false },
+          { question: "Features?", options: ["Auth", "DB"], is_multi_select: true }
+        ]
+      }
+    } as any;
+
+    const req0 = buildElicitationRequestFromAskQuestion(multiQCall, "sess_1", 0);
+    expect(req0?.message).toBe("[Question 1/2] Env?");
+    expect(req0?.requestedSchema?.required).toEqual(["q0"]);
+
+    const req1 = buildElicitationRequestFromAskQuestion(multiQCall, "sess_1", 1);
+    expect(req1?.message).toBe("[Question 2/2] Features?");
+    expect(req1?.requestedSchema?.required).toEqual(["q1"]);
+
+    expect(encodeElicitationKeys(multiQCall, { q0: "Prod" }, 0)).toBe("\x1b[B\r");
+    expect(encodeElicitationKeys(multiQCall, { q1: ["Auth", "DB"] }, 1)).toBe(" \x1b[B \r");
+  });
 });
 
 describe("Encoding Elicitation Responses to PTY Keypresses", () => {


### PR DESCRIPTION
## Description

Expands status-9 interactive tool bridging in `agy-acp` for `ask_question` dialogs to support multi-select questions and multi-question sequences.

Key capabilities added:
1. **Multi-select questions**:
   - Parses `is_multi_select` / `isMultiSelect` options from `rawInput`.
   - Generates PTY keypresses: `\x1b[B` (Down arrow) to navigate, Space to toggle option selection, and Enter (`\r`) to submit.
   - Provides option IDs for single selection (`agy-q-0`), comma-separated multi-selection (`agy-q-0,2`), select all (`agy-q-all`), submit empty (`agy-q-none`), and skip (`agy-q-skip`).

2. **Multi-question sequences**:
   - Plumbs `questionIndex` through `onPermission` and `requestPermissionV1` / `requestPermissionV2`.
   - Sequences through each question prompt in multi-question `ask_question` dialogs during status-9 execution in `cli.ts`.
   - Formats ACP v2 titles with question step indicators (e.g., `[Question 1/2] ...`).

## Related Issues

Fixes #34

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed