### PR TITLE
Suppress background <SYSTEM_MESSAGE> task outputs in stepType 15

### DIFF
--- a/src/agy/db/system-message.ts
+++ b/src/agy/db/system-message.ts
@@ -3,7 +3,10 @@
 // suppressed so background notifications and command outputs do not render as regular
 // assistant response text in ACP clients.
 
-/** True if the text contains an internal `<SYSTEM_MESSAGE>` payload. */
+/**
+ * True if the text is an internal `<SYSTEM_MESSAGE>` envelope injected by agy
+ * (starts with `<SYSTEM_MESSAGE>` at the beginning of the text payload).
+ */
 export function isSystemMessage(text: string): boolean {
-  return text.includes("<SYSTEM_MESSAGE>");
+  return /^\s*<SYSTEM_MESSAGE>/i.test(text);
 }

--- a/src/agy/db/system-message.ts
+++ b/src/agy/db/system-message.ts
@@ -4,9 +4,9 @@
 // assistant response text in ACP clients.
 
 /**
- * True if the text is an internal `<SYSTEM_MESSAGE>` envelope injected by agy
- * (starts with `<SYSTEM_MESSAGE>` at the beginning of the text payload).
+ * True if the text matches an internal agy system message envelope
+ * (starts with `<SYSTEM_MESSAGE>\n[Message]`).
  */
 export function isSystemMessage(text: string): boolean {
-  return /^\s*<SYSTEM_MESSAGE>/i.test(text);
+  return /^\s*<SYSTEM_MESSAGE>\s*\n\[Message\]\s+/i.test(text);
 }

--- a/src/agy/db/system-message.ts
+++ b/src/agy/db/system-message.ts
@@ -10,3 +10,28 @@
 export function isSystemMessage(text: string): boolean {
   return /^\s*<SYSTEM_MESSAGE>\s*\n\[Message\]\s+/i.test(text);
 }
+
+/**
+ * True while a growing text value could still become an internal system
+ * message envelope. Streaming callers defer these prefixes until they can be
+ * classified, avoiding emission of a partial internal marker.
+ */
+export function isSystemMessagePrefix(text: string): boolean {
+  const tag = "<SYSTEM_MESSAGE>";
+  const marker = "[Message]";
+  const trimmed = text.trimStart();
+  const tagCandidate = trimmed.slice(0, Math.min(trimmed.length, tag.length));
+  if (tagCandidate.toLowerCase() !== tag.slice(0, tagCandidate.length).toLowerCase()) return false;
+  if (trimmed.length <= tag.length) return true;
+
+  const afterTag = trimmed.slice(tag.length);
+  const markerStart = afterTag.search(/\S/);
+  if (markerStart === -1) return true;
+  if (markerStart === 0 || afterTag[markerStart - 1] !== "\n") return false;
+
+  const markerCandidate = afterTag.slice(markerStart);
+  return (
+    markerCandidate.length <= marker.length &&
+    markerCandidate.toLowerCase() === marker.slice(0, markerCandidate.length).toLowerCase()
+  );
+}

--- a/src/agy/db/system-message.ts
+++ b/src/agy/db/system-message.ts
@@ -1,0 +1,9 @@
+// System message filtering: agy appends internal `<SYSTEM_MESSAGE>` task completion
+// notifications into step type 15 (agentText). When translated, these should be
+// suppressed so background notifications and command outputs do not render as regular
+// assistant response text in ACP clients.
+
+/** True if the text contains an internal `<SYSTEM_MESSAGE>` payload. */
+export function isSystemMessage(text: string): boolean {
+  return text.includes("<SYSTEM_MESSAGE>");
+}

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -122,13 +122,14 @@ export class Translator {
     const out: SessionUpdate[] = [];
     let streamingAgentMessageId: string | null = null;
     let streamingHasVisibleText = false;
-    for (const row of rows) {
+    for (const [rowIndex, row] of rows.entries()) {
       let streamingNeedsSeparator = false;
+      const canGrow = rowIndex === rows.length - 1 && row.status !== 3 && row.status !== 6 && row.status !== 7;
       if (this.opts.mode === "stream") {
         if (row.stepType === 15) {
           const text = row.stepPayload.agentText?.text ?? "";
           const isSysMsg = isSystemMessage(text);
-          const isSysMsgPrefix = isSystemMessagePrefix(text);
+          const isSysMsgPrefix = canGrow && isSystemMessagePrefix(text);
           if (text.length > 0 && !isSysMsg && !isSysMsgPrefix) streamingAgentMessageId ??= String(row.idx);
           const visible =
             text.length > 0 && !isSysMsg && !isSysMsgPrefix && !(this.opts.skipNarration && isNarration(text));
@@ -139,7 +140,7 @@ export class Translator {
           streamingHasVisibleText = false;
         }
       }
-      this.translateRow(row, out, streamingAgentMessageId, streamingNeedsSeparator);
+      this.translateRow(row, out, streamingAgentMessageId, streamingNeedsSeparator, canGrow);
     }
     // Replay groups agent text per batch; a batch ends a message boundary.
     if (this.opts.mode === "replay") this.flushAgentBuffer(out);
@@ -151,13 +152,14 @@ export class Translator {
     row: StepRow,
     out: SessionUpdate[],
     streamingAgentMessageId: string | null,
-    streamingNeedsSeparator: boolean
+    streamingNeedsSeparator: boolean,
+    canGrow: boolean
   ): void {
     this._lastStepIdx = Math.max(this._lastStepIdx, row.idx);
 
     switch (row.stepType) {
       case 15: // agent text chunk
-        this.handleAgentText(row, out, streamingAgentMessageId, streamingNeedsSeparator);
+        this.handleAgentText(row, out, streamingAgentMessageId, streamingNeedsSeparator, canGrow);
         return;
 
       case 23: // conversation title (+ optional think narration)
@@ -277,7 +279,8 @@ export class Translator {
     row: StepRow,
     out: SessionUpdate[],
     streamingAgentMessageId: string | null,
-    streamingNeedsSeparator: boolean
+    streamingNeedsSeparator: boolean,
+    canGrow: boolean
   ): void {
     const thought = row.stepPayload.agentText?.thought;
     if (thought) {
@@ -286,7 +289,7 @@ export class Translator {
 
     const text = row.stepPayload.agentText?.text ?? "";
     if (isSystemMessage(text)) return;
-    if (this.opts.mode === "stream" && isSystemMessagePrefix(text)) return;
+    if (this.opts.mode === "stream" && canGrow && isSystemMessagePrefix(text)) return;
 
     const messageId = streamingAgentMessageId ?? String(row.idx);
 

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -16,6 +16,7 @@
 
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { filterNarration, isNarration } from "./narration.js";
+import { isSystemMessage } from "./system-message.js";
 import type { FileContentCache } from "./tool-call-updates.js";
 import type { StepRow } from "./types.js";
 import { sessionUpdateFromStep } from "./updates.js";
@@ -126,8 +127,9 @@ export class Translator {
       if (this.opts.mode === "stream") {
         if (row.stepType === 15) {
           const text = row.stepPayload.agentText?.text ?? "";
-          if (text.length > 0) streamingAgentMessageId ??= String(row.idx);
-          const visible = text.length > 0 && !(this.opts.skipNarration && isNarration(text));
+          const isSysMsg = isSystemMessage(text);
+          if (text.length > 0 && !isSysMsg) streamingAgentMessageId ??= String(row.idx);
+          const visible = text.length > 0 && !isSysMsg && !(this.opts.skipNarration && isNarration(text));
           streamingNeedsSeparator = visible && streamingHasVisibleText;
           if (visible) streamingHasVisibleText = true;
         } else {
@@ -281,6 +283,8 @@ export class Translator {
     }
 
     const text = row.stepPayload.agentText?.text ?? "";
+    if (isSystemMessage(text)) return;
+
     const messageId = streamingAgentMessageId ?? String(row.idx);
 
     if (this.opts.mode === "replay") {

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -16,7 +16,7 @@
 
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { filterNarration, isNarration } from "./narration.js";
-import { isSystemMessage } from "./system-message.js";
+import { isSystemMessage, isSystemMessagePrefix } from "./system-message.js";
 import type { FileContentCache } from "./tool-call-updates.js";
 import type { StepRow } from "./types.js";
 import { sessionUpdateFromStep } from "./updates.js";
@@ -128,8 +128,10 @@ export class Translator {
         if (row.stepType === 15) {
           const text = row.stepPayload.agentText?.text ?? "";
           const isSysMsg = isSystemMessage(text);
-          if (text.length > 0 && !isSysMsg) streamingAgentMessageId ??= String(row.idx);
-          const visible = text.length > 0 && !isSysMsg && !(this.opts.skipNarration && isNarration(text));
+          const isSysMsgPrefix = isSystemMessagePrefix(text);
+          if (text.length > 0 && !isSysMsg && !isSysMsgPrefix) streamingAgentMessageId ??= String(row.idx);
+          const visible =
+            text.length > 0 && !isSysMsg && !isSysMsgPrefix && !(this.opts.skipNarration && isNarration(text));
           streamingNeedsSeparator = visible && streamingHasVisibleText;
           if (visible) streamingHasVisibleText = true;
         } else {
@@ -284,6 +286,7 @@ export class Translator {
 
     const text = row.stepPayload.agentText?.text ?? "";
     if (isSystemMessage(text)) return;
+    if (this.opts.mode === "stream" && isSystemMessagePrefix(text)) return;
 
     const messageId = streamingAgentMessageId ?? String(row.idx);
 

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -18,6 +18,7 @@ import {
   type UpdateContext
 } from "./tool-call-updates.js";
 import type { StepRow } from "./types.js";
+import { isSystemMessage } from "./system-message.js";
 
 export type { UpdateContext } from "./tool-call-updates.js";
 
@@ -31,9 +32,11 @@ export type { UpdateContext } from "./tool-call-updates.js";
 const LIFECYCLE_STEP_TYPES = new Set<number>([90, 98, 101]);
 
 /** Step type 15 — a chunk of the agent's streamed text message (+ optional thought). */
-function agentUpdate(stepRow: StepRow): SessionUpdate | SessionUpdate[] {
+function agentUpdate(stepRow: StepRow): SessionUpdate | SessionUpdate[] | null {
   const text = stepRow.stepPayload.agentText?.text ?? "";
   const thought = stepRow.stepPayload.agentText?.thought;
+
+  const hasText = text.length > 0 && !isSystemMessage(text);
 
   if (thought) {
     const updates: SessionUpdate[] = [
@@ -43,7 +46,7 @@ function agentUpdate(stepRow: StepRow): SessionUpdate | SessionUpdate[] {
         messageId: `agent-thought-${stepRow.idx}`
       }
     ];
-    if (text) {
+    if (hasText) {
       updates.push({
         sessionUpdate: "agent_message_chunk",
         content: { type: "text", text },
@@ -52,6 +55,8 @@ function agentUpdate(stepRow: StepRow): SessionUpdate | SessionUpdate[] {
     }
     return updates;
   }
+
+  if (!hasText) return null;
 
   return {
     sessionUpdate: "agent_message_chunk",

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -975,10 +975,12 @@ describe("Translator", () => {
     ]);
   });
 
-  it("preserves assistant messages that mention <SYSTEM_MESSAGE> in prose", () => {
+  it("preserves assistant messages that mention <SYSTEM_MESSAGE> in prose or at start", () => {
     const db = createConversationDb(dir, "conv-prose-sys-msg");
-    const proseText = "The error notification contains <SYSTEM_MESSAGE> tag.";
-    insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: { text: proseText } }) });
+    const proseText1 = "The error notification contains <SYSTEM_MESSAGE> tag.";
+    const proseText2 = "<SYSTEM_MESSAGE> tag is used by agy for internal task notifications.";
+    insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: { text: proseText1 } }) });
+    insertStep(db, { idx: 2, stepType: 15, stepPayload: encodeStepPayload({ agentText: { text: proseText2 } }) });
     db.close();
 
     const conn = ConversationDb.open(dir, "conv-prose-sys-msg")!;
@@ -990,8 +992,8 @@ describe("Translator", () => {
       {
         sessionUpdate: "agent_message_chunk",
         messageId: "1",
-        content: { type: "text", text: proseText },
-        _meta: { stepIdx: 1 }
+        content: { type: "text", text: `${proseText1}\n${proseText2}` },
+        _meta: { stepIdx: 1, endStepIdx: 2 }
       }
     ]);
   });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -980,6 +980,7 @@ describe("Translator", () => {
     insertStep(db, {
       idx: 1,
       stepType: 15,
+      status: 1,
       stepPayload: encodeStepPayload({ agentText: { text: "<SYSTEM_MESSAGE>\n[Messag" } })
     });
 
@@ -987,14 +988,17 @@ describe("Translator", () => {
     const translator = new Translator({ mode: "stream", skipNarration: false });
     expect(translator.translate(conn.readAfter(0))).toEqual([]);
 
-    updateStepPayload(
+    updateStep(
       db,
       1,
-      encodeStepPayload({
-        agentText: {
-          text: "<SYSTEM_MESSAGE>\n[Message] timestamp=2026-07-28T10:07:08Z content=Task id task-175 finished"
-        }
-      })
+      {
+        status: 3,
+        stepPayload: encodeStepPayload({
+          agentText: {
+            text: "<SYSTEM_MESSAGE>\n[Message] timestamp=2026-07-28T10:07:08Z content=Task id task-175 finished"
+          }
+        })
+      }
     );
     expect(translator.translate(conn.readAfter(0))).toEqual([]);
     expect(translator.translate(conn.readAfter(0))).toEqual([]);
@@ -1008,6 +1012,7 @@ describe("Translator", () => {
     insertStep(db, {
       idx: 1,
       stepType: 15,
+      status: 1,
       stepPayload: encodeStepPayload({ agentText: { text: "<SYSTEM_MESSAGE>\n\n" } })
     });
 
@@ -1015,10 +1020,13 @@ describe("Translator", () => {
     const translator = new Translator({ mode: "stream", skipNarration: false });
     expect(translator.translate(conn.readAfter(0))).toEqual([]);
 
-    updateStepPayload(
+    updateStep(
       db,
       1,
-      encodeStepPayload({ agentText: { text: "<SYSTEM_MESSAGE>\n\n[Message] payload" } })
+      {
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: { text: "<SYSTEM_MESSAGE>\n\n[Message] payload" } })
+      }
     );
     expect(translator.translate(conn.readAfter(0))).toEqual([]);
 
@@ -1031,6 +1039,7 @@ describe("Translator", () => {
     insertStep(db, {
       idx: 1,
       stepType: 15,
+      status: 1,
       stepPayload: encodeStepPayload({ agentText: { text: "<SYSTEM_MESSAGE>\n[Messag" } })
     });
 
@@ -1050,6 +1059,65 @@ describe("Translator", () => {
 
     conn.close();
     db.close();
+  });
+
+  it("releases an ambiguous system-message prefix when its row is terminal", () => {
+    const db = createConversationDb(dir, "conv-terminal-sys-msg-prefix");
+    const text = "<SYSTEM_MESSAGE>\n[Messag";
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({ agentText: { text } })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-terminal-sys-msg-prefix")!;
+    const updates = new Translator({ mode: "stream", skipNarration: false }).translate(conn.readAfter(0));
+    conn.close();
+
+    expect(updates).toEqual([
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text }
+      }
+    ]);
+  });
+
+  it("releases an ambiguous system-message prefix at a later step boundary", () => {
+    const db = createConversationDb(dir, "conv-bounded-sys-msg-prefix");
+    const text = "<SYSTEM_MESSAGE>\n[Messag";
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      status: 1,
+      stepPayload: encodeStepPayload({ agentText: { text } })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({ agentText: { text: "done" } })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-bounded-sys-msg-prefix")!;
+    const updates = new Translator({ mode: "stream", skipNarration: false }).translate(conn.readAfter(0));
+    conn.close();
+
+    expect(updates).toEqual([
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text }
+      },
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "\ndone" }
+      }
+    ]);
   });
 
   it("preserves assistant messages that mention <SYSTEM_MESSAGE> in prose or at start", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -975,6 +975,83 @@ describe("Translator", () => {
     ]);
   });
 
+  it("buffers a growing system-message envelope until it can be classified", () => {
+    const db = createConversationDb(dir, "conv-growing-sys-msg");
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      stepPayload: encodeStepPayload({ agentText: { text: "<SYSTEM_MESSAGE>\n[Messag" } })
+    });
+
+    const conn = ConversationDb.open(dir, "conv-growing-sys-msg")!;
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    expect(translator.translate(conn.readAfter(0))).toEqual([]);
+
+    updateStepPayload(
+      db,
+      1,
+      encodeStepPayload({
+        agentText: {
+          text: "<SYSTEM_MESSAGE>\n[Message] timestamp=2026-07-28T10:07:08Z content=Task id task-175 finished"
+        }
+      })
+    );
+    expect(translator.translate(conn.readAfter(0))).toEqual([]);
+    expect(translator.translate(conn.readAfter(0))).toEqual([]);
+
+    conn.close();
+    db.close();
+  });
+
+  it("buffers all whitespace prefixes accepted by the system-message envelope", () => {
+    const db = createConversationDb(dir, "conv-growing-whitespace-sys-msg");
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      stepPayload: encodeStepPayload({ agentText: { text: "<SYSTEM_MESSAGE>\n\n" } })
+    });
+
+    const conn = ConversationDb.open(dir, "conv-growing-whitespace-sys-msg")!;
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    expect(translator.translate(conn.readAfter(0))).toEqual([]);
+
+    updateStepPayload(
+      db,
+      1,
+      encodeStepPayload({ agentText: { text: "<SYSTEM_MESSAGE>\n\n[Message] payload" } })
+    );
+    expect(translator.translate(conn.readAfter(0))).toEqual([]);
+
+    conn.close();
+    db.close();
+  });
+
+  it("releases a buffered system-message prefix when growing text proves ordinary", () => {
+    const db = createConversationDb(dir, "conv-growing-sys-msg-prose");
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      stepPayload: encodeStepPayload({ agentText: { text: "<SYSTEM_MESSAGE>\n[Messag" } })
+    });
+
+    const conn = ConversationDb.open(dir, "conv-growing-sys-msg-prose")!;
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    expect(translator.translate(conn.readAfter(0))).toEqual([]);
+
+    const prose = "<SYSTEM_MESSAGE>\n[Messagical text is not an internal notification.";
+    updateStepPayload(db, 1, encodeStepPayload({ agentText: { text: prose } }));
+    expect(translator.translate(conn.readAfter(0))).toEqual([
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: prose }
+      }
+    ]);
+
+    conn.close();
+    db.close();
+  });
+
   it("preserves assistant messages that mention <SYSTEM_MESSAGE> in prose or at start", () => {
     const db = createConversationDb(dir, "conv-prose-sys-msg");
     const proseText1 = "The error notification contains <SYSTEM_MESSAGE> tag.";

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -974,6 +974,27 @@ describe("Translator", () => {
       }
     ]);
   });
+
+  it("preserves assistant messages that mention <SYSTEM_MESSAGE> in prose", () => {
+    const db = createConversationDb(dir, "conv-prose-sys-msg");
+    const proseText = "The error notification contains <SYSTEM_MESSAGE> tag.";
+    insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: { text: proseText } }) });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-prose-sys-msg")!;
+    const translator = new Translator({ mode: "replay", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toEqual([
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: proseText },
+        _meta: { stepIdx: 1 }
+      }
+    ]);
+  });
 });
 
 describe("StreamPoller", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -933,6 +933,47 @@ describe("Translator", () => {
       }
     ]);
   });
+
+  it("suppresses <SYSTEM_MESSAGE> task outputs in stepType 15 during replay and streaming", () => {
+    const db = createConversationDb(dir, "conv-sys-msg");
+    const sysMsgText = "<SYSTEM_MESSAGE>\n[Message] timestamp=2026-07-28T10:07:08Z content=Task id task-175 finished";
+    insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: { text: "Hello" } }) });
+    insertStep(db, { idx: 2, stepType: 15, stepPayload: encodeStepPayload({ agentText: { text: sysMsgText } }) });
+    insertStep(db, { idx: 3, stepType: 15, stepPayload: encodeStepPayload({ agentText: { text: "World" } }) });
+    db.close();
+
+    const connReplay = ConversationDb.open(dir, "conv-sys-msg")!;
+    const replayTranslator = new Translator({ mode: "replay", skipNarration: false });
+    const replayUpdates = replayTranslator.translate(connReplay.readAfter(-1));
+    connReplay.close();
+
+    expect(replayUpdates).toEqual([
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "Hello\nWorld" },
+        _meta: { stepIdx: 1, endStepIdx: 3 }
+      }
+    ]);
+
+    const connStream = ConversationDb.open(dir, "conv-sys-msg")!;
+    const streamTranslator = new Translator({ mode: "stream", skipNarration: false });
+    const streamUpdates = streamTranslator.translate(connStream.readAfter(-1));
+    connStream.close();
+
+    expect(streamUpdates).toEqual([
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "Hello" }
+      },
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "1",
+        content: { type: "text", text: "\nWorld" }
+      }
+    ]);
+  });
 });
 
 describe("StreamPoller", () => {


### PR DESCRIPTION
## Description

Suppresses internal `<SYSTEM_MESSAGE>` task completion notifications logged under `stepType 15` (`agentText`) in the `agy` conversation database. Previously, when background tasks completed, `agy` appended system notifications into `agentText` steps, which `Translator` converted into `agent_message_chunk` updates. As a result, internal task logs and command outputs unexpectedly rendered as regular assistant chat responses in ACP clients (such as Zed).

With this change:
- Introduced `isSystemMessage()` helper to detect `<SYSTEM_MESSAGE>` tags.
- Updated `Translator` to skip emitting `agent_message_chunk` updates for `<SYSTEM_MESSAGE>` steps in both streaming and replay modes while preserving attached `thought` payloads.
- Updated `agentUpdate()` in `updates.ts` to return `null` when a step type 15 payload only contains a `<SYSTEM_MESSAGE>`.

## Related Issues

Fixes #39

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed