### PR TITLE
Keep turns active after persisting user prompts

### DIFF
--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -151,10 +151,13 @@ export class StreamPoller {
     // step with no trailing message — most notably a denied/failed command
     // (status 7), after which agy returns to idle without emitting more text.
     // Gate completion on "latest step is terminal" (3/6/7), not "latest is an
-    // agent message", so those turns don't hang until the deadline.
+    // agent message", so those turns don't hang until the deadline. Exclude
+    // stepType 14 (user prompt), which is inserted with status 3 as the turn
+    // opens before agy appends any assistant response steps.
     this._latestStepTerminal =
       !rows.hasDecodeError &&
       latest !== undefined &&
+      latest.stepType !== 14 &&
       (latest.status === 3 || latest.status === 6 || latest.status === 7);
     const updates = this.translator.translate(rows);
     const rowsByToolCallId = new Map(rows.map((row) => [toolCallId(row), row]));

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1809,6 +1809,38 @@ describe("StreamPoller", () => {
     poller.close();
     db.close();
   });
+
+  it("does not treat stepType 14 (user prompt, status 3) as a turn completion candidate", () => {
+    const db = createConversationDb(dir, "conv-user-prompt-only");
+    insertStep(db, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Hello assistant" })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-user-prompt-only",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    expect(poller.poll()).toEqual([]);
+    expect(poller.turnCompleteCandidate).toBe(false);
+
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({ agentText: "Hello user" })
+    });
+    expect(poller.poll()).toHaveLength(1);
+    expect(poller.turnCompleteCandidate).toBe(true);
+
+    poller.close();
+    db.close();
+  });
 });
 
 describe("ReplayCache", () => {


### PR DESCRIPTION
## Description

Prevent interactive ACP turns from completing as soon as agy persists the user's prompt.

`StreamPoller` previously treated every terminal-status latest row as a turn completion candidate. Because agy inserts step type 14 user prompts with status 3 before appending assistant steps, the CLI could return `end_turn` while agy continued generating in the background.

Exclude step type 14 from terminal completion candidates while preserving completion for terminal assistant and tool rows, including denied or failed commands with no trailing message. Add a regression test covering the prompt-only state and the subsequent assistant response.

## Related Issues

Fixes #48

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] Executed `npm run build` and it completed without errors
- [x] Executed `npm test` and all tests pass
- [x] Verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] Added or updated tests covering the changes
- [x] Updated documentation if relevant (not required for this internal lifecycle fix)
- [x] Confirmed no generated build output, local logs, or API keys are committed
