### PR TITLE
Do not advertise directory paths in ACP tool call locations

### DIFF
--- a/src/agy/db/replay.ts
+++ b/src/agy/db/replay.ts
@@ -26,16 +26,25 @@ interface CacheEntry extends ReplayResult {
   stat: DbStat;
   skipNarration: boolean;
   cwd: string | undefined;
+  locationReadability: Map<string, boolean>;
+}
+
+interface BuiltReplay extends ReplayResult {
+  locationReadability: Map<string, boolean>;
 }
 
 /** Translate an entire conversation from scratch. Returns null if unreadable. */
-function buildReplay(dir: string, id: string, opts: ReplayOptions): ReplayResult | null {
+function buildReplay(dir: string, id: string, opts: ReplayOptions): BuiltReplay | null {
   const conn = ConversationDb.open(dir, id);
   if (!conn) return null;
   try {
     const translator = new Translator({ mode: "replay", ...opts });
     const updates = translator.translate(conn.readAfter(-1));
-    return { updates, maxIdx: translator.lastStepIdx };
+    return {
+      updates,
+      maxIdx: translator.lastStepIdx,
+      locationReadability: translator.locationReadability
+    };
   } finally {
     conn.close();
   }
@@ -62,11 +71,10 @@ export class ReplayCache {
 
     if (entry && sameOptions) {
       // Fast path: file identical to what we cached.
-      const locationsStillReadable = entry.updates.every((update) => {
-        const locations = (update as SessionUpdate & { locations?: Array<{ path?: unknown }> }).locations ?? [];
-        return locations.every((location) => typeof location.path === "string" && isReadableFile(location.path));
-      });
-      if (entry.stat.mtimeMs === stat.mtimeMs && entry.stat.size === stat.size && locationsStillReadable) {
+      const locationStateUnchanged = [...entry.locationReadability].every(
+        ([filePath, wasReadable]) => isReadableFile(filePath) === wasReadable
+      );
+      if (entry.stat.mtimeMs === stat.mtimeMs && entry.stat.size === stat.size && locationStateUnchanged) {
         return { updates: entry.updates, maxIdx: entry.maxIdx };
       }
     }
@@ -74,11 +82,7 @@ export class ReplayCache {
     // Full (re)build.
     const built = buildReplay(dir, id, opts);
     if (!built) return null;
-    this.store(id, built, stat, opts);
-    return built;
-  }
-
-  private store(id: string, result: ReplayResult, stat: DbStat, opts: ReplayOptions): void {
-    this.cache.set(id, { ...result, stat, skipNarration: opts.skipNarration, cwd: opts.cwd });
+    this.cache.set(id, { ...built, stat, skipNarration: opts.skipNarration, cwd: opts.cwd });
+    return { updates: built.updates, maxIdx: built.maxIdx };
   }
 }

--- a/src/agy/db/replay.ts
+++ b/src/agy/db/replay.ts
@@ -8,6 +8,7 @@
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { ConversationDb, type DbStat, statConversation } from "./database.js";
 import { Lru } from "./lru.js";
+import { isReadableFile } from "./tool-call-updates.js";
 import { Translator } from "./translator.js";
 
 export interface ReplayOptions {
@@ -61,7 +62,11 @@ export class ReplayCache {
 
     if (entry && sameOptions) {
       // Fast path: file identical to what we cached.
-      if (entry.stat.mtimeMs === stat.mtimeMs && entry.stat.size === stat.size) {
+      const locationsStillReadable = entry.updates.every((update) => {
+        const locations = (update as SessionUpdate & { locations?: Array<{ path?: unknown }> }).locations ?? [];
+        return locations.every((location) => typeof location.path === "string" && isReadableFile(location.path));
+      });
+      if (entry.stat.mtimeMs === stat.mtimeMs && entry.stat.size === stat.size && locationsStillReadable) {
         return { updates: entry.updates, maxIdx: entry.maxIdx };
       }
     }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -19,6 +19,8 @@ export interface UpdateContext {
   cwd?: string;
   /** Prior file contents for full-file write diffs. */
   fileContents?: FileContentCache;
+  /** Candidate location path -> readability observed while translating. */
+  locationReadability?: Map<string, boolean>;
 }
 
 /** Cap on fetched URL / large tool bodies surfaced in session updates. */
@@ -266,6 +268,13 @@ export function isReadableFile(filePath: string | null | undefined): boolean {
   }
 }
 
+function isReadableLocation(filePath: string | null, ctx?: UpdateContext): boolean {
+  if (!filePath) return false;
+  const readable = isReadableFile(filePath);
+  ctx?.locationReadability?.set(filePath, readable);
+  return readable;
+}
+
 // --- per-tool builders --------------------------------------------------------
 // agy's rawInputJson keys are inconsistently PascalCase/camelCase across tool
 // versions (`TargetFile` vs `targetFile`), so every lookup below tries both.
@@ -327,7 +336,7 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
 
     title = shown ? `Read ${shown}` : "Read file";
     if (shown && endLine !== null) title += `:${locationLine}-${endLine}`;
-    if (resolvedFile && isReadableFile(resolvedFile)) locations.push({ path: resolvedFile, line: locationLine });
+    if (isReadableLocation(resolvedFile, ctx)) locations.push({ path: resolvedFile, line: locationLine });
 
     const body = asStr(view?.content);
     if (body) {
@@ -382,7 +391,7 @@ export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpda
     const resolvedPath = resolvePath(searchPath, displayCwd);
     const shown = searchPath ? toDisplayPath(searchPath, displayCwd) : "";
     title = shown ? `Search '${query}' ${shown}` : `Search '${query}'`;
-    if (resolvedPath && isReadableFile(resolvedPath)) locations.push({ path: resolvedPath });
+    if (isReadableLocation(resolvedPath, ctx)) locations.push({ path: resolvedPath });
 
     const body = asStr(grep?.textOutput)?.trim() || renderHits(grep?.hits) || asStr(grep?.shellCommand)?.trim();
     if (body) content.push(codeBlock(body));
@@ -564,7 +573,7 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
       const prior = fileContents?.get(cacheKey) ?? null;
       content.push({ type: "diff", path: targetFile, oldText: prior, newText: fullContent });
       fileContents?.set(cacheKey, fullContent);
-      if (isReadableFile(resolvedTarget)) locations.push({ path: resolvedTarget });
+      if (isReadableLocation(resolvedTarget, ctx)) locations.push({ path: resolvedTarget });
     }
   } else {
     // replace_file_content (one inline chunk) or multi_replace_file_content
@@ -578,7 +587,7 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
       const oldText = asStr(pick(chunk, "TargetContent", "targetContent"));
       content.push({ type: "diff", path: targetFile, oldText, newText });
 
-      if (isReadableFile(resolvedTarget)) {
+      if (isReadableLocation(resolvedTarget, ctx)) {
         const line = asNum(pick(chunk, "StartLine", "startLine"));
         locations.push(line !== null ? { path: resolvedTarget, line } : { path: resolvedTarget });
       }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -242,7 +242,12 @@ function fsPath(p: string | null | undefined): string | null {
   try {
     return fileURLToPath(p);
   } catch {
-    return decodeURIComponent(p.slice("file://".length));
+    const raw = p.slice("file://".length);
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      return raw;
+    }
   }
 }
 

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -4,6 +4,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { SessionUpdate, ToolKind } from "@agentclientprotocol/sdk";
 import type { ErrorDetails, PermissionInfo, TaskDetails } from "./columns.js";
 import { isPlanFile, planUpdateFromMarkdown } from "../../acp/agent-plan/index.js";
@@ -239,9 +240,9 @@ function fsPath(p: string | null | undefined): string | null {
   if (!p) return null;
   if (!p.startsWith("file://")) return p;
   try {
-    return decodeURIComponent(new URL(p).pathname);
+    return fileURLToPath(p);
   } catch {
-    return p.slice("file://".length);
+    return decodeURIComponent(p.slice("file://".length));
   }
 }
 

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -2,6 +2,7 @@
 // result variants) into ACP `tool_call` updates. Shared helpers first, then one
 // builder per tool family, grouped by the ACP `ToolKind` they map to.
 
+import fs from "node:fs";
 import path from "node:path";
 import type { SessionUpdate, ToolKind } from "@agentclientprotocol/sdk";
 import type { ErrorDetails, PermissionInfo, TaskDetails } from "./columns.js";
@@ -244,6 +245,16 @@ function fsPath(p: string | null | undefined): string | null {
   }
 }
 
+/** Return true if `filePath` is known to be a directory on disk. */
+function isDirectory(filePath: string | null | undefined): boolean {
+  if (!filePath) return false;
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 // --- per-tool builders --------------------------------------------------------
 // agy's rawInputJson keys are inconsistently PascalCase/camelCase across tool
 // versions (`TargetFile` vs `targetFile`), so every lookup below tries both.
@@ -289,7 +300,6 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
     const dir = fsPath(asStr(list?.dirUri)) ?? fsPath(asStr(pick(rawInput, "DirectoryPath", "directoryPath")));
     const shown = dir ? toDisplayPath(dir, displayCwd) : "";
     title = shown ? `Read ${shown}` : "Read directory";
-    if (dir) locations.push({ path: dir });
 
     const entries = (list?.entries ?? []).filter((e) => e.name.trim().length > 0);
     if (entries.length > 0) {
@@ -304,7 +314,7 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
 
     title = shown ? `Read ${shown}` : "Read file";
     if (shown && endLine !== null) title += `:${startLine === 0 ? 1 : startLine}-${endLine}`;
-    if (filePath) locations.push({ path: filePath, line: startLine });
+    if (filePath && !isDirectory(filePath)) locations.push({ path: filePath, line: startLine });
 
     const body = asStr(view?.content);
     if (body) {
@@ -358,7 +368,7 @@ export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpda
     const searchPath = fsPath(asStr(pick(rawInput, "SearchPath", "searchPath"))) ?? fsPath(asStr(grep?.cwdUri));
     const shown = searchPath ? toDisplayPath(searchPath, displayCwd) : "";
     title = shown ? `Search '${query}' ${shown}` : `Search '${query}'`;
-    if (searchPath) locations.push({ path: searchPath });
+    if (searchPath && !isDirectory(searchPath)) locations.push({ path: searchPath });
 
     const body = asStr(grep?.textOutput)?.trim() || renderHits(grep?.hits) || asStr(grep?.shellCommand)?.trim();
     if (body) content.push(codeBlock(body));
@@ -413,7 +423,7 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
   const commandCwd =
     fsPath(asStr(pick(rawInput, "Cwd", "cwd"))) ??
     fsPath(commandResult?.cwd?.trim() ? commandResult.cwd : null);
-  const locations = commandCwd ? [{ path: commandCwd }] : [];
+  const locations: Record<string, unknown>[] = [];
 
   const update = toolCallUpdate({
     stepRow,
@@ -539,7 +549,7 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
       const prior = fileContents?.get(cacheKey) ?? null;
       content.push({ type: "diff", path: targetFile, oldText: prior, newText: fullContent });
       fileContents?.set(cacheKey, fullContent);
-      locations.push({ path: targetFile });
+      if (!isDirectory(targetFile)) locations.push({ path: targetFile });
     }
   } else {
     // replace_file_content (one inline chunk) or multi_replace_file_content
@@ -553,8 +563,10 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
       const oldText = asStr(pick(chunk, "TargetContent", "targetContent"));
       content.push({ type: "diff", path: targetFile, oldText, newText });
 
-      const line = asNum(pick(chunk, "StartLine", "startLine"));
-      locations.push(line !== null ? { path: targetFile, line } : { path: targetFile });
+      if (!isDirectory(targetFile)) {
+        const line = asNum(pick(chunk, "StartLine", "startLine"));
+        locations.push(line !== null ? { path: targetFile, line } : { path: targetFile });
+      }
     }
   }
 

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -255,6 +255,16 @@ function isDirectory(filePath: string | null | undefined): boolean {
   }
 }
 
+/** Return true if `filePath` is positively known to be a file on disk. */
+function isFile(filePath: string | null | undefined): boolean {
+  if (!filePath) return false;
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
 // --- per-tool builders --------------------------------------------------------
 // agy's rawInputJson keys are inconsistently PascalCase/camelCase across tool
 // versions (`TargetFile` vs `targetFile`), so every lookup below tries both.
@@ -368,7 +378,7 @@ export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpda
     const searchPath = fsPath(asStr(pick(rawInput, "SearchPath", "searchPath"))) ?? fsPath(asStr(grep?.cwdUri));
     const shown = searchPath ? toDisplayPath(searchPath, displayCwd) : "";
     title = shown ? `Search '${query}' ${shown}` : `Search '${query}'`;
-    if (searchPath && !isDirectory(searchPath)) locations.push({ path: searchPath });
+    if (searchPath && isFile(searchPath)) locations.push({ path: searchPath });
 
     const body = asStr(grep?.textOutput)?.trim() || renderHits(grep?.hits) || asStr(grep?.shellCommand)?.trim();
     if (body) content.push(codeBlock(body));

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -333,7 +333,7 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
 
     title = shown ? `Read ${shown}` : "Read file";
     if (shown && endLine !== null) title += `:${startLine === 0 ? 1 : startLine}-${endLine}`;
-    if (resolvedFile && !isDirectory(resolvedFile)) locations.push({ path: resolvedFile, line: startLine });
+    if (resolvedFile && isFile(resolvedFile)) locations.push({ path: resolvedFile, line: startLine });
 
     const body = asStr(view?.content);
     if (body) {
@@ -349,7 +349,7 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
           fileSizeOrTotal: asNum(view?.fileSizeOrTotal)
         })
       ) {
-        fileContents.set(path.resolve(filePath), body);
+        fileContents.set(path.resolve(resolvedFile ?? filePath), body);
       }
     }
   }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -245,6 +245,14 @@ function fsPath(p: string | null | undefined): string | null {
   }
 }
 
+/** Resolve relative or `file://` path against session cwd. */
+function resolvePath(filePath: string | null | undefined, cwd?: string): string | null {
+  const p = fsPath(filePath);
+  if (!p) return null;
+  if (path.isAbsolute(p)) return path.resolve(p);
+  return cwd ? path.resolve(cwd, p) : path.resolve(p);
+}
+
 /** Return true if `filePath` is known to be a directory on disk. */
 function isDirectory(filePath: string | null | undefined): boolean {
   if (!filePath) return false;
@@ -318,13 +326,14 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   } else {
     const filePath =
       fsPath(asStr(pick(rawInput, "AbsolutePath", "absolutePath", "FilePath"))) ?? fsPath(asStr(view?.fileUri));
+    const resolvedFile = resolvePath(filePath, displayCwd);
     const shown = filePath ? toDisplayPath(filePath, displayCwd) : "";
     const startLine = asNum(pick(rawInput, "StartLine", "startLine")) ?? asNum(view?.startLine) ?? 1;
     const endLine = asNum(pick(rawInput, "EndLine", "endLine")) ?? asNum(view?.endLine);
 
     title = shown ? `Read ${shown}` : "Read file";
     if (shown && endLine !== null) title += `:${startLine === 0 ? 1 : startLine}-${endLine}`;
-    if (filePath && !isDirectory(filePath)) locations.push({ path: filePath, line: startLine });
+    if (resolvedFile && !isDirectory(resolvedFile)) locations.push({ path: resolvedFile, line: startLine });
 
     const body = asStr(view?.content);
     if (body) {
@@ -376,9 +385,10 @@ export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpda
   if (grep || name === "grep_search" || stepType === 7) {
     const query = asStr(grep?.query) ?? asStr(pick(rawInput, "Query", "query")) ?? "";
     const searchPath = fsPath(asStr(pick(rawInput, "SearchPath", "searchPath"))) ?? fsPath(asStr(grep?.cwdUri));
+    const resolvedPath = resolvePath(searchPath, displayCwd);
     const shown = searchPath ? toDisplayPath(searchPath, displayCwd) : "";
     title = shown ? `Search '${query}' ${shown}` : `Search '${query}'`;
-    if (searchPath && isFile(searchPath)) locations.push({ path: searchPath });
+    if (resolvedPath && isFile(resolvedPath)) locations.push({ path: resolvedPath });
 
     const body = asStr(grep?.textOutput)?.trim() || renderHits(grep?.hits) || asStr(grep?.shellCommand)?.trim();
     if (body) content.push(codeBlock(body));
@@ -536,6 +546,7 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   const displayCwd = fsPath(cwd) ?? undefined;
 
   const targetFile = fsPath(asStr(pick(rawInput, "TargetFile", "targetFile"))) ?? "";
+  const resolvedTarget = resolvePath(targetFile, displayCwd) ?? targetFile;
   const fullContent = asStr(pick(rawInput, "CodeContent", "codeContent"));
 
   // Brain plan artifacts → structured plan session update (v1 `plan` / v2 plan_update).
@@ -555,11 +566,11 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
     if (targetFile) {
       // Prefer prior view_file/write content as oldText when known; otherwise null
       // (new file or prior content never observed in this translator pass).
-      const cacheKey = path.resolve(targetFile);
+      const cacheKey = path.resolve(resolvedTarget);
       const prior = fileContents?.get(cacheKey) ?? null;
       content.push({ type: "diff", path: targetFile, oldText: prior, newText: fullContent });
       fileContents?.set(cacheKey, fullContent);
-      if (!isDirectory(targetFile)) locations.push({ path: targetFile });
+      if (!isDirectory(resolvedTarget)) locations.push({ path: resolvedTarget });
     }
   } else {
     // replace_file_content (one inline chunk) or multi_replace_file_content
@@ -573,9 +584,9 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
       const oldText = asStr(pick(chunk, "TargetContent", "targetContent"));
       content.push({ type: "diff", path: targetFile, oldText, newText });
 
-      if (!isDirectory(targetFile)) {
+      if (!isDirectory(resolvedTarget)) {
         const line = asNum(pick(chunk, "StartLine", "startLine"));
-        locations.push(line !== null ? { path: targetFile, line } : { path: targetFile });
+        locations.push(line !== null ? { path: resolvedTarget, line } : { path: resolvedTarget });
       }
     }
   }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -235,19 +235,14 @@ function asNum(v: unknown): number | null {
   return null;
 }
 
-/** Strip a `file://` scheme so the value can be resolved/displayed as a path. */
+/** Convert a valid `file://` URL to a path; reject malformed URLs without throwing. */
 function fsPath(p: string | null | undefined): string | null {
   if (!p) return null;
   if (!p.startsWith("file://")) return p;
   try {
     return fileURLToPath(p);
   } catch {
-    const raw = p.slice("file://".length);
-    try {
-      return decodeURIComponent(raw);
-    } catch {
-      return raw;
-    }
+    return null;
   }
 }
 
@@ -259,21 +254,13 @@ function resolvePath(filePath: string | null | undefined, cwd?: string): string 
   return cwd ? path.resolve(cwd, p) : path.resolve(p);
 }
 
-/** Return true if `filePath` is known to be a directory on disk. */
-function isDirectory(filePath: string | null | undefined): boolean {
+/** Return true if `filePath` is positively known to be a readable file. */
+export function isReadableFile(filePath: string | null | undefined): boolean {
   if (!filePath) return false;
   try {
-    return fs.statSync(filePath).isDirectory();
-  } catch {
-    return false;
-  }
-}
-
-/** Return true if `filePath` is positively known to be a file on disk. */
-function isFile(filePath: string | null | undefined): boolean {
-  if (!filePath) return false;
-  try {
-    return fs.statSync(filePath).isFile();
+    if (!fs.statSync(filePath).isFile()) return false;
+    fs.accessSync(filePath, fs.constants.R_OK);
+    return true;
   } catch {
     return false;
   }
@@ -336,10 +323,11 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
     const shown = filePath ? toDisplayPath(filePath, displayCwd) : "";
     const startLine = asNum(pick(rawInput, "StartLine", "startLine")) ?? asNum(view?.startLine) ?? 1;
     const endLine = asNum(pick(rawInput, "EndLine", "endLine")) ?? asNum(view?.endLine);
+    const locationLine = startLine === 0 ? 1 : startLine;
 
     title = shown ? `Read ${shown}` : "Read file";
-    if (shown && endLine !== null) title += `:${startLine === 0 ? 1 : startLine}-${endLine}`;
-    if (resolvedFile && isFile(resolvedFile)) locations.push({ path: resolvedFile, line: startLine });
+    if (shown && endLine !== null) title += `:${locationLine}-${endLine}`;
+    if (resolvedFile && isReadableFile(resolvedFile)) locations.push({ path: resolvedFile, line: locationLine });
 
     const body = asStr(view?.content);
     if (body) {
@@ -394,7 +382,7 @@ export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpda
     const resolvedPath = resolvePath(searchPath, displayCwd);
     const shown = searchPath ? toDisplayPath(searchPath, displayCwd) : "";
     title = shown ? `Search '${query}' ${shown}` : `Search '${query}'`;
-    if (resolvedPath && isFile(resolvedPath)) locations.push({ path: resolvedPath });
+    if (resolvedPath && isReadableFile(resolvedPath)) locations.push({ path: resolvedPath });
 
     const body = asStr(grep?.textOutput)?.trim() || renderHits(grep?.hits) || asStr(grep?.shellCommand)?.trim();
     if (body) content.push(codeBlock(body));
@@ -576,7 +564,7 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
       const prior = fileContents?.get(cacheKey) ?? null;
       content.push({ type: "diff", path: targetFile, oldText: prior, newText: fullContent });
       fileContents?.set(cacheKey, fullContent);
-      if (!isDirectory(resolvedTarget)) locations.push({ path: resolvedTarget });
+      if (isReadableFile(resolvedTarget)) locations.push({ path: resolvedTarget });
     }
   } else {
     // replace_file_content (one inline chunk) or multi_replace_file_content
@@ -590,7 +578,7 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
       const oldText = asStr(pick(chunk, "TargetContent", "targetContent"));
       content.push({ type: "diff", path: targetFile, oldText, newText });
 
-      if (!isDirectory(resolvedTarget)) {
+      if (isReadableFile(resolvedTarget)) {
         const line = asNum(pick(chunk, "StartLine", "startLine"));
         locations.push(line !== null ? { path: resolvedTarget, line } : { path: resolvedTarget });
       }

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -93,6 +93,8 @@ export class Translator {
   private readonly toolSnapshots = new Map<string, string>();
   // Stream + replay: last known file bodies from view_file / write_to_file (for diffs).
   private readonly fileContents: FileContentCache = new Map();
+  // Candidate ACP location paths and their readability during the latest translation.
+  readonly locationReadability = new Map<string, boolean>();
   // Replay: buffered consecutive agent-text parts, flushed at boundaries.
   private readonly pendingAgentParts: string[] = [];
   // Replay: message id for the current buffered agent-text group.
@@ -182,7 +184,8 @@ export class Translator {
   private pushDispatched(row: StepRow, out: SessionUpdate[]): void {
     const update = sessionUpdateFromStep(row, {
       cwd: this.opts.cwd,
-      fileContents: this.fileContents
+      fileContents: this.fileContents,
+      locationReadability: this.locationReadability
     });
     if (Array.isArray(update)) {
       for (const item of update) this.emitProgressive(row.idx, item, out);

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -558,6 +558,73 @@ describe("Translator", () => {
     expect(update.locations).toBeUndefined();
   });
 
+  it("does not emit non-existent or deleted SearchPath in locations for grep_search steps", () => {
+    const deletedDir = path.join(dir, "non-existent-folder");
+    const db = createConversationDb(dir, "conv-grep-deleted-dir");
+    insertStep(db, {
+      idx: 1,
+      stepType: 7,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "g-deleted",
+            namePrimary: "grep_search",
+            rawInputJson: JSON.stringify({ Query: "foo", SearchPath: deletedDir })
+          })
+        }),
+        grepSearch: encodeGrepSearchResult({
+          query: "foo",
+          cwdUri: `file://${deletedDir}`
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-grep-deleted-dir")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as { locations?: unknown[] };
+    expect(update.locations).toBeUndefined();
+  });
+
+  it("emits SearchPath in locations for grep_search steps when SearchPath is a file", () => {
+    const file = path.join(dir, "test.txt");
+    fs.writeFileSync(file, "hello world");
+    const db = createConversationDb(dir, "conv-grep-file");
+    insertStep(db, {
+      idx: 1,
+      stepType: 7,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "g-file",
+            namePrimary: "grep_search",
+            rawInputJson: JSON.stringify({ Query: "hello", SearchPath: file })
+          })
+        }),
+        grepSearch: encodeGrepSearchResult({
+          query: "hello",
+          cwdUri: `file://${file}`
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-grep-file")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as { locations?: Array<{ path: string }> };
+    expect(update.locations).toEqual([{ path: file }]);
+  });
+
   it("does not attach exitCode in rawOutput for pending run_command steps", () => {
     const db = createConversationDb(dir, "conv-exec-pending");
     insertStep(db, {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -662,6 +662,97 @@ describe("Translator", () => {
     expect(update.locations).toEqual([{ path: absFile }]);
   });
 
+  it("does not emit location for replayed view_file step when file does not exist on disk", () => {
+    const missingFile = path.join(dir, "non-existent-view.txt");
+    const db = createConversationDb(dir, "conv-view-missing");
+    insertStep(db, {
+      idx: 1,
+      stepType: 8,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "view-missing",
+            namePrimary: "view_file",
+            rawInputJson: JSON.stringify({ AbsolutePath: missingFile })
+          })
+        }),
+        viewFile: encodeViewFileResult({
+          fileUri: `file://${missingFile}`,
+          content: "cached historical content\n"
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-view-missing")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false, cwd: dir });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as { locations?: unknown[] };
+    expect(update.locations).toBeUndefined();
+  });
+
+  it("uses resolved session path for view_file cache keys on full-file writes with relative paths", () => {
+    const db = createConversationDb(dir, "conv-write-diff-rel");
+    insertStep(db, {
+      idx: 1,
+      stepType: 8,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "read-rel",
+            namePrimary: "view_file",
+            rawInputJson: '{"AbsolutePath":"a.ts"}'
+          })
+        }),
+        viewFile: encodeViewFileResult({
+          fileUri: "a.ts",
+          content: "export const x = 1;\n"
+        })
+      })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "write-rel",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({
+              TargetFile: "a.ts",
+              CodeContent: "export const x = 2;\n"
+            })
+          })
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-write-diff-rel")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false, cwd: dir });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    const write = updates.find(
+      (u) => (u as { toolCallId?: string }).toolCallId === "write-rel"
+    ) as {
+      content?: Array<{ type?: string; path?: string; oldText?: string | null; newText?: string }>;
+    };
+    expect(write).toBeTruthy();
+    const diff = (write.content ?? []).find((c) => c.type === "diff");
+    expect(diff).toMatchObject({
+      type: "diff",
+      oldText: "export const x = 1;\n",
+      newText: "export const x = 2;\n"
+    });
+  });
+
   it("does not attach exitCode in rawOutput for pending run_command steps", () => {
     const db = createConversationDb(dir, "conv-exec-pending");
     insertStep(db, {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -724,6 +724,27 @@ describe("Translator", () => {
     expect(update.locations).toEqual([{ path: winFile, line: 1 }]);
   });
 
+  it("handles malformed percent-encoded file URIs without throwing URIError", () => {
+    const db = createConversationDb(dir, "conv-malformed-uri");
+    insertStep(db, {
+      idx: 1,
+      stepType: 8,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        viewFile: encodeViewFileResult({
+          fileUri: "file:///tmp/foo%bar",
+          content: "malformed URI test content\n"
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-malformed-uri")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    expect(() => translator.translate(conn.readAfter(-1))).not.toThrow();
+    conn.close();
+  });
+
   it("uses resolved session path for view_file cache keys on full-file writes with relative paths", () => {
     const db = createConversationDb(dir, "conv-write-diff-rel");
     insertStep(db, {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1677,6 +1677,37 @@ describe("ReplayCache", () => {
     expect(rebuilt?.updates).not.toBe(first?.updates);
   });
 
+  it("rebuilds cached locations when a referenced file is restored", () => {
+    const file = path.join(dir, "restored-location.txt");
+    const db = createConversationDb(dir, "conv-replay-restored-location");
+    insertStep(db, {
+      idx: 1,
+      stepType: 8,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "restored-view",
+            namePrimary: "view_file",
+            rawInputJson: JSON.stringify({ AbsolutePath: file })
+          })
+        }),
+        viewFile: encodeViewFileResult({ fileUri: `file://${file}`, content: "content" })
+      })
+    });
+    db.close();
+
+    const cache = new ReplayCache(8);
+    const first = cache.get(dir, "conv-replay-restored-location", { skipNarration: false });
+    expect((first?.updates[0] as { locations?: unknown[] }).locations).toBeUndefined();
+
+    fs.writeFileSync(file, "content");
+
+    const rebuilt = cache.get(dir, "conv-replay-restored-location", { skipNarration: false });
+    expect((rebuilt?.updates[0] as { locations?: unknown[] }).locations).toEqual([{ path: file, line: 1 }]);
+    expect(rebuilt?.updates).not.toBe(first?.updates);
+  });
+
   it("returns null for a missing conversation", () => {
     const cache = new ReplayCache(8);
     expect(cache.get(dir, "missing", { skipNarration: false })).toBeNull();

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -695,6 +695,55 @@ describe("Translator", () => {
     expect(update.locations).toBeUndefined();
   });
 
+  it("does not emit locations for replayed edits when the target does not exist on disk", () => {
+    const missingFile = path.join(dir, "non-existent-edit.txt");
+    const db = createConversationDb(dir, "conv-edit-missing");
+    insertStep(db, {
+      idx: 1,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "write-missing",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({ TargetFile: missingFile, CodeContent: "new content\n" })
+          })
+        })
+      })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "replace-missing",
+            namePrimary: "replace_file_content",
+            rawInputJson: JSON.stringify({
+              TargetFile: missingFile,
+              TargetContent: "old content",
+              ReplacementContent: "new content",
+              StartLine: 3
+            })
+          })
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-edit-missing")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false, cwd: dir });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(2);
+    for (const update of updates as Array<{ locations?: unknown[] }>) {
+      expect(update.locations).toBeUndefined();
+    }
+  });
+
   it("decodes Windows file URIs with drive letters in view_file fallback", () => {
     const winFile = path.join(dir, "win.txt");
     fs.writeFileSync(winFile, "content");
@@ -743,6 +792,35 @@ describe("Translator", () => {
     const translator = new Translator({ mode: "replay", skipNarration: false });
     expect(() => translator.translate(conn.readAfter(-1))).not.toThrow();
     conn.close();
+  });
+
+  it("does not reinterpret an encoded path separator in a malformed file URI", () => {
+    const nestedDir = path.join(dir, "encoded");
+    const nestedFile = path.join(nestedDir, "path.txt");
+    fs.mkdirSync(nestedDir);
+    fs.writeFileSync(nestedFile, "content");
+    const malformedUri = `file://${path.join(dir, "encoded%2Fpath.txt")}`;
+    const db = createConversationDb(dir, "conv-encoded-separator-uri");
+    insertStep(db, {
+      idx: 1,
+      stepType: 8,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        viewFile: encodeViewFileResult({
+          fileUri: malformedUri,
+          content: "content"
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-encoded-separator-uri")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    expect((updates[0] as { locations?: unknown[] }).locations).toBeUndefined();
   });
 
   it("uses resolved session path for view_file cache keys on full-file writes with relative paths", () => {
@@ -1565,6 +1643,38 @@ describe("ReplayCache", () => {
     expect(cache.get(dir, "conv-replay-mutation", { skipNarration: false })?.updates).toMatchObject([
       { content: { text: "complete result" } }
     ]);
+  });
+
+  it("rebuilds cached locations when a referenced file is deleted", () => {
+    const file = path.join(dir, "cached-location.txt");
+    fs.writeFileSync(file, "content");
+    const db = createConversationDb(dir, "conv-replay-deleted-location");
+    insertStep(db, {
+      idx: 1,
+      stepType: 8,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "cached-view",
+            namePrimary: "view_file",
+            rawInputJson: JSON.stringify({ AbsolutePath: file })
+          })
+        }),
+        viewFile: encodeViewFileResult({ fileUri: `file://${file}`, content: "content" })
+      })
+    });
+    db.close();
+
+    const cache = new ReplayCache(8);
+    const first = cache.get(dir, "conv-replay-deleted-location", { skipNarration: false });
+    expect((first?.updates[0] as { locations?: unknown[] }).locations).toEqual([{ path: file, line: 1 }]);
+
+    fs.rmSync(file);
+
+    const rebuilt = cache.get(dir, "conv-replay-deleted-location", { skipNarration: false });
+    expect((rebuilt?.updates[0] as { locations?: unknown[] }).locations).toBeUndefined();
+    expect(rebuilt?.updates).not.toBe(first?.updates);
   });
 
   it("returns null for a missing conversation", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -464,6 +464,100 @@ describe("Translator", () => {
     expect(body).toContain("README.md");
   });
 
+  it("does not emit directory Cwd in locations for run_command steps (regression for issue #16)", () => {
+    const db = createConversationDb(dir, "conv-exec-no-dir-location");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "c-dir",
+            namePrimary: "run_command",
+            rawInputJson: JSON.stringify({ CommandLine: "ls", Cwd: dir })
+          })
+        }),
+        commandResult: encodeCommandResult({
+          cwd: dir,
+          exitCode: 0,
+          output: "ok\n",
+          command: "ls"
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-exec-no-dir-location")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as { locations?: unknown[] };
+    expect(update.locations).toBeUndefined();
+  });
+
+  it("does not emit directory path in locations for list_dir steps", () => {
+    const db = createConversationDb(dir, "conv-list-dir-no-location");
+    insertStep(db, {
+      idx: 1,
+      stepType: 9,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "l-dir",
+            namePrimary: "list_dir",
+            rawInputJson: JSON.stringify({ DirectoryPath: dir })
+          })
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-list-dir-no-location")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as { locations?: unknown[] };
+    expect(update.locations).toBeUndefined();
+  });
+
+  it("does not emit directory SearchPath in locations for grep_search steps", () => {
+    const db = createConversationDb(dir, "conv-grep-dir-no-location");
+    insertStep(db, {
+      idx: 1,
+      stepType: 7,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "g-dir",
+            namePrimary: "grep_search",
+            rawInputJson: JSON.stringify({ Query: "foo", SearchPath: dir })
+          })
+        }),
+        grepSearch: encodeGrepSearchResult({
+          query: "foo",
+          cwdUri: `file://${dir}`
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-grep-dir-no-location")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as { locations?: unknown[] };
+    expect(update.locations).toBeUndefined();
+  });
+
   it("does not attach exitCode in rawOutput for pending run_command steps", () => {
     const db = createConversationDb(dir, "conv-exec-pending");
     insertStep(db, {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -625,6 +625,43 @@ describe("Translator", () => {
     expect(update.locations).toEqual([{ path: file }]);
   });
 
+  it("resolves relative SearchPath against session cwd for grep_search steps", () => {
+    const relFile = "subfolder/rel-file.txt";
+    const absFolder = path.join(dir, "subfolder");
+    fs.mkdirSync(absFolder, { recursive: true });
+    const absFile = path.join(dir, relFile);
+    fs.writeFileSync(absFile, "relative content");
+
+    const db = createConversationDb(dir, "conv-grep-rel");
+    insertStep(db, {
+      idx: 1,
+      stepType: 7,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "g-rel",
+            namePrimary: "grep_search",
+            rawInputJson: JSON.stringify({ Query: "relative", SearchPath: relFile })
+          })
+        }),
+        grepSearch: encodeGrepSearchResult({
+          query: "relative"
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-grep-rel")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false, cwd: dir });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as { locations?: Array<{ path: string }> };
+    expect(update.locations).toEqual([{ path: absFile }]);
+  });
+
   it("does not attach exitCode in rawOutput for pending run_command steps", () => {
     const db = createConversationDb(dir, "conv-exec-pending");
     insertStep(db, {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -695,6 +695,35 @@ describe("Translator", () => {
     expect(update.locations).toBeUndefined();
   });
 
+  it("decodes Windows file URIs with drive letters in view_file fallback", () => {
+    const winFile = path.join(dir, "win.txt");
+    fs.writeFileSync(winFile, "content");
+    const fileUri = `file:///${winFile.replace(/\\/g, "/")}`;
+    const db = createConversationDb(dir, "conv-win-uri");
+    insertStep(db, {
+      idx: 1,
+      stepType: 8,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        viewFile: encodeViewFileResult({
+          fileUri,
+          startLine: 1,
+          content: "content"
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-win-uri")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    const update = updates[0] as { locations?: Array<{ path: string }> };
+    expect(update.locations).toEqual([{ path: winFile, line: 1 }]);
+  });
+
   it("uses resolved session path for view_file cache keys on full-file writes with relative paths", () => {
     const db = createConversationDb(dir, "conv-write-diff-rel");
     insertStep(db, {


### PR DESCRIPTION
## Description

ACP clients like Zed interpret the `locations` array on `tool_call` updates as readable file locations and attempt to read their contents. When tools like `run_command` (`Cwd`), `list_dir` (`dirUri`), or `grep_search` (`SearchPath`) advertised directory paths in `locations`, Zed logged errors attempting to read directory bytes as files.

This change filters out directory paths from `locations` across tool call update builders and adds an `isDirectory` check to ensure directory paths are never advertised as file locations.

## Related Issues

Fixes #16

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed