### PR TITLE
Bridge manage_task status-9 interactions to ACP permission UI

### DIFF
--- a/src/acp/tool-calls/permissions.ts
+++ b/src/acp/tool-calls/permissions.ts
@@ -39,6 +39,7 @@ export function isBridgeablePermissionTool(toolName: string): boolean {
   if (!toolName || toolName === "ask_question") return false;
   if (toolName === "run_command") return true;
   if (toolName === "ask_permission") return true;
+  if (toolName === "manage_task") return true;
   if (toolName === "view_file" || toolName === "list_dir") return true;
   if (isEditToolName(toolName)) return true;
   return false;
@@ -286,6 +287,11 @@ export function permissionOptions(
     return askPermissionOptions(toolCall);
   }
 
+  // manage_task gated actions (kill, send_input). Same 4-row TUI layout.
+  if (toolName === "manage_task") {
+    return manageTaskOptions(toolCall);
+  }
+
   // File edits: standard ACP option ids/kinds so clients can render native
   // Keep / Reject (or equivalent) review UI against the tool_call diff.
   if (isEditToolName(toolName ?? "") || (toolName == null && isEditToolCall(toolCall))) {
@@ -356,6 +362,32 @@ function standardEditPermissionOptions(): PermissionMenuOption[] {
     { optionId: "allow-once", kind: "allow_once", name: "Allow" },
     { optionId: "allow-always", kind: "allow_always", name: "Always allow" },
     { optionId: "reject-once", kind: "reject_once", name: "Reject" }
+  ];
+}
+
+/**
+ * Options for agy's `manage_task` gated actions (kill, send_input, etc.).
+ * The TUI renders the standard 4-row permission menu, so the standard
+ * permissionKeys navigation applies.
+ */
+function manageTaskOptions(toolCall: SessionUpdate): PermissionMenuOption[] {
+  const input = toolRawInput(toolCall);
+  const action = pickString(input, "Action", "action") ?? "manage";
+  const taskId = pickString(input, "TaskId", "taskId");
+  const target = taskId ? `manage_task ${action} (${taskId})` : `manage_task ${action}`;
+  return [
+    { optionId: "agy-allow-once", kind: "allow_once", name: "Yes" },
+    {
+      optionId: "agy-allow-conversation",
+      kind: "allow_always",
+      name: `Yes, and always allow '${target}' in this conversation`
+    },
+    {
+      optionId: "agy-allow-settings",
+      kind: "allow_always",
+      name: `Yes, and always allow '${target}' (Persist to settings.json)`
+    },
+    { optionId: "agy-reject-once", kind: "reject_once", name: "No" }
   ];
 }
 

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -1106,7 +1106,7 @@ function unsupportedInteractionDetail(
     if (ask.questions.some((q) => q.options.length === 0)) return "ask_question has a question with no selectable options";
     return "ask_question could not be bridged";
   }
-  return "only standard permission menus (run_command, ask_permission, file read/write) and ask_question can be bridged safely";
+  return "only standard permission menus (run_command, ask_permission, manage_task, file read/write) and ask_question can be bridged safely";
 }
 
 function isAgyStatusLine(line: string): boolean {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -313,6 +313,49 @@ describe("permission bridge", () => {
     expect(interactionKeys("agy-reject-once", "ask_permission", askPermission)).toBe("\x1b[B\x1b[B\x1b[B\r");
   });
 
+  it("bridges agy's manage_task gated actions (kill, send_input) as a 4-row menu", () => {
+    const manageTaskKill = {
+      sessionUpdate: "tool_call" as const,
+      toolCallId: "mt1",
+      title: "Manage task kill",
+      kind: "other" as const,
+      status: "pending" as const,
+      rawInput: {
+        Action: "kill",
+        TaskId: "task-42",
+        toolAction: "Killing background task",
+        toolSummary: "Kill task"
+      }
+    };
+    expect(isBridgeablePermissionTool("manage_task")).toBe(true);
+    expect(canBridgeInteraction("manage_task", manageTaskKill)).toBe(true);
+    expect(permissionOptions(manageTaskKill, "manage_task")).toEqual([
+      { optionId: "agy-allow-once", kind: "allow_once", name: "Yes" },
+      { optionId: "agy-allow-conversation", kind: "allow_always", name: "Yes, and always allow 'manage_task kill (task-42)' in this conversation" },
+      { optionId: "agy-allow-settings", kind: "allow_always", name: "Yes, and always allow 'manage_task kill (task-42)' (Persist to settings.json)" },
+      { optionId: "agy-reject-once", kind: "reject_once", name: "No" }
+    ]);
+    expect(interactionKeys("agy-allow-once", "manage_task", manageTaskKill)).toBe("\r");
+    expect(interactionKeys("agy-allow-conversation", "manage_task", manageTaskKill)).toBe("\x1b[B\r");
+    expect(interactionKeys("agy-reject-once", "manage_task", manageTaskKill)).toBe("\x1b[B\x1b[B\x1b[B\r");
+
+    // Without a TaskId, the target omits the parenthetical.
+    const manageTaskNoId = {
+      sessionUpdate: "tool_call" as const,
+      toolCallId: "mt2",
+      title: "Manage task send_input",
+      kind: "other" as const,
+      status: "pending" as const,
+      rawInput: { Action: "send_input" }
+    };
+    expect(permissionOptions(manageTaskNoId, "manage_task")).toEqual([
+      { optionId: "agy-allow-once", kind: "allow_once", name: "Yes" },
+      { optionId: "agy-allow-conversation", kind: "allow_always", name: "Yes, and always allow 'manage_task send_input' in this conversation" },
+      { optionId: "agy-allow-settings", kind: "allow_always", name: "Yes, and always allow 'manage_task send_input' (Persist to settings.json)" },
+      { optionId: "agy-reject-once", kind: "reject_once", name: "No" }
+    ]);
+  });
+
   for (const [choice, keys] of [
     ["agy-allow-once", "\r"],
     ["agy-allow-conversation", "\x1b[B\r"],
@@ -603,6 +646,29 @@ describe("permission bridge", () => {
     expect((await result).stopReason).toBe("end_turn");
     expect(calls).toBe(1);
     expect(pty.writes).toEqual(["\x1b[B", "\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("bridges manage_task status-9 interaction through full PTY turn loop", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const manageInput = JSON.stringify({ Action: "send_input", TaskId: "task-7", Input: "yes\n" });
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "manage-task");
+      insertStep(db, pendingToolRow("manage_task", manageInput, 132));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const result = session.prompt("go", async () => {}, async () => {
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "manage-task.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "sent input" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 150);
+      return "agy-allow-once";
+    });
+    expect((await result).stopReason).toBe("end_turn");
+    expect(pty.writes).toEqual(["\r"]);
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Description

Bridges agy `manage_task` interactive steps (status 9) to the ACP client permission UI (`session/request_permission`).

When agy gates interactive orchestration actions (such as `manage_task` `kill` or `send_input`), agy-acp now:
- Recognizes `manage_task` as a bridgeable permission tool
- Builds contextual permission menu options surfacing `Action` and `TaskId`
- Maps choice selections to the standard 4-row PTY keypress navigation sequence

## Related Issues

Fixes #23

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed