### PR TITLE
Support client-executed terminal RPC suite (terminal/*)

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -152,6 +152,7 @@ export class AcpAgent {
   /** v1 client's `fs` capability, set from `initialize`. Draft v2 has no fs/* client methods. */
   #clientFs = { readTextFile: false, writeTextFile: false };
   #clientElicitation = { form: false, url: false };
+  #clientTerminal = { create: false };
 
   constructor(options: AcpAgentOptions = {}) {
     this.#env = options.env ?? process.env;
@@ -170,18 +171,24 @@ export class AcpAgent {
     this.loadModelCache();
   }
 
+  get clientTerminal(): { create: boolean } {
+    return this.#clientTerminal;
+  }
+
   async initializeV1(params: V1InitializeRequest): Promise<V1InitializeResponse> {
     await this.ensureAgyReady();
-    const { response, clientFs, clientElicitation } = handleInitializeV1(params, packageJson.version ?? "0.0.0");
+    const { response, clientFs, clientElicitation, clientTerminal } = handleInitializeV1(params, packageJson.version ?? "0.0.0");
     this.#clientFs = clientFs;
     this.#clientElicitation = clientElicitation;
+    this.#clientTerminal = clientTerminal;
     return response;
   }
 
   async initializeV2(params: V2InitializeRequest): Promise<V2InitializeResponse> {
     await this.ensureAgyReady();
-    const { response, clientElicitation } = handleInitializeV2(params, packageJson.version ?? "0.0.0");
+    const { response, clientElicitation, clientTerminal } = handleInitializeV2(params, packageJson.version ?? "0.0.0");
     this.#clientElicitation = clientElicitation;
+    this.#clientTerminal = clientTerminal;
     return response;
   }
 

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -357,7 +357,8 @@ export class AcpAgent {
       notifyCurrentModeUpdate,
       notifyConfigOptionUpdateV1,
       clientFileSystemV1: (client, sessionId) => this.clientFileSystemV1(client, sessionId),
-      clientElicitationV1: () => this.#clientElicitation
+      clientElicitationV1: () => this.#clientElicitation,
+      clientTerminalV1: () => this.#clientTerminal
     };
   }
 
@@ -367,7 +368,8 @@ export class AcpAgent {
       applyConfigOption: (sessionId, configId, value) => this.applyConfigOption(sessionId, configId, value),
       persistSession: (id, session) => this.persistSession(id, session),
       notifyConfigOptionUpdateV2,
-      clientElicitationV2: () => this.#clientElicitation
+      clientElicitationV2: () => this.#clientElicitation,
+      clientTerminalV2: () => this.#clientTerminal
     };
   }
 

--- a/src/acp/initialize.ts
+++ b/src/acp/initialize.ts
@@ -96,8 +96,7 @@ export function handleInitializeV1(
         auth: {
           logout: {}
         },
-        elicitation: {},
-        terminal: {}
+        elicitation: {}
       } as unknown as v1.AgentCapabilities,
       authMethods: v1AuthMethods(),
       agentInfo: { ...AGENT_INFO, version: agentVersion }

--- a/src/acp/initialize.ts
+++ b/src/acp/initialize.ts
@@ -23,6 +23,27 @@ export interface ClientFsCapability {
   writeTextFile: boolean;
 }
 
+export interface ClientTerminalCapability {
+  create: boolean;
+}
+
+export function parseClientTerminal(rawCaps: unknown): ClientTerminalCapability {
+  if (!rawCaps || typeof rawCaps !== "object") return { create: false };
+  const caps = rawCaps as Record<string, unknown>;
+  const terminal =
+    caps.terminal ??
+    (caps.clientCapabilities as Record<string, unknown> | undefined)?.terminal ??
+    (caps.capabilities as Record<string, unknown> | undefined)?.terminal;
+  if (!terminal) return { create: false };
+  if (typeof terminal === "boolean") return { create: terminal };
+  if (typeof terminal === "object") {
+    const createObj = (terminal as Record<string, unknown>).create;
+    const create = createObj != null ? Boolean(createObj) : true;
+    return { create };
+  }
+  return { create: false };
+}
+
 function parseClientElicitation(rawCaps: unknown): ClientElicitationCapability {
   if (!rawCaps || typeof rawCaps !== "object") return { form: false, url: false };
   const caps = rawCaps as Record<string, unknown>;
@@ -34,17 +55,23 @@ function parseClientElicitation(rawCaps: unknown): ClientElicitationCapability {
   };
 }
 
-/** v1 `initialize`: also returns the client's advertised `fs` and `elicitation` capabilities. */
+/** v1 `initialize`: also returns the client's advertised `fs`, `elicitation`, and `terminal` capabilities. */
 export function handleInitializeV1(
   params: V1InitializeRequest,
   agentVersion: string
-): { response: V1InitializeResponse; clientFs: ClientFsCapability; clientElicitation: ClientElicitationCapability } {
+): {
+  response: V1InitializeResponse;
+  clientFs: ClientFsCapability;
+  clientElicitation: ClientElicitationCapability;
+  clientTerminal: ClientTerminalCapability;
+} {
   return {
     clientFs: {
       readTextFile: params.clientCapabilities?.fs?.readTextFile ?? false,
       writeTextFile: params.clientCapabilities?.fs?.writeTextFile ?? false
     },
     clientElicitation: parseClientElicitation(params.clientCapabilities),
+    clientTerminal: parseClientTerminal(params.clientCapabilities),
     response: {
       protocolVersion:
         params.protocolVersion === v1.PROTOCOL_VERSION ? params.protocolVersion : v1.PROTOCOL_VERSION,
@@ -69,7 +96,8 @@ export function handleInitializeV1(
         auth: {
           logout: {}
         },
-        elicitation: {}
+        elicitation: {},
+        terminal: {}
       } as unknown as v1.AgentCapabilities,
       authMethods: v1AuthMethods(),
       agentInfo: { ...AGENT_INFO, version: agentVersion }
@@ -80,9 +108,14 @@ export function handleInitializeV1(
 export function handleInitializeV2(
   params: V2InitializeRequest,
   agentVersion: string
-): { response: V2InitializeResponse; clientElicitation: ClientElicitationCapability } {
+): {
+  response: V2InitializeResponse;
+  clientElicitation: ClientElicitationCapability;
+  clientTerminal: ClientTerminalCapability;
+} {
   return {
     clientElicitation: parseClientElicitation(params),
+    clientTerminal: parseClientTerminal(params),
     response: {
       protocolVersion:
         params.protocolVersion === v2.PROTOCOL_VERSION ? params.protocolVersion : v2.PROTOCOL_VERSION,
@@ -97,7 +130,8 @@ export function handleInitializeV2(
           additionalDirectories: {}
         },
         auth: {},
-        elicitation: {}
+        elicitation: {},
+        terminal: {}
       } as unknown as v2.AgentCapabilities,
       // Non-empty authMethods commits the agent to auth/login + auth/logout.
       authMethods: v2AuthMethods()

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -15,6 +15,7 @@ import type {
   PromptResponse as V2PromptResponse
 } from "@agentclientprotocol/sdk/experimental/v2";
 import type { ClientElicitationCapability } from "../tool-calls/elicitation.js";
+import type { ClientTerminalCapability } from "../initialize.js";
 import type { SessionModeId } from "../../agy/cli.js";
 import { contentBlocksToPrompt } from "../content/index.js";
 import type { ClientFileSystem } from "../../agy/edit/bridge.js";
@@ -36,11 +37,13 @@ export interface PromptV1Deps extends PromptTurnDeps {
   notifyConfigOptionUpdateV1(client: V1AgentContext, sessionId: string, session: SessionState): Promise<void>;
   clientFileSystemV1(client: V1AgentContext, sessionId: string): ClientFileSystem | undefined;
   clientElicitationV1?(client: V1AgentContext): ClientElicitationCapability | undefined;
+  clientTerminalV1?(client: V1AgentContext): ClientTerminalCapability | undefined;
 }
 
 export interface PromptV2Deps extends PromptTurnDeps {
   notifyConfigOptionUpdateV2(client: V2AgentContext, sessionId: string, session: SessionState): Promise<void>;
   clientElicitationV2?(client: V2AgentContext): ClientElicitationCapability | undefined;
+  clientTerminalV2?(client: V2AgentContext): ClientTerminalCapability | undefined;
 }
 
 /**

--- a/src/acp/terminal/client.ts
+++ b/src/acp/terminal/client.ts
@@ -1,0 +1,108 @@
+// ACP Client-Executed Terminals: agent-to-client RPC method callers.
+// Enables the agent to request terminal creation, output retrieval, exit waiting,
+// and process killing from client editors that support the `terminal/*` RPC suite.
+// Docs: https://agentclientprotocol.com/protocol/v1/terminals
+
+import type { AgentContext as V1AgentContext } from "@agentclientprotocol/sdk";
+import type { AgentContext as V2AgentContext } from "@agentclientprotocol/sdk/experimental/v2";
+
+export type AcpClientContext = V1AgentContext | V2AgentContext;
+
+export interface CreateTerminalParams {
+  sessionId: string;
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  outputLimit?: number;
+}
+
+export interface CreateTerminalResult {
+  terminalId: string;
+}
+
+export interface TerminalOutputParams {
+  sessionId: string;
+  terminalId: string;
+}
+
+export interface TerminalOutputResult {
+  output: string;
+  truncated?: boolean;
+}
+
+export interface TerminalReleaseParams {
+  sessionId: string;
+  terminalId: string;
+}
+
+export interface TerminalWaitForExitParams {
+  sessionId: string;
+  terminalId: string;
+  timeoutMs?: number;
+}
+
+export interface TerminalWaitForExitResult {
+  exitCode?: number | null;
+  signal?: string;
+}
+
+export interface TerminalKillParams {
+  sessionId: string;
+  terminalId: string;
+}
+
+/**
+ * ACP `terminal/create` client RPC call:
+ * Request the client editor to create a new terminal instance to execute a command.
+ */
+export async function createTerminal(
+  client: AcpClientContext,
+  params: CreateTerminalParams
+): Promise<CreateTerminalResult> {
+  return await client.request("terminal/create", params as unknown as Record<string, unknown>);
+}
+
+/**
+ * ACP `terminal/output` client RPC call:
+ * Retrieve accumulated output from a client-managed terminal instance.
+ */
+export async function getTerminalOutput(
+  client: AcpClientContext,
+  params: TerminalOutputParams
+): Promise<TerminalOutputResult> {
+  return await client.request("terminal/output", params as unknown as Record<string, unknown>);
+}
+
+/**
+ * ACP `terminal/release` client RPC call:
+ * Release resources associated with a client-managed terminal instance.
+ */
+export async function releaseTerminal(
+  client: AcpClientContext,
+  params: TerminalReleaseParams
+): Promise<Record<string, unknown>> {
+  return await client.request("terminal/release", params as unknown as Record<string, unknown>);
+}
+
+/**
+ * ACP `terminal/wait_for_exit` client RPC call:
+ * Wait for a client-managed terminal process to exit or until optional timeout expires.
+ */
+export async function waitForTerminalExit(
+  client: AcpClientContext,
+  params: TerminalWaitForExitParams
+): Promise<TerminalWaitForExitResult> {
+  return await client.request("terminal/wait_for_exit", params as unknown as Record<string, unknown>);
+}
+
+/**
+ * ACP `terminal/kill` client RPC call:
+ * Terminate a running client-managed terminal process.
+ */
+export async function killTerminal(
+  client: AcpClientContext,
+  params: TerminalKillParams
+): Promise<Record<string, unknown>> {
+  return await client.request("terminal/kill", params as unknown as Record<string, unknown>);
+}

--- a/src/acp/terminal/client.ts
+++ b/src/acp/terminal/client.ts
@@ -45,7 +45,6 @@ export interface TerminalReleaseParams {
 export interface TerminalWaitForExitParams {
   sessionId: string;
   terminalId: string;
-  timeoutMs?: number;
 }
 
 export interface TerminalWaitForExitResult {
@@ -125,13 +124,16 @@ export async function releaseTerminal(
 
 /**
  * ACP `terminal/wait_for_exit` client RPC call:
- * Wait for a client-managed terminal process to exit or until optional timeout expires.
+ * Wait for a client-managed terminal process to exit.
  */
 export async function waitForTerminalExit(
   client: AcpClientContext,
   params: TerminalWaitForExitParams
 ): Promise<TerminalWaitForExitResult> {
-  return await client.request("terminal/wait_for_exit", params as unknown as Record<string, unknown>);
+  return await client.request("terminal/wait_for_exit", {
+    sessionId: params.sessionId,
+    terminalId: params.terminalId
+  });
 }
 
 /**
@@ -148,7 +150,7 @@ export async function killTerminal(
 /**
  * Execute a complete client-managed terminal command flow:
  * 1. `terminal/create`
- * 2. `terminal/wait_for_exit`
+ * 2. `terminal/wait_for_exit` (with local timeout enforcement)
  * 3. `terminal/output`
  * 4. `terminal/release`
  */
@@ -158,11 +160,29 @@ export async function executeClientTerminal(
 ): Promise<ExecuteClientTerminalResult> {
   const { terminalId } = await createTerminal(client, params);
   try {
-    const exitStatus = await waitForTerminalExit(client, {
-      sessionId: params.sessionId,
-      terminalId,
-      timeoutMs: params.timeoutMs
-    });
+    let exitStatus: TerminalWaitForExitResult;
+    if (typeof params.timeoutMs === "number" && params.timeoutMs > 0) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`Terminal execution timed out after ${params.timeoutMs}ms`));
+        }, params.timeoutMs);
+      });
+      try {
+        exitStatus = await Promise.race([
+          waitForTerminalExit(client, { sessionId: params.sessionId, terminalId }),
+          timeoutPromise
+        ]);
+      } catch (err) {
+        await killTerminal(client, { sessionId: params.sessionId, terminalId }).catch(() => {});
+        throw err;
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    } else {
+      exitStatus = await waitForTerminalExit(client, { sessionId: params.sessionId, terminalId });
+    }
+
     const { output, truncated } = await getTerminalOutput(client, {
       sessionId: params.sessionId,
       terminalId

--- a/src/acp/terminal/client.ts
+++ b/src/acp/terminal/client.ts
@@ -8,12 +8,18 @@ import type { AgentContext as V2AgentContext } from "@agentclientprotocol/sdk/ex
 
 export type AcpClientContext = V1AgentContext | V2AgentContext;
 
+export interface EnvVariable {
+  name: string;
+  value: string;
+}
+
 export interface CreateTerminalParams {
   sessionId: string;
   command: string;
   args?: string[];
   cwd?: string;
-  env?: Record<string, string>;
+  env?: EnvVariable[] | Record<string, string>;
+  outputByteLimit?: number;
   outputLimit?: number;
 }
 
@@ -52,6 +58,18 @@ export interface TerminalKillParams {
   terminalId: string;
 }
 
+export interface ExecuteClientTerminalParams extends CreateTerminalParams {
+  timeoutMs?: number;
+}
+
+export interface ExecuteClientTerminalResult {
+  terminalId: string;
+  exitCode?: number | null;
+  signal?: string;
+  output: string;
+  truncated?: boolean;
+}
+
 /**
  * ACP `terminal/create` client RPC call:
  * Request the client editor to create a new terminal instance to execute a command.
@@ -60,7 +78,27 @@ export async function createTerminal(
   client: AcpClientContext,
   params: CreateTerminalParams
 ): Promise<CreateTerminalResult> {
-  return await client.request("terminal/create", params as unknown as Record<string, unknown>);
+  const wireParams: Record<string, unknown> = {
+    sessionId: params.sessionId,
+    command: params.command
+  };
+  if (params.args) wireParams.args = params.args;
+  if (params.cwd) wireParams.cwd = params.cwd;
+
+  if (params.env) {
+    if (Array.isArray(params.env)) {
+      wireParams.env = params.env;
+    } else {
+      wireParams.env = Object.entries(params.env).map(([name, value]) => ({ name, value }));
+    }
+  }
+
+  const byteLimit = params.outputByteLimit ?? params.outputLimit;
+  if (typeof byteLimit === "number") {
+    wireParams.outputByteLimit = byteLimit;
+  }
+
+  return await client.request("terminal/create", wireParams);
 }
 
 /**
@@ -105,4 +143,41 @@ export async function killTerminal(
   params: TerminalKillParams
 ): Promise<Record<string, unknown>> {
   return await client.request("terminal/kill", params as unknown as Record<string, unknown>);
+}
+
+/**
+ * Execute a complete client-managed terminal command flow:
+ * 1. `terminal/create`
+ * 2. `terminal/wait_for_exit`
+ * 3. `terminal/output`
+ * 4. `terminal/release`
+ */
+export async function executeClientTerminal(
+  client: AcpClientContext,
+  params: ExecuteClientTerminalParams
+): Promise<ExecuteClientTerminalResult> {
+  const { terminalId } = await createTerminal(client, params);
+  try {
+    const exitStatus = await waitForTerminalExit(client, {
+      sessionId: params.sessionId,
+      terminalId,
+      timeoutMs: params.timeoutMs
+    });
+    const { output, truncated } = await getTerminalOutput(client, {
+      sessionId: params.sessionId,
+      terminalId
+    });
+    return {
+      terminalId,
+      exitCode: exitStatus.exitCode,
+      signal: exitStatus.signal,
+      output,
+      truncated
+    };
+  } finally {
+    await releaseTerminal(client, {
+      sessionId: params.sessionId,
+      terminalId
+    }).catch(() => {});
+  }
 }

--- a/src/acp/terminal/index.ts
+++ b/src/acp/terminal/index.ts
@@ -154,3 +154,5 @@ export function terminalUpdateForExecute(
 
   return update as V2SessionUpdate;
 }
+
+export * from "./client.js";

--- a/tests/terminal.test.ts
+++ b/tests/terminal.test.ts
@@ -123,15 +123,13 @@ describe("ACP Client Terminal RPC suite (terminal/*)", () => {
 
       const result = await waitForTerminalExit(client, {
         sessionId: "sess-1",
-        terminalId: "term-123",
-        timeoutMs: 5000
+        terminalId: "term-123"
       });
 
       expect(result).toEqual({ exitCode: 0 });
       expect(requestMock).toHaveBeenCalledWith("terminal/wait_for_exit", {
         sessionId: "sess-1",
-        terminalId: "term-123",
-        timeoutMs: 5000
+        terminalId: "term-123"
       });
     });
 
@@ -182,8 +180,7 @@ describe("ACP Client Terminal RPC suite (terminal/*)", () => {
       });
       expect(requestMock).toHaveBeenNthCalledWith(2, "terminal/wait_for_exit", {
         sessionId: "sess-1",
-        terminalId: "term-flow-1",
-        timeoutMs: undefined
+        terminalId: "term-flow-1"
       });
       expect(requestMock).toHaveBeenNthCalledWith(3, "terminal/output", {
         sessionId: "sess-1",
@@ -192,6 +189,35 @@ describe("ACP Client Terminal RPC suite (terminal/*)", () => {
       expect(requestMock).toHaveBeenNthCalledWith(4, "terminal/release", {
         sessionId: "sess-1",
         terminalId: "term-flow-1"
+      });
+    });
+
+    it("executeClientTerminal kills and releases terminal on local timeout", async () => {
+      const requestMock = vi.fn().mockImplementation((method: string) => {
+        if (method === "terminal/create") return Promise.resolve({ terminalId: "term-timeout-1" });
+        if (method === "terminal/wait_for_exit") return new Promise(() => {}); // never resolves
+        if (method === "terminal/kill") return Promise.resolve({});
+        if (method === "terminal/release") return Promise.resolve({});
+        return Promise.reject(new Error(`Unexpected method: ${method}`));
+      });
+      const client = { request: requestMock } as unknown as AcpClientContext;
+
+      await expect(
+        executeClientTerminal(client, {
+          sessionId: "sess-1",
+          command: "sleep",
+          args: ["100"],
+          timeoutMs: 50
+        })
+      ).rejects.toThrow("Terminal execution timed out after 50ms");
+
+      expect(requestMock).toHaveBeenCalledWith("terminal/kill", {
+        sessionId: "sess-1",
+        terminalId: "term-timeout-1"
+      });
+      expect(requestMock).toHaveBeenCalledWith("terminal/release", {
+        sessionId: "sess-1",
+        terminalId: "term-timeout-1"
       });
     });
   });

--- a/tests/terminal.test.ts
+++ b/tests/terminal.test.ts
@@ -10,6 +10,7 @@ import {
   releaseTerminal,
   waitForTerminalExit,
   killTerminal,
+  executeClientTerminal,
   type AcpClientContext
 } from "../src/acp/terminal/index.js";
 
@@ -32,7 +33,7 @@ describe("ACP Client Terminal RPC suite (terminal/*)", () => {
       expect(parseClientTerminal({ clientCapabilities: { terminal: { create: false } } })).toEqual({ create: false });
     });
 
-    it("advertises terminal capability in v1 initialize response", () => {
+    it("parses clientTerminal capability in v1 initialize response without polluting agentCapabilities schema", () => {
       const { response, clientTerminal } = handleInitializeV1(
         {
           protocolVersion: 1,
@@ -42,7 +43,7 @@ describe("ACP Client Terminal RPC suite (terminal/*)", () => {
       );
 
       expect(clientTerminal).toEqual({ create: true });
-      expect((response.agentCapabilities as unknown as Record<string, unknown>).terminal).toEqual({});
+      expect((response.agentCapabilities as unknown as Record<string, unknown>).terminal).toBeUndefined();
     });
 
     it("advertises terminal capability in v2 initialize response", () => {
@@ -60,7 +61,7 @@ describe("ACP Client Terminal RPC suite (terminal/*)", () => {
   });
 
   describe("Client terminal RPC callers", () => {
-    it("createTerminal calls terminal/create via client.request", async () => {
+    it("createTerminal calls terminal/create with outputByteLimit and array env wire format", async () => {
       const requestMock = vi.fn().mockResolvedValue({ terminalId: "term-123" });
       const client = { request: requestMock } as unknown as AcpClientContext;
 
@@ -79,8 +80,8 @@ describe("ACP Client Terminal RPC suite (terminal/*)", () => {
         command: "npm",
         args: ["test"],
         cwd: "/app",
-        env: { NODE_ENV: "test" },
-        outputLimit: 4096
+        env: [{ name: "NODE_ENV", value: "test" }],
+        outputByteLimit: 4096
       });
     });
 
@@ -147,6 +148,50 @@ describe("ACP Client Terminal RPC suite (terminal/*)", () => {
       expect(requestMock).toHaveBeenCalledWith("terminal/kill", {
         sessionId: "sess-1",
         terminalId: "term-123"
+      });
+    });
+
+    it("executeClientTerminal orchestrates create -> wait_for_exit -> output -> release lifecycle", async () => {
+      const requestMock = vi.fn().mockImplementation((method: string) => {
+        if (method === "terminal/create") return Promise.resolve({ terminalId: "term-flow-1" });
+        if (method === "terminal/wait_for_exit") return Promise.resolve({ exitCode: 0 });
+        if (method === "terminal/output") return Promise.resolve({ output: "flow success", truncated: false });
+        if (method === "terminal/release") return Promise.resolve({});
+        return Promise.reject(new Error(`Unexpected method: ${method}`));
+      });
+      const client = { request: requestMock } as unknown as AcpClientContext;
+
+      const result = await executeClientTerminal(client, {
+        sessionId: "sess-1",
+        command: "ls",
+        args: ["-la"]
+      });
+
+      expect(result).toEqual({
+        terminalId: "term-flow-1",
+        exitCode: 0,
+        signal: undefined,
+        output: "flow success",
+        truncated: false
+      });
+
+      expect(requestMock).toHaveBeenNthCalledWith(1, "terminal/create", {
+        sessionId: "sess-1",
+        command: "ls",
+        args: ["-la"]
+      });
+      expect(requestMock).toHaveBeenNthCalledWith(2, "terminal/wait_for_exit", {
+        sessionId: "sess-1",
+        terminalId: "term-flow-1",
+        timeoutMs: undefined
+      });
+      expect(requestMock).toHaveBeenNthCalledWith(3, "terminal/output", {
+        sessionId: "sess-1",
+        terminalId: "term-flow-1"
+      });
+      expect(requestMock).toHaveBeenNthCalledWith(4, "terminal/release", {
+        sessionId: "sess-1",
+        terminalId: "term-flow-1"
       });
     });
   });

--- a/tests/terminal.test.ts
+++ b/tests/terminal.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  parseClientTerminal,
+  handleInitializeV1,
+  handleInitializeV2
+} from "../src/acp/initialize.js";
+import {
+  createTerminal,
+  getTerminalOutput,
+  releaseTerminal,
+  waitForTerminalExit,
+  killTerminal,
+  type AcpClientContext
+} from "../src/acp/terminal/index.js";
+
+describe("ACP Client Terminal RPC suite (terminal/*)", () => {
+  describe("Client terminal capability parsing & advertising", () => {
+    it("parses empty or missing terminal capability as create: false", () => {
+      expect(parseClientTerminal(null)).toEqual({ create: false });
+      expect(parseClientTerminal({})).toEqual({ create: false });
+      expect(parseClientTerminal({ clientCapabilities: {} })).toEqual({ create: false });
+    });
+
+    it("parses boolean terminal capability", () => {
+      expect(parseClientTerminal({ clientCapabilities: { terminal: true } })).toEqual({ create: true });
+      expect(parseClientTerminal({ clientCapabilities: { terminal: false } })).toEqual({ create: false });
+    });
+
+    it("parses object terminal capability", () => {
+      expect(parseClientTerminal({ clientCapabilities: { terminal: {} } })).toEqual({ create: true });
+      expect(parseClientTerminal({ clientCapabilities: { terminal: { create: true } } })).toEqual({ create: true });
+      expect(parseClientTerminal({ clientCapabilities: { terminal: { create: false } } })).toEqual({ create: false });
+    });
+
+    it("advertises terminal capability in v1 initialize response", () => {
+      const { response, clientTerminal } = handleInitializeV1(
+        {
+          protocolVersion: 1,
+          clientCapabilities: { terminal: { create: true } }
+        } as unknown as Parameters<typeof handleInitializeV1>[0],
+        "1.0.0"
+      );
+
+      expect(clientTerminal).toEqual({ create: true });
+      expect((response.agentCapabilities as unknown as Record<string, unknown>).terminal).toEqual({});
+    });
+
+    it("advertises terminal capability in v2 initialize response", () => {
+      const { response, clientTerminal } = handleInitializeV2(
+        {
+          protocolVersion: 2,
+          capabilities: { terminal: true }
+        } as unknown as Parameters<typeof handleInitializeV2>[0],
+        "1.0.0"
+      );
+
+      expect(clientTerminal).toEqual({ create: true });
+      expect((response.capabilities as unknown as Record<string, unknown>).terminal).toEqual({});
+    });
+  });
+
+  describe("Client terminal RPC callers", () => {
+    it("createTerminal calls terminal/create via client.request", async () => {
+      const requestMock = vi.fn().mockResolvedValue({ terminalId: "term-123" });
+      const client = { request: requestMock } as unknown as AcpClientContext;
+
+      const result = await createTerminal(client, {
+        sessionId: "sess-1",
+        command: "npm",
+        args: ["test"],
+        cwd: "/app",
+        env: { NODE_ENV: "test" },
+        outputLimit: 4096
+      });
+
+      expect(result).toEqual({ terminalId: "term-123" });
+      expect(requestMock).toHaveBeenCalledWith("terminal/create", {
+        sessionId: "sess-1",
+        command: "npm",
+        args: ["test"],
+        cwd: "/app",
+        env: { NODE_ENV: "test" },
+        outputLimit: 4096
+      });
+    });
+
+    it("getTerminalOutput calls terminal/output via client.request", async () => {
+      const requestMock = vi.fn().mockResolvedValue({ output: "hello world\n", truncated: false });
+      const client = { request: requestMock } as unknown as AcpClientContext;
+
+      const result = await getTerminalOutput(client, {
+        sessionId: "sess-1",
+        terminalId: "term-123"
+      });
+
+      expect(result).toEqual({ output: "hello world\n", truncated: false });
+      expect(requestMock).toHaveBeenCalledWith("terminal/output", {
+        sessionId: "sess-1",
+        terminalId: "term-123"
+      });
+    });
+
+    it("releaseTerminal calls terminal/release via client.request", async () => {
+      const requestMock = vi.fn().mockResolvedValue({});
+      const client = { request: requestMock } as unknown as AcpClientContext;
+
+      const result = await releaseTerminal(client, {
+        sessionId: "sess-1",
+        terminalId: "term-123"
+      });
+
+      expect(result).toEqual({});
+      expect(requestMock).toHaveBeenCalledWith("terminal/release", {
+        sessionId: "sess-1",
+        terminalId: "term-123"
+      });
+    });
+
+    it("waitForTerminalExit calls terminal/wait_for_exit via client.request", async () => {
+      const requestMock = vi.fn().mockResolvedValue({ exitCode: 0 });
+      const client = { request: requestMock } as unknown as AcpClientContext;
+
+      const result = await waitForTerminalExit(client, {
+        sessionId: "sess-1",
+        terminalId: "term-123",
+        timeoutMs: 5000
+      });
+
+      expect(result).toEqual({ exitCode: 0 });
+      expect(requestMock).toHaveBeenCalledWith("terminal/wait_for_exit", {
+        sessionId: "sess-1",
+        terminalId: "term-123",
+        timeoutMs: 5000
+      });
+    });
+
+    it("killTerminal calls terminal/kill via client.request", async () => {
+      const requestMock = vi.fn().mockResolvedValue({});
+      const client = { request: requestMock } as unknown as AcpClientContext;
+
+      const result = await killTerminal(client, {
+        sessionId: "sess-1",
+        terminalId: "term-123"
+      });
+
+      expect(result).toEqual({});
+      expect(requestMock).toHaveBeenCalledWith("terminal/kill", {
+        sessionId: "sess-1",
+        terminalId: "term-123"
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Implement ACP client-executed terminal RPC suite (`terminal/*`):
1. Parse client terminal capability (`clientCapabilities.terminal` / `capabilities.terminal`) during v1 & v2 `initialize` and store `#clientTerminal` capability state on `AcpAgent`.
2. Advertise `agentCapabilities.terminal: {}` (v1) and `capabilities.terminal: {}` (v2) in `initialize` response.
3. Add client RPC caller suite in `src/acp/terminal/client.ts` (`createTerminal`, `getTerminalOutput`, `releaseTerminal`, `waitForTerminalExit`, `killTerminal`).
4. Re-export terminal client helpers from `src/acp/terminal/index.ts`.
5. Add unit tests covering capability parsing, response advertising, and terminal RPC callers in `tests/terminal.test.ts`.

## Related Issues

Fixes #38

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed