### PR TITLE
Include command code block alongside output in execute tool call content

### DIFF
--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -401,12 +401,12 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     "Command Execution";
 
   const content: Record<string, unknown>[] = [];
-  // Prefer decoded field-28 output over empty; fall back to showing the command line.
+  if (command?.trim()) {
+    content.push(codeBlock(command.trim()));
+  }
   const output = commandResult?.output ?? "";
   if (output.trim()) {
     content.push(outputCodeBlock(output));
-  } else if (command?.trim()) {
-    content.push(codeBlock(command.trim()));
   }
 
   // Prefer explicit Cwd from args; fall back to command-result cwd.

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -461,6 +461,7 @@ describe("Translator", () => {
     expect(update.kind).toBe("execute");
     expect(update.rawOutput).toMatchObject({ exitCode: 0 });
     const body = (update.content ?? []).map((c) => c.content?.text ?? "").join("\n");
+    expect(body).toContain("ls");
     expect(body).toContain("README.md");
   });
 


### PR DESCRIPTION
## Description

Include both the command code block (`codeBlock(command)`) and the output code block (`outputCodeBlock(output)`) in the `content` array for `kind: "execute"` tool calls when both are available in `executeUpdate`.

This ensures that ACP clients (like Zed) render both the command line string and the output when expanding the tool call card.

## Related Issues

Fixes #43

## Type of Change

- [x] New feature (non-breaking change adding functionality)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/acp/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed