### PR TITLE
Support programmatic tool-call name field alongside title/kind

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,7 @@ Need interactive agy control plane or client terminal protocol beyond DB polling
 
 ### Fidelity improvements
 
-- [ ] [`name`](https://agentclientprotocol.com/rfds/tool-call-name): optional programmatic tool-call name alongside `title` / `kind` (unstable)
+- [x] [`name`](https://agentclientprotocol.com/rfds/tool-call-name): optional programmatic tool-call name alongside `title` / `kind` (unstable)
 - [ ] [`ContentBlock`](https://agentclientprotocol.com/protocol/v1/content): agent-outbound images / richer blocks when agy produces them
 - [ ] [`plan_update`](https://agentclientprotocol.com/rfds/plan-operations): unstable id-based plan ops (+ `plan_removed`) if a client prefers that over classic `plan`
 
@@ -153,7 +153,7 @@ differs or is incomplete.
 
 ### Fidelity improvements
 
-- [ ] [`name`](https://agentclientprotocol.com/rfds/tool-call-name): optional programmatic tool-call name alongside `title` / `kind`
+- [x] [`name`](https://agentclientprotocol.com/rfds/tool-call-name): optional programmatic tool-call name alongside `title` / `kind`
 - [ ] [`diff`](https://agentclientprotocol.com/rfds/diff-delete): `delete` / rename ops and richer [fileType](https://agentclientprotocol.com/rfds/v2/diff-file-states) when agy exposes them
 - [ ] [`ContentBlock`](https://agentclientprotocol.com/protocol/v2/content): agent-outbound images / richer blocks when agy produces them
 

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -152,6 +152,8 @@ export class AcpAgent {
   /** v1 client's `fs` capability, set from `initialize`. Draft v2 has no fs/* client methods. */
   #clientFs = { readTextFile: false, writeTextFile: false };
   #clientElicitation = { form: false, url: false };
+  #clientTerminal = { create: false };
+  #clientToolCallName = { name: false };
 
   constructor(options: AcpAgentOptions = {}) {
     this.#env = options.env ?? process.env;
@@ -172,16 +174,20 @@ export class AcpAgent {
 
   async initializeV1(params: V1InitializeRequest): Promise<V1InitializeResponse> {
     await this.ensureAgyReady();
-    const { response, clientFs, clientElicitation } = handleInitializeV1(params, packageJson.version ?? "0.0.0");
+    const { response, clientFs, clientElicitation, clientTerminal, clientToolCallName } = handleInitializeV1(params, packageJson.version ?? "0.0.0");
     this.#clientFs = clientFs;
     this.#clientElicitation = clientElicitation;
+    this.#clientTerminal = clientTerminal;
+    this.#clientToolCallName = clientToolCallName;
     return response;
   }
 
   async initializeV2(params: V2InitializeRequest): Promise<V2InitializeResponse> {
     await this.ensureAgyReady();
-    const { response, clientElicitation } = handleInitializeV2(params, packageJson.version ?? "0.0.0");
+    const { response, clientElicitation, clientTerminal, clientToolCallName } = handleInitializeV2(params, packageJson.version ?? "0.0.0");
     this.#clientElicitation = clientElicitation;
+    this.#clientTerminal = clientTerminal;
+    this.#clientToolCallName = clientToolCallName;
     return response;
   }
 
@@ -350,7 +356,9 @@ export class AcpAgent {
       notifyCurrentModeUpdate,
       notifyConfigOptionUpdateV1,
       clientFileSystemV1: (client, sessionId) => this.clientFileSystemV1(client, sessionId),
-      clientElicitationV1: () => this.#clientElicitation
+      clientElicitationV1: () => this.#clientElicitation,
+      clientTerminalV1: () => this.#clientTerminal,
+      clientToolCallNameV1: () => this.#clientToolCallName
     };
   }
 
@@ -360,7 +368,9 @@ export class AcpAgent {
       applyConfigOption: (sessionId, configId, value) => this.applyConfigOption(sessionId, configId, value),
       persistSession: (id, session) => this.persistSession(id, session),
       notifyConfigOptionUpdateV2,
-      clientElicitationV2: () => this.#clientElicitation
+      clientElicitationV2: () => this.#clientElicitation,
+      clientTerminalV2: () => this.#clientTerminal,
+      clientToolCallNameV2: () => this.#clientToolCallName
     };
   }
 

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -152,7 +152,6 @@ export class AcpAgent {
   /** v1 client's `fs` capability, set from `initialize`. Draft v2 has no fs/* client methods. */
   #clientFs = { readTextFile: false, writeTextFile: false };
   #clientElicitation = { form: false, url: false };
-  #clientTerminal = { create: false };
   #clientToolCallName = { name: false };
 
   constructor(options: AcpAgentOptions = {}) {
@@ -174,19 +173,17 @@ export class AcpAgent {
 
   async initializeV1(params: V1InitializeRequest): Promise<V1InitializeResponse> {
     await this.ensureAgyReady();
-    const { response, clientFs, clientElicitation, clientTerminal, clientToolCallName } = handleInitializeV1(params, packageJson.version ?? "0.0.0");
+    const { response, clientFs, clientElicitation, clientToolCallName } = handleInitializeV1(params, packageJson.version ?? "0.0.0");
     this.#clientFs = clientFs;
     this.#clientElicitation = clientElicitation;
-    this.#clientTerminal = clientTerminal;
     this.#clientToolCallName = clientToolCallName;
     return response;
   }
 
   async initializeV2(params: V2InitializeRequest): Promise<V2InitializeResponse> {
     await this.ensureAgyReady();
-    const { response, clientElicitation, clientTerminal, clientToolCallName } = handleInitializeV2(params, packageJson.version ?? "0.0.0");
+    const { response, clientElicitation, clientToolCallName } = handleInitializeV2(params, packageJson.version ?? "0.0.0");
     this.#clientElicitation = clientElicitation;
-    this.#clientTerminal = clientTerminal;
     this.#clientToolCallName = clientToolCallName;
     return response;
   }
@@ -297,6 +294,7 @@ export class AcpAgent {
   loadSession(params: LoadSessionRequest, client: V1AgentContext): Promise<LoadSessionResponse> {
     return handleLoadSession(params, client, {
       ...this.reloadSessionDeps(),
+      clientToolCallNameV1: () => this.#clientToolCallName,
       notifyAvailableCommandsV1
     });
   }
@@ -357,7 +355,6 @@ export class AcpAgent {
       notifyConfigOptionUpdateV1,
       clientFileSystemV1: (client, sessionId) => this.clientFileSystemV1(client, sessionId),
       clientElicitationV1: () => this.#clientElicitation,
-      clientTerminalV1: () => this.#clientTerminal,
       clientToolCallNameV1: () => this.#clientToolCallName
     };
   }
@@ -369,7 +366,6 @@ export class AcpAgent {
       persistSession: (id, session) => this.persistSession(id, session),
       notifyConfigOptionUpdateV2,
       clientElicitationV2: () => this.#clientElicitation,
-      clientTerminalV2: () => this.#clientTerminal,
       clientToolCallNameV2: () => this.#clientToolCallName
     };
   }

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -309,6 +309,7 @@ export class AcpAgent {
   resumeSessionV2(params: V2ResumeSessionRequest, client: V2AgentContext): Promise<V2ResumeSessionResponse> {
     return handleResumeSessionV2(params, client, {
       ...this.reloadSessionDeps(),
+      clientToolCallNameV2: () => this.#clientToolCallName,
       notifyAvailableCommandsV2
     });
   }

--- a/src/acp/initialize.ts
+++ b/src/acp/initialize.ts
@@ -37,12 +37,14 @@ export function parseClientToolCallName(rawCaps: unknown, defaultEnabled = false
   const capabilityMeta =
     (clientCaps._meta as Record<string, unknown> | undefined) ??
     (caps._meta as Record<string, unknown> | undefined);
+  const nestedToolCall =
+    (clientCaps.toolCall as Record<string, unknown> | undefined) ??
+    (clientCaps.tool_call as Record<string, unknown> | undefined);
 
   const toolCallName =
     clientCaps.toolCallName ??
     clientCaps.tool_call_name ??
-    (clientCaps.toolCall as Record<string, unknown> | undefined)?.name ??
-    (clientCaps.tool_call as Record<string, unknown> | undefined)?.name ??
+    nestedToolCall?.name ??
     clientCaps.unstable_toolCallName ??
     clientCaps.unstable_tool_call_name ??
     (clientCaps.unstable as Record<string, unknown> | undefined)?.toolCallName ??

--- a/src/acp/initialize.ts
+++ b/src/acp/initialize.ts
@@ -23,6 +23,55 @@ export interface ClientFsCapability {
   writeTextFile: boolean;
 }
 
+export interface ClientTerminalCapability {
+  create: boolean;
+}
+
+export interface ClientToolCallNameCapability {
+  name: boolean;
+}
+
+export function parseClientTerminal(rawCaps: unknown): ClientTerminalCapability {
+  if (!rawCaps || typeof rawCaps !== "object") return { create: false };
+  const caps = rawCaps as Record<string, unknown>;
+  const terminal =
+    caps.terminal ??
+    (caps.clientCapabilities as Record<string, unknown> | undefined)?.terminal ??
+    (caps.capabilities as Record<string, unknown> | undefined)?.terminal;
+  if (!terminal) return { create: false };
+  if (typeof terminal === "boolean") return { create: terminal };
+  if (typeof terminal === "object") {
+    const createObj = (terminal as Record<string, unknown>).create;
+    const create = createObj != null ? Boolean(createObj) : true;
+    return { create };
+  }
+  return { create: false };
+}
+
+export function parseClientToolCallName(rawCaps: unknown, defaultEnabled = false): ClientToolCallNameCapability {
+  if (!rawCaps || typeof rawCaps !== "object") return { name: defaultEnabled };
+  const caps = rawCaps as Record<string, unknown>;
+  const clientCaps =
+    (caps.clientCapabilities as Record<string, unknown> | undefined) ??
+    (caps.capabilities as Record<string, unknown> | undefined) ??
+    caps;
+
+  const toolCallName =
+    clientCaps.toolCallName ??
+    clientCaps.tool_call_name ??
+    (clientCaps.toolCall as Record<string, unknown> | undefined)?.name ??
+    (clientCaps.tool_call as Record<string, unknown> | undefined)?.name ??
+    clientCaps.unstable_toolCallName ??
+    clientCaps.unstable_tool_call_name ??
+    (clientCaps.unstable as Record<string, unknown> | undefined)?.toolCallName ??
+    (clientCaps.unstable as Record<string, unknown> | undefined)?.tool_call_name;
+
+  if (typeof toolCallName === "boolean") return { name: toolCallName };
+  if (toolCallName && typeof toolCallName === "object") {
+    return { name: Boolean((toolCallName as Record<string, unknown>).name ?? true) };
+  }
+  return { name: defaultEnabled };
+}
 function parseClientElicitation(rawCaps: unknown): ClientElicitationCapability {
   if (!rawCaps || typeof rawCaps !== "object") return { form: false, url: false };
   const caps = rawCaps as Record<string, unknown>;
@@ -34,7 +83,7 @@ function parseClientElicitation(rawCaps: unknown): ClientElicitationCapability {
   };
 }
 
-/** v1 `initialize`: also returns the client's advertised `fs` and `elicitation` capabilities. */
+/** v1 `initialize`: also returns the client's advertised `fs`, `elicitation`, `terminal`, and `toolCallName` capabilities. */
 export function handleInitializeV1(
   params: V1InitializeRequest,
   agentVersion: string
@@ -42,6 +91,8 @@ export function handleInitializeV1(
   response: V1InitializeResponse;
   clientFs: ClientFsCapability;
   clientElicitation: ClientElicitationCapability;
+  clientTerminal: ClientTerminalCapability;
+  clientToolCallName: ClientToolCallNameCapability;
 } {
   return {
     clientFs: {
@@ -49,6 +100,8 @@ export function handleInitializeV1(
       writeTextFile: params.clientCapabilities?.fs?.writeTextFile ?? false
     },
     clientElicitation: parseClientElicitation(params.clientCapabilities),
+    clientTerminal: parseClientTerminal(params.clientCapabilities),
+    clientToolCallName: parseClientToolCallName(params.clientCapabilities, false),
     response: {
       protocolVersion:
         params.protocolVersion === v1.PROTOCOL_VERSION ? params.protocolVersion : v1.PROTOCOL_VERSION,
@@ -72,8 +125,9 @@ export function handleInitializeV1(
         },
         auth: {
           logout: {}
-        }
-      },
+        },
+        toolCallName: {}
+      } as unknown as v1.AgentCapabilities,
       authMethods: v1AuthMethods(),
       agentInfo: { ...AGENT_INFO, version: agentVersion }
     }
@@ -86,9 +140,13 @@ export function handleInitializeV2(
 ): {
   response: V2InitializeResponse;
   clientElicitation: ClientElicitationCapability;
+  clientTerminal: ClientTerminalCapability;
+  clientToolCallName: ClientToolCallNameCapability;
 } {
   return {
     clientElicitation: parseClientElicitation(params),
+    clientTerminal: parseClientTerminal(params),
+    clientToolCallName: parseClientToolCallName(params, true),
     response: {
       protocolVersion:
         params.protocolVersion === v2.PROTOCOL_VERSION ? params.protocolVersion : v2.PROTOCOL_VERSION,
@@ -102,8 +160,13 @@ export function handleInitializeV2(
           },
           additionalDirectories: {}
         },
-        auth: {}
-      },
+        auth: {},
+        terminal: {},
+        toolCallName: {},
+        _meta: {
+          toolCallName: {}
+        }
+      } as unknown as v2.AgentCapabilities,
       // Non-empty authMethods commits the agent to auth/login + auth/logout.
       authMethods: v2AuthMethods()
     }

--- a/src/acp/initialize.ts
+++ b/src/acp/initialize.ts
@@ -34,6 +34,9 @@ export function parseClientToolCallName(rawCaps: unknown, defaultEnabled = false
     (caps.clientCapabilities as Record<string, unknown> | undefined) ??
     (caps.capabilities as Record<string, unknown> | undefined) ??
     caps;
+  const capabilityMeta =
+    (clientCaps._meta as Record<string, unknown> | undefined) ??
+    (caps._meta as Record<string, unknown> | undefined);
 
   const toolCallName =
     clientCaps.toolCallName ??
@@ -43,7 +46,9 @@ export function parseClientToolCallName(rawCaps: unknown, defaultEnabled = false
     clientCaps.unstable_toolCallName ??
     clientCaps.unstable_tool_call_name ??
     (clientCaps.unstable as Record<string, unknown> | undefined)?.toolCallName ??
-    (clientCaps.unstable as Record<string, unknown> | undefined)?.tool_call_name;
+    (clientCaps.unstable as Record<string, unknown> | undefined)?.tool_call_name ??
+    capabilityMeta?.toolCallName ??
+    capabilityMeta?.tool_call_name;
 
   if (typeof toolCallName === "boolean") return { name: toolCallName };
   if (toolCallName && typeof toolCallName === "object") {

--- a/src/acp/initialize.ts
+++ b/src/acp/initialize.ts
@@ -23,29 +23,8 @@ export interface ClientFsCapability {
   writeTextFile: boolean;
 }
 
-export interface ClientTerminalCapability {
-  create: boolean;
-}
-
 export interface ClientToolCallNameCapability {
   name: boolean;
-}
-
-export function parseClientTerminal(rawCaps: unknown): ClientTerminalCapability {
-  if (!rawCaps || typeof rawCaps !== "object") return { create: false };
-  const caps = rawCaps as Record<string, unknown>;
-  const terminal =
-    caps.terminal ??
-    (caps.clientCapabilities as Record<string, unknown> | undefined)?.terminal ??
-    (caps.capabilities as Record<string, unknown> | undefined)?.terminal;
-  if (!terminal) return { create: false };
-  if (typeof terminal === "boolean") return { create: terminal };
-  if (typeof terminal === "object") {
-    const createObj = (terminal as Record<string, unknown>).create;
-    const create = createObj != null ? Boolean(createObj) : true;
-    return { create };
-  }
-  return { create: false };
 }
 
 export function parseClientToolCallName(rawCaps: unknown, defaultEnabled = false): ClientToolCallNameCapability {
@@ -83,7 +62,7 @@ function parseClientElicitation(rawCaps: unknown): ClientElicitationCapability {
   };
 }
 
-/** v1 `initialize`: also returns the client's advertised `fs`, `elicitation`, `terminal`, and `toolCallName` capabilities. */
+/** v1 `initialize`: also returns the client's advertised `fs`, `elicitation`, and `toolCallName` capabilities. */
 export function handleInitializeV1(
   params: V1InitializeRequest,
   agentVersion: string
@@ -91,7 +70,6 @@ export function handleInitializeV1(
   response: V1InitializeResponse;
   clientFs: ClientFsCapability;
   clientElicitation: ClientElicitationCapability;
-  clientTerminal: ClientTerminalCapability;
   clientToolCallName: ClientToolCallNameCapability;
 } {
   return {
@@ -100,7 +78,6 @@ export function handleInitializeV1(
       writeTextFile: params.clientCapabilities?.fs?.writeTextFile ?? false
     },
     clientElicitation: parseClientElicitation(params.clientCapabilities),
-    clientTerminal: parseClientTerminal(params.clientCapabilities),
     clientToolCallName: parseClientToolCallName(params.clientCapabilities, false),
     response: {
       protocolVersion:
@@ -140,12 +117,10 @@ export function handleInitializeV2(
 ): {
   response: V2InitializeResponse;
   clientElicitation: ClientElicitationCapability;
-  clientTerminal: ClientTerminalCapability;
   clientToolCallName: ClientToolCallNameCapability;
 } {
   return {
     clientElicitation: parseClientElicitation(params),
-    clientTerminal: parseClientTerminal(params),
     clientToolCallName: parseClientToolCallName(params, true),
     response: {
       protocolVersion:
@@ -161,7 +136,6 @@ export function handleInitializeV2(
           additionalDirectories: {}
         },
         auth: {},
-        terminal: {},
         toolCallName: {},
         _meta: {
           toolCallName: {}

--- a/src/acp/session/load.ts
+++ b/src/acp/session/load.ts
@@ -8,6 +8,7 @@ import type {
   LoadSessionRequest,
   LoadSessionResponse
 } from "@agentclientprotocol/sdk";
+import type { ClientToolCallNameCapability } from "../initialize.js";
 import { sessionConfigOptionsV1 } from "./config-options.js";
 import { sessionModeState } from "./modes.js";
 import type { StoredSession } from "./store.js";
@@ -27,6 +28,7 @@ export interface LoadSessionDeps {
     cwd: string,
     emit: (update: v1.SessionUpdate) => Promise<void>
   ): Promise<void>;
+  clientToolCallNameV1?(client: V1AgentContext): ClientToolCallNameCapability | undefined;
   notifyAvailableCommandsV1(client: V1AgentContext, sessionId: string): Promise<void>;
 }
 
@@ -44,10 +46,11 @@ export async function handleLoadSession(
 
   if (stored.conversationId) {
     const tracker = createTerminalOutputTracker();
+    const clientToolCallName = deps.clientToolCallNameV1?.(client) ?? { name: false };
     await deps.replayConversation(session, stored.conversationId, cwd, async (update) => {
       await client.notify(v1.methods.client.session.update, {
         sessionId: params.sessionId,
-        update: sessionUpdateToV1(update, tracker)
+        update: sessionUpdateToV1(update, tracker, { clientToolCallName })
       });
     });
   }

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -287,7 +287,16 @@ async function runV2PromptTurn(
             }
           }, async (toolCall, { toolName, questionIndex }) => {
             const elicitationCap = deps.clientElicitationV2?.(client);
-            return requestPermissionV2(client, params.sessionId, toolCall, toolName, signal, questionIndex, elicitationCap);
+            return requestPermissionV2(
+              client,
+              params.sessionId,
+              toolCall,
+              toolName,
+              signal,
+              questionIndex,
+              elicitationCap,
+              clientToolCallName
+            );
           }, undefined, deps.clientElicitationV2?.(client));
         } finally {
           const userStepIdxs = session.agy.lastPromptUserStepIdxs;

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -15,6 +15,7 @@ import type {
   PromptResponse as V2PromptResponse
 } from "@agentclientprotocol/sdk/experimental/v2";
 import type { ClientElicitationCapability } from "../tool-calls/elicitation.js";
+import type { ClientTerminalCapability, ClientToolCallNameCapability } from "../initialize.js";
 import type { SessionModeId } from "../../agy/cli.js";
 import { contentBlocksToPrompt } from "../content/index.js";
 import type { ClientFileSystem } from "../../agy/edit/bridge.js";
@@ -36,11 +37,15 @@ export interface PromptV1Deps extends PromptTurnDeps {
   notifyConfigOptionUpdateV1(client: V1AgentContext, sessionId: string, session: SessionState): Promise<void>;
   clientFileSystemV1(client: V1AgentContext, sessionId: string): ClientFileSystem | undefined;
   clientElicitationV1?(client: V1AgentContext): ClientElicitationCapability | undefined;
+  clientTerminalV1?(client: V1AgentContext): ClientTerminalCapability | undefined;
+  clientToolCallNameV1?(client: V1AgentContext): ClientToolCallNameCapability | undefined;
 }
 
 export interface PromptV2Deps extends PromptTurnDeps {
   notifyConfigOptionUpdateV2(client: V2AgentContext, sessionId: string, session: SessionState): Promise<void>;
   clientElicitationV2?(client: V2AgentContext): ClientElicitationCapability | undefined;
+  clientTerminalV2?(client: V2AgentContext): ClientTerminalCapability | undefined;
+  clientToolCallNameV2?(client: V2AgentContext): ClientToolCallNameCapability | undefined;
 }
 
 /**
@@ -137,10 +142,11 @@ export async function handlePromptV1(
 
   try {
     const tracker = createTerminalOutputTracker();
+    const clientToolCallName = deps.clientToolCallNameV1?.(client);
     const outcome = await session.agy.prompt(prompt, async (update) => {
       await client.notify(v1.methods.client.session.update, {
         sessionId: params.sessionId,
-        update: sessionUpdateToV1(update, tracker)
+        update: sessionUpdateToV1(update, tracker, { clientToolCallName })
       });
     }, async (toolCall, { toolName, questionIndex }) => {
       const elicitationCap = deps.clientElicitationV1?.(client);
@@ -265,10 +271,11 @@ async function runV2PromptTurn(
     try {
       const terminalTracker = createTerminalOutputTracker();
       const toolContentTracker = createToolCallContentTracker();
+      const clientToolCallName = deps.clientToolCallNameV2?.(client);
       const outcome = await (async () => {
         try {
           return await session.agy.prompt(promptText, async (update) => {
-            for (const v2Update of expandSessionUpdateToV2(update, terminalTracker, toolContentTracker)) {
+            for (const v2Update of expandSessionUpdateToV2(update, terminalTracker, toolContentTracker, { clientToolCallName })) {
               await notify(v2Update);
             }
           }, async (toolCall, { toolName, questionIndex }) => {

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -15,7 +15,7 @@ import type {
   PromptResponse as V2PromptResponse
 } from "@agentclientprotocol/sdk/experimental/v2";
 import type { ClientElicitationCapability } from "../tool-calls/elicitation.js";
-import type { ClientTerminalCapability, ClientToolCallNameCapability } from "../initialize.js";
+import type { ClientToolCallNameCapability } from "../initialize.js";
 import type { SessionModeId } from "../../agy/cli.js";
 import { contentBlocksToPrompt } from "../content/index.js";
 import type { ClientFileSystem } from "../../agy/edit/bridge.js";
@@ -37,14 +37,12 @@ export interface PromptV1Deps extends PromptTurnDeps {
   notifyConfigOptionUpdateV1(client: V1AgentContext, sessionId: string, session: SessionState): Promise<void>;
   clientFileSystemV1(client: V1AgentContext, sessionId: string): ClientFileSystem | undefined;
   clientElicitationV1?(client: V1AgentContext): ClientElicitationCapability | undefined;
-  clientTerminalV1?(client: V1AgentContext): ClientTerminalCapability | undefined;
   clientToolCallNameV1?(client: V1AgentContext): ClientToolCallNameCapability | undefined;
 }
 
 export interface PromptV2Deps extends PromptTurnDeps {
   notifyConfigOptionUpdateV2(client: V2AgentContext, sessionId: string, session: SessionState): Promise<void>;
   clientElicitationV2?(client: V2AgentContext): ClientElicitationCapability | undefined;
-  clientTerminalV2?(client: V2AgentContext): ClientTerminalCapability | undefined;
   clientToolCallNameV2?(client: V2AgentContext): ClientToolCallNameCapability | undefined;
 }
 
@@ -150,7 +148,16 @@ export async function handlePromptV1(
       });
     }, async (toolCall, { toolName, questionIndex }) => {
       const elicitationCap = deps.clientElicitationV1?.(client);
-      return requestPermissionV1(client, params.sessionId, toolCall, toolName, signal, questionIndex, elicitationCap);
+      return requestPermissionV1(
+        client,
+        params.sessionId,
+        toolCall,
+        toolName,
+        signal,
+        questionIndex,
+        elicitationCap,
+        clientToolCallName
+      );
     }, deps.clientFileSystemV1(client, params.sessionId), deps.clientElicitationV1?.(client));
     await deps.persistSession(params.sessionId, session);
     return {

--- a/src/acp/session/request-permission.ts
+++ b/src/acp/session/request-permission.ts
@@ -84,7 +84,8 @@ export async function requestPermissionV2(
   toolName: string | undefined,
   signal: AbortSignal,
   questionIndex?: number,
-  clientElicitation?: ClientElicitationCapability
+  clientElicitation?: ClientElicitationCapability,
+  clientToolCallName?: ClientToolCallNameCapability
 ): Promise<PermissionChoice | "cancelled"> {
   if (signal.aborted) return "cancelled";
 
@@ -108,11 +109,12 @@ export async function requestPermissionV2(
     }
   }
 
-  const expanded = expandSessionUpdateToV2(toolCall);
+  const options = { clientToolCallName };
+  const expanded = expandSessionUpdateToV2(toolCall, undefined, undefined, options);
   const converted = (expanded.find((item) => {
     const kind = (item as unknown as { sessionUpdate?: string }).sessionUpdate;
     return kind === "tool_call_update" || kind === "tool_call";
-  }) ?? sessionUpdateToV2(toolCall)) as unknown as Record<string, unknown>;
+  }) ?? sessionUpdateToV2(toolCall, options)) as unknown as Record<string, unknown>;
   const { sessionUpdate: _discriminator, ...requestToolCall } = converted;
 
   let title = String(requestToolCall.title ?? "Permission required");

--- a/src/acp/session/request-permission.ts
+++ b/src/acp/session/request-permission.ts
@@ -6,6 +6,7 @@ import * as v1 from "@agentclientprotocol/sdk";
 import type { AgentContext as V1AgentContext, SessionUpdate as V1SessionUpdate } from "@agentclientprotocol/sdk";
 import * as v2 from "@agentclientprotocol/sdk/experimental/v2";
 import type { AgentContext as V2AgentContext } from "@agentclientprotocol/sdk/experimental/v2";
+import type { ClientToolCallNameCapability } from "../initialize.js";
 import { permissionOptions, parseAskQuestion, type PermissionChoice } from "../tool-calls/permissions.js";
 import {
   buildElicitationRequestFromAskQuestion,
@@ -23,7 +24,8 @@ export async function requestPermissionV1(
   toolName: string | undefined,
   signal: AbortSignal | undefined,
   questionIndex?: number,
-  clientElicitation?: ClientElicitationCapability
+  clientElicitation?: ClientElicitationCapability,
+  clientToolCallName?: ClientToolCallNameCapability
 ): Promise<PermissionChoice | "cancelled"> {
   if (signal?.aborted) return "cancelled";
 
@@ -49,6 +51,9 @@ export async function requestPermissionV1(
 
   const { sessionUpdate: _discriminator, ...requestToolCall } = toolCall as unknown as Record<string, unknown>;
   const toolCallPayload = { ...requestToolCall };
+  if (clientToolCallName?.name !== true) {
+    delete toolCallPayload.name;
+  }
   if (toolName === "ask_question") {
     const ask = parseAskQuestion(toolCall);
     const qIdx = questionIndex ?? 0;

--- a/src/acp/session/resume.ts
+++ b/src/acp/session/resume.ts
@@ -15,6 +15,7 @@ import type {
   ResumeSessionRequest as V2ResumeSessionRequest,
   ResumeSessionResponse as V2ResumeSessionResponse
 } from "@agentclientprotocol/sdk/experimental/v2";
+import type { ClientToolCallNameCapability } from "../initialize.js";
 import { sessionConfigOptionsV1, sessionConfigOptionsV2 } from "./config-options.js";
 import { sessionModeState } from "./modes.js";
 import type { StoredSession } from "./store.js";
@@ -65,6 +66,7 @@ export async function handleResumeSessionV2(
   params: V2ResumeSessionRequest,
   client: V2AgentContext,
   deps: ResumeSessionDeps & {
+    clientToolCallNameV2?(client: V2AgentContext): ClientToolCallNameCapability | undefined;
     notifyAvailableCommandsV2(client: V2AgentContext, sessionId: string): Promise<void>;
   }
 ): Promise<V2ResumeSessionResponse> {
@@ -80,12 +82,18 @@ export async function handleResumeSessionV2(
     if (stored.conversationId) {
       const terminalTracker = createTerminalOutputTracker();
       const toolContentTracker = createToolCallContentTracker();
+      const clientToolCallName = deps.clientToolCallNameV2?.(client);
       await deps.replayConversation(
         session,
         stored.conversationId,
         cwd,
         async (update) => {
-          for (const v2Update of expandSessionUpdateToV2(update, terminalTracker, toolContentTracker)) {
+          for (const v2Update of expandSessionUpdateToV2(
+            update,
+            terminalTracker,
+            toolContentTracker,
+            { clientToolCallName }
+          )) {
             await client.notify(v2.methods.client.session.update, {
               sessionId: params.sessionId,
               update: v2Update

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -13,6 +13,12 @@
 import type { SessionUpdate as V1SessionUpdate } from "@agentclientprotocol/sdk";
 import type { SessionUpdate as V2SessionUpdate } from "@agentclientprotocol/sdk/experimental/v2";
 import { asRecord, executeTerminalMeta, terminalUpdateForExecute } from "../terminal/index.js";
+import type { ClientToolCallNameCapability } from "../initialize.js";
+
+export interface WireTransformOptions {
+  clientToolCallName?: ClientToolCallNameCapability;
+  allowToolCallName?: boolean;
+}
 
 /** Absolute-path friendly git_patch text for a single-file text change. */
 export function gitPatchForFile(
@@ -175,14 +181,19 @@ function setTrackedToolContentCount(
 /** Identity cast for the v1 wire format (builders already emit v1 shapes). */
 export function sessionUpdateToV1(
   update: V1SessionUpdate,
-  tracker: TerminalOutputTracker = defaultTerminalOutputTracker
+  tracker: TerminalOutputTracker = defaultTerminalOutputTracker,
+  options?: WireTransformOptions
 ): V1SessionUpdate {
   const raw = update as unknown as Record<string, unknown>;
   if (raw.sessionUpdate === "tool_call" || raw.sessionUpdate === "tool_call_update") {
+    const allowName = options?.allowToolCallName ?? (options?.clientToolCallName ? options.clientToolCallName.name === true : true);
     const v1Update: Record<string, unknown> = {
       ...raw,
       status: mapToolStatusForV1(raw.status)
     };
+    if (!allowName) {
+      delete v1Update.name;
+    }
 
     if (Array.isArray(v1Update.content)) {
       v1Update.content = v1Update.content.map(cleanContentItem);
@@ -248,8 +259,15 @@ export function sessionUpdateToV1(
  * Prefer {@link expandSessionUpdateToV2} on the wire — execute tools also emit
  * a sibling `terminal_update`.
  */
-export function sessionUpdateToV2(update: V1SessionUpdate): V2SessionUpdate {
+export function sessionUpdateToV2(
+  update: V1SessionUpdate,
+  options?: WireTransformOptions
+): V2SessionUpdate {
   const raw = { ...(update as unknown as Record<string, unknown>) };
+  const allowName = options?.allowToolCallName ?? (options?.clientToolCallName ? options.clientToolCallName.name === true : true);
+  if (!allowName) {
+    delete raw.name;
+  }
 
   if (raw.sessionUpdate === "tool_call") {
     raw.sessionUpdate = "tool_call_update";
@@ -335,12 +353,13 @@ function planToV2(raw: Record<string, unknown>): V2SessionUpdate {
 export function expandSessionUpdateToV2(
   update: V1SessionUpdate,
   terminalTracker: TerminalOutputTracker = defaultV2TerminalOutputTracker,
-  toolContentTracker: ToolCallContentTracker = defaultToolCallContentTracker
+  toolContentTracker: ToolCallContentTracker = defaultToolCallContentTracker,
+  options?: WireTransformOptions
 ): V2SessionUpdate[] {
   const meta = executeTerminalMeta(update);
 
   if (!meta) {
-    const v2Update = sessionUpdateToV2(update);
+    const v2Update = sessionUpdateToV2(update, options);
     return processV2ToolContentChunks(v2Update, toolContentTracker);
   }
 
@@ -367,7 +386,7 @@ export function expandSessionUpdateToV2(
     meta.status === "failed" ||
     meta.status === "cancelled";
 
-  const tool = sessionUpdateToV2(update) as unknown as Record<string, unknown>;
+  const tool = sessionUpdateToV2(update, options) as unknown as Record<string, unknown>;
   tool.content = withTerminalContent(tool.content, meta.terminalId, meta.status);
   const toolV2Updates = processV2ToolContentChunks(tool as V2SessionUpdate, toolContentTracker);
 

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -732,7 +732,7 @@ export function otherUpdate(stepRow: StepRow): SessionUpdate {
     if (Object.keys(rest).length > 0) content.push(codeBlock(JSON.stringify(rest, null, 2)));
   }
 
-  const name = namePrimary || "unknown";
+  const name = namePrimary || toolRun?.call?.nameSecondary || "";
 
   return toolCallUpdate({ stepRow, title, kind: toolKind(name), name, content });
 }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -128,6 +128,15 @@ function taskBlock(t: TaskDetails): Record<string, unknown> {
   return textBlock(lines.join("\n"));
 }
 
+/** Decoded agy tool identity, preferring the primary field when both exist. */
+export function decodedToolName(stepRow: StepRow): string {
+  return (
+    stepRow.stepPayload.toolRun?.call?.namePrimary ||
+    stepRow.stepPayload.toolRun?.call?.nameSecondary ||
+    ""
+  );
+}
+
 /**
  * Build a `tool_call` update with the envelope common to every tool step: the
  * parsed args become `rawInput`, a decoded error becomes `rawOutput` plus a
@@ -157,8 +166,7 @@ export function toolCallUpdate(opts: {
 
   const name =
     nameOpt ||
-    stepRow.stepPayload.toolRun?.call?.namePrimary ||
-    stepRow.stepPayload.toolRun?.call?.nameSecondary ||
+    decodedToolName(stepRow) ||
     undefined;
 
   // Emit `tool_call` (v1 create shape). The v2 boundary rewrites this to
@@ -316,7 +324,7 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   const toolRun = stepPayload.toolRun;
   const rawInput = parseRawInput(stepRow);
   const displayCwd = fsPath(cwd) ?? undefined;
-  const namePrimary = toolRun?.call?.namePrimary ?? "";
+  const nameFromCall = decodedToolName(stepRow);
   const view = stepPayload.viewFile;
   const list = stepPayload.listDirectory;
 
@@ -325,8 +333,8 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   const content: Record<string, unknown>[] = [];
   const locations: Record<string, unknown>[] = [];
 
-  if (list || namePrimary === "list_dir" || stepType === 9) {
-    name = "list_dir";
+  if (list || nameFromCall === "list_dir" || stepType === 9) {
+    name = nameFromCall || "list_dir";
     const dir = fsPath(asStr(list?.dirUri)) ?? fsPath(asStr(pick(rawInput, "DirectoryPath", "directoryPath")));
     const shown = dir ? toDisplayPath(dir, displayCwd) : "";
     title = shown ? `Read ${shown}` : "Read directory";
@@ -336,6 +344,7 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
       content.push(codeBlock(entries.map((e) => `${e.name}${e.isDirectory !== 0 ? "/" : ""}`).join("\n")));
     }
   } else {
+    name = nameFromCall || "view_file";
     const filePath =
       fsPath(asStr(pick(rawInput, "AbsolutePath", "absolutePath", "FilePath"))) ?? fsPath(asStr(view?.fileUri));
     const resolvedFile = resolvePath(filePath, displayCwd);
@@ -386,7 +395,7 @@ function renderHits(hits: SearchHit[] | undefined): string {
 export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate {
   const cwd = ctx?.cwd;
   const { stepPayload, stepType } = stepRow;
-  const namePrimary = stepPayload.toolRun?.call?.namePrimary ?? "";
+  const nameFromCall = decodedToolName(stepRow);
   const rawInput = parseRawInput(stepRow);
   const displayCwd = fsPath(cwd) ?? undefined;
   const grep = stepPayload.grepSearch;
@@ -396,8 +405,8 @@ export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpda
   const content: Record<string, unknown>[] = [];
   const locations: Record<string, unknown>[] = [];
 
-  if (grep || namePrimary === "grep_search" || stepType === 7) {
-    name = "grep_search";
+  if (grep || nameFromCall === "grep_search" || stepType === 7) {
+    name = nameFromCall || "grep_search";
     const query = asStr(grep?.query) ?? asStr(pick(rawInput, "Query", "query")) ?? "";
     const searchPath = fsPath(asStr(pick(rawInput, "SearchPath", "searchPath"))) ?? fsPath(asStr(grep?.cwdUri));
     const resolvedPath = resolvePath(searchPath, displayCwd);
@@ -408,6 +417,7 @@ export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpda
     const body = asStr(grep?.textOutput)?.trim() || renderHits(grep?.hits) || asStr(grep?.shellCommand)?.trim();
     if (body) content.push(codeBlock(body));
   } else {
+    name = nameFromCall || "search_web";
     // search_web: field 42 carries query metadata; hit lists are not persisted.
     const web = stepPayload.webSearch;
     const query =
@@ -460,7 +470,7 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     fsPath(commandResult?.cwd?.trim() ? commandResult.cwd : null);
   const locations: Record<string, unknown>[] = [];
 
-  const name = toolRun?.call?.namePrimary || "run_command";
+  const name = decodedToolName(stepRow) || "run_command";
 
   const update = toolCallUpdate({
     stepRow,
@@ -537,7 +547,7 @@ export function fetchUpdate(stepRow: StepRow): SessionUpdate {
     content.push(codeBlock(sliced.text));
   }
 
-  const name = toolRun?.call?.namePrimary || "read_url_content";
+  const name = decodedToolName(stepRow) || "read_url_content";
 
   const update = toolCallUpdate({ stepRow, title, kind: "fetch", name, content }) as SessionUpdate & {
     rawOutput?: unknown;
@@ -581,7 +591,7 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   const content: Record<string, unknown>[] = [];
   const locations: Record<string, unknown>[] = [];
 
-  let name = stepRow.stepPayload.toolRun?.call?.namePrimary || "";
+  let name = decodedToolName(stepRow);
 
   if (fullContent !== null) {
     if (!name || name === "edit") name = "write_to_file";
@@ -641,7 +651,7 @@ export function questionUpdate(stepRow: StepRow): SessionUpdate {
     content.push(textBlock(lines.join("\n")));
   }
 
-  const name = toolRun?.call?.namePrimary || "ask_question";
+  const name = decodedToolName(stepRow) || "ask_question";
 
   return toolCallUpdate({ stepRow, title, kind: "other", name, content });
 }
@@ -663,7 +673,7 @@ export function subagentUpdate(stepRow: StepRow): SessionUpdate {
     .filter((prompt): prompt is string => Boolean(prompt))
     .map(codeBlock);
 
-  const name = toolRun?.call?.namePrimary || "invoke_subagent";
+  const name = decodedToolName(stepRow) || "invoke_subagent";
 
   return toolCallUpdate({ stepRow, title, kind: "other", name, content });
 }
@@ -675,10 +685,10 @@ export function subagentUpdate(stepRow: StepRow): SessionUpdate {
  */
 export function otherUpdate(stepRow: StepRow): SessionUpdate {
   const toolRun = stepRow.stepPayload.toolRun;
-  const namePrimary = toolRun?.call?.namePrimary ?? "";
+  const name = decodedToolName(stepRow);
   const rawInput = parseRawInput(stepRow);
 
-  switch (namePrimary) {
+  switch (name) {
     case "manage_task": {
       const action = asStr(pick(rawInput, "Action", "action"))?.trim() || "manage";
       const taskId = asStr(pick(rawInput, "TaskId", "taskId"));
@@ -723,7 +733,7 @@ export function otherUpdate(stepRow: StepRow): SessionUpdate {
     asStr(toolRun?.titlePrimary)?.trim() ||
     asStr(pick(rawInput, "toolSummary", "ToolSummary"))?.trim() ||
     asStr(toolRun?.titleSecondary)?.trim() ||
-    namePrimary ||
+    name ||
     "Tool";
 
   const content: Record<string, unknown>[] = [];
@@ -731,8 +741,6 @@ export function otherUpdate(stepRow: StepRow): SessionUpdate {
     const { toolAction: _toolAction, toolSummary: _toolSummary, ...rest } = rawInput as Record<string, unknown>;
     if (Object.keys(rest).length > 0) content.push(codeBlock(JSON.stringify(rest, null, 2)));
   }
-
-  const name = namePrimary || toolRun?.call?.nameSecondary || "";
 
   return toolCallUpdate({ stepRow, title, kind: toolKind(name), name, content });
 }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -138,11 +138,12 @@ export function toolCallUpdate(opts: {
   stepRow: StepRow;
   title: string;
   kind: ToolKind;
+  name?: string;
   status?: "pending" | "in_progress" | "completed" | "failed" | "cancelled";
   content?: Record<string, unknown>[];
   locations?: Record<string, unknown>[];
 }): SessionUpdate {
-  const { stepRow, title, kind, status = toolCallStatus(stepRow), content, locations } = opts;
+  const { stepRow, title, kind, name: nameOpt, status = toolCallStatus(stepRow), content, locations } = opts;
 
   const blocks: Record<string, unknown>[] = [...(content ?? [])];
   if (stepRow.task) blocks.push(taskBlock(stepRow.task));
@@ -154,11 +155,18 @@ export function toolCallUpdate(opts: {
     ? { message: stepRow.error.message || stepRow.error.detail, detail: stepRow.error.detail, stackTrace: stepRow.error.stackTrace }
     : undefined;
 
+  const name =
+    nameOpt ||
+    stepRow.stepPayload.toolRun?.call?.namePrimary ||
+    stepRow.stepPayload.toolRun?.call?.nameSecondary ||
+    undefined;
+
   // Emit `tool_call` (v1 create shape). The v2 boundary rewrites this to
   // `tool_call_update` (first update creates the call).
   return {
     sessionUpdate: "tool_call",
     toolCallId: toolCallId(stepRow),
+    ...(name ? { name } : {}),
     title,
     kind,
     status,
@@ -308,15 +316,17 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   const toolRun = stepPayload.toolRun;
   const rawInput = parseRawInput(stepRow);
   const displayCwd = fsPath(cwd) ?? undefined;
-  const name = toolRun?.call?.namePrimary ?? "";
+  const namePrimary = toolRun?.call?.namePrimary ?? "";
   const view = stepPayload.viewFile;
   const list = stepPayload.listDirectory;
 
   let title = "Read";
+  let name = "view_file";
   const content: Record<string, unknown>[] = [];
   const locations: Record<string, unknown>[] = [];
 
-  if (list || name === "list_dir" || stepType === 9) {
+  if (list || namePrimary === "list_dir" || stepType === 9) {
+    name = "list_dir";
     const dir = fsPath(asStr(list?.dirUri)) ?? fsPath(asStr(pick(rawInput, "DirectoryPath", "directoryPath")));
     const shown = dir ? toDisplayPath(dir, displayCwd) : "";
     title = shown ? `Read ${shown}` : "Read directory";
@@ -357,7 +367,7 @@ export function readUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
     }
   }
 
-  return toolCallUpdate({ stepRow, title, kind: "read", content, locations });
+  return toolCallUpdate({ stepRow, title, kind: "read", name, content, locations });
 }
 
 /** Render grep hits into readable, pipe-joined lines. `field2` is the line
@@ -376,16 +386,18 @@ function renderHits(hits: SearchHit[] | undefined): string {
 export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate {
   const cwd = ctx?.cwd;
   const { stepPayload, stepType } = stepRow;
-  const name = stepPayload.toolRun?.call?.namePrimary ?? "";
+  const namePrimary = stepPayload.toolRun?.call?.namePrimary ?? "";
   const rawInput = parseRawInput(stepRow);
   const displayCwd = fsPath(cwd) ?? undefined;
   const grep = stepPayload.grepSearch;
 
   let title = "Search";
+  let name = "search_web";
   const content: Record<string, unknown>[] = [];
   const locations: Record<string, unknown>[] = [];
 
-  if (grep || name === "grep_search" || stepType === 7) {
+  if (grep || namePrimary === "grep_search" || stepType === 7) {
+    name = "grep_search";
     const query = asStr(grep?.query) ?? asStr(pick(rawInput, "Query", "query")) ?? "";
     const searchPath = fsPath(asStr(pick(rawInput, "SearchPath", "searchPath"))) ?? fsPath(asStr(grep?.cwdUri));
     const resolvedPath = resolvePath(searchPath, displayCwd);
@@ -411,7 +423,7 @@ export function searchUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpda
     if (lines.length > 0) content.push(codeBlock(lines.join("\n")));
   }
 
-  return toolCallUpdate({ stepRow, title, kind: "search", content, locations });
+  return toolCallUpdate({ stepRow, title, kind: "search", name, content, locations });
 }
 
 /** Step type 21 (run_command): a shell command execution. */
@@ -448,10 +460,13 @@ export function executeUpdate(stepRow: StepRow): SessionUpdate {
     fsPath(commandResult?.cwd?.trim() ? commandResult.cwd : null);
   const locations: Record<string, unknown>[] = [];
 
+  const name = toolRun?.call?.namePrimary || "run_command";
+
   const update = toolCallUpdate({
     stepRow,
     title,
     kind: "execute",
+    name,
     content,
     locations
   }) as SessionUpdate & { rawOutput?: unknown; rawInput?: unknown };
@@ -522,7 +537,9 @@ export function fetchUpdate(stepRow: StepRow): SessionUpdate {
     content.push(codeBlock(sliced.text));
   }
 
-  const update = toolCallUpdate({ stepRow, title, kind: "fetch", content }) as SessionUpdate & {
+  const name = toolRun?.call?.namePrimary || "read_url_content";
+
+  const update = toolCallUpdate({ stepRow, title, kind: "fetch", name, content }) as SessionUpdate & {
     rawOutput?: unknown;
   };
 
@@ -564,7 +581,10 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   const content: Record<string, unknown>[] = [];
   const locations: Record<string, unknown>[] = [];
 
+  let name = stepRow.stepPayload.toolRun?.call?.namePrimary || "";
+
   if (fullContent !== null) {
+    if (!name || name === "edit") name = "write_to_file";
     // write_to_file: the whole file content is the new text.
     if (targetFile) {
       // Prefer prior view_file/write content as oldText when known; otherwise null
@@ -580,6 +600,9 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
     // (a ReplacementChunks array) — normalize both to a list of chunks.
     const chunksRaw = pick(rawInput, "ReplacementChunks", "replacementChunks");
     const chunks = Array.isArray(chunksRaw) ? chunksRaw : [rawInput];
+    if (!name || name === "edit") {
+      name = Array.isArray(chunksRaw) ? "multi_replace_file_content" : "replace_file_content";
+    }
 
     for (const chunk of chunks) {
       const newText = asStr(pick(chunk, "ReplacementContent", "replacementContent"));
@@ -594,7 +617,7 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
     }
   }
 
-  return toolCallUpdate({ stepRow, title, kind: "edit", content, locations });
+  return toolCallUpdate({ stepRow, title, kind: "edit", name, content, locations });
 }
 
 /** Step type 138 (ask_question): the agent poses one or more multiple-choice questions. */
@@ -618,7 +641,9 @@ export function questionUpdate(stepRow: StepRow): SessionUpdate {
     content.push(textBlock(lines.join("\n")));
   }
 
-  return toolCallUpdate({ stepRow, title, kind: "other", content });
+  const name = toolRun?.call?.namePrimary || "ask_question";
+
+  return toolCallUpdate({ stepRow, title, kind: "other", name, content });
 }
 
 /** Step type 127 (invoke_subagent): delegates one or more tasks to subagents. */
@@ -638,7 +663,9 @@ export function subagentUpdate(stepRow: StepRow): SessionUpdate {
     .filter((prompt): prompt is string => Boolean(prompt))
     .map(codeBlock);
 
-  return toolCallUpdate({ stepRow, title, kind: "other", content });
+  const name = toolRun?.call?.namePrimary || "invoke_subagent";
+
+  return toolCallUpdate({ stepRow, title, kind: "other", name, content });
 }
 
 /**
@@ -648,10 +675,10 @@ export function subagentUpdate(stepRow: StepRow): SessionUpdate {
  */
 export function otherUpdate(stepRow: StepRow): SessionUpdate {
   const toolRun = stepRow.stepPayload.toolRun;
-  const name = toolRun?.call?.namePrimary ?? "";
+  const namePrimary = toolRun?.call?.namePrimary ?? "";
   const rawInput = parseRawInput(stepRow);
 
-  switch (name) {
+  switch (namePrimary) {
     case "manage_task": {
       const action = asStr(pick(rawInput, "Action", "action"))?.trim() || "manage";
       const taskId = asStr(pick(rawInput, "TaskId", "taskId"));
@@ -659,6 +686,7 @@ export function otherUpdate(stepRow: StepRow): SessionUpdate {
         stepRow,
         title: `Manage task ${action}`,
         kind: "other",
+        name: "manage_task",
         content: taskId ? [textBlock(`Task: ${taskId}`)] : []
       });
     }
@@ -669,6 +697,7 @@ export function otherUpdate(stepRow: StepRow): SessionUpdate {
         stepRow,
         title: duration ? `Schedule timer (${duration}s)` : "Schedule timer",
         kind: "other",
+        name: "schedule",
         content: prompt ? [textBlock(prompt)] : []
       });
     }
@@ -678,12 +707,13 @@ export function otherUpdate(stepRow: StepRow): SessionUpdate {
         stepRow,
         title: "Send message to subagent",
         kind: "other",
+        name: "send_message",
         content: message ? [textBlock(message)] : []
       });
     }
     case "manage_subagents": {
       const action = asStr(pick(rawInput, "Action", "action"))?.trim() || "manage";
-      return toolCallUpdate({ stepRow, title: `Subagents: ${action}`, kind: "other" });
+      return toolCallUpdate({ stepRow, title: `Subagents: ${action}`, kind: "other", name: "manage_subagents" });
     }
   }
 
@@ -693,7 +723,7 @@ export function otherUpdate(stepRow: StepRow): SessionUpdate {
     asStr(toolRun?.titlePrimary)?.trim() ||
     asStr(pick(rawInput, "toolSummary", "ToolSummary"))?.trim() ||
     asStr(toolRun?.titleSecondary)?.trim() ||
-    name ||
+    namePrimary ||
     "Tool";
 
   const content: Record<string, unknown>[] = [];
@@ -702,5 +732,7 @@ export function otherUpdate(stepRow: StepRow): SessionUpdate {
     if (Object.keys(rest).length > 0) content.push(codeBlock(JSON.stringify(rest, null, 2)));
   }
 
-  return toolCallUpdate({ stepRow, title, kind: toolKind(name), content });
+  const name = namePrimary || "unknown";
+
+  return toolCallUpdate({ stepRow, title, kind: toolKind(name), name, content });
 }

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -52,6 +52,7 @@ function updateSnapshot(update: SessionUpdate): string {
   return JSON.stringify({
     sessionUpdate: raw.sessionUpdate,
     toolCallId: raw.toolCallId,
+    name: raw.name,
     title: raw.title,
     kind: raw.kind,
     status: raw.status,

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -5,6 +5,7 @@
 
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import {
+  decodedToolName,
   editUpdate,
   executeUpdate,
   fetchUpdate,
@@ -128,7 +129,7 @@ function userPromptUpdate(stepRow: StepRow): SessionUpdate[] {
  *  step carries no actual tool call (e.g. type-17 artifact progress wrappers
  *  have a tool-run header but no `call`), so we don't emit empty tool_calls. */
 function buildByToolName(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate | SessionUpdate[] | null {
-  const name = stepRow.stepPayload.toolRun?.call?.namePrimary ?? "";
+  const name = decodedToolName(stepRow);
   if (!name) return null;
 
   if (isThoughtToolName(name)) return thoughtUpdate(stepRow);

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../src/agent.js";
 import { configFromEnv, type AgyCliConfig, type PtyFactory, type SpawnFactory } from "../src/agy/cli.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
-import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
+import { encodeCommandResult, encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 import { createTerminalOutputTracker, createToolCallContentTracker, expandSessionUpdateToV2, sessionUpdateToV1, sessionUpdateToV2 } from "../src/acp/session/update-wire.js";
 import { filterUpdatesForReplayFrom } from "../src/acp/session/setup.js";
 import { terminalIdForToolCall } from "../src/acp/terminal/index.js";
@@ -2156,3 +2156,97 @@ function optionValues(configOption: SelectConfigOption): string[] {
 function optionNames(configOption: SelectConfigOption): string[] {
   return configOption.options.map((option) => option.name);
 }
+
+describe("tool call name field (gh#52)", () => {
+  it("advertises toolCallName in initialize agent capabilities", async () => {
+    vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue(null);
+    const spawnProcess = (_command: string, args: string[]) => {
+      if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+      return new FakeProcess(["ok"]);
+    };
+    const options = { env: printModeEnv(), spawnProcess: spawnProcess as unknown as SpawnFactory };
+    const connectionV1 = acpClient({ name: "test-client" }).connect(createAcpApp(options));
+    const connectionV2 = acpV2.client({ name: "test-client" }).connect(createAcpV2App(options));
+
+    try {
+      const initV1 = (await connectionV1.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      })) as any;
+      expect(initV1.agentCapabilities?.toolCallName).toEqual({});
+
+      const initV2 = (await connectionV2.agent.request(acpV2.methods.agent.initialize, {
+        protocolVersion: acpV2.PROTOCOL_VERSION,
+        info: { name: "test-client", version: "0.0.0" },
+        capabilities: {}
+      })) as any;
+      expect((initV2.capabilities as any)?.toolCallName ?? (initV2.capabilities as any)?._meta?.toolCallName).toBeDefined();
+    } finally {
+      connectionV1.close();
+      connectionV2.close();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("emits name field on tool_call_update for ACP v2 turns", async () => {
+    await withConversationsDir(async (dir) => {
+      vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue(null);
+      const sessionUpdates: any[] = [];
+      const connection = acpV2.client({ name: "test-client" })
+        .onNotification(acpV2.methods.client.session.update, (ctx) => {
+          sessionUpdates.push(ctx.params.update);
+        })
+        .connect(
+          createAcpV2App({
+            env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+            spawnProcess: spawnAgyWritingConversation(dir, "v2-name-session", [
+              {
+                idx: 1,
+                stepType: 21,
+                status: 3,
+                stepPayload: encodeStepPayload({
+                  toolRun: encodeToolRun({
+                    call: encodeToolCall({
+                      callId: "call-cmd-1",
+                      namePrimary: "run_command",
+                      rawInputJson: JSON.stringify({ CommandLine: "echo hello" })
+                    })
+                  }),
+                  commandResult: encodeCommandResult({ command: "echo hello", output: "hello", exitCode: 0, cwd: dir })
+                })
+              }
+            ])
+          })
+        );
+
+      try {
+        await connection.agent.request(acpV2.methods.agent.initialize, {
+          protocolVersion: acpV2.PROTOCOL_VERSION,
+          info: { name: "test-client", version: "0.0.0" },
+          capabilities: {}
+        });
+        const session = await connection.agent.request(acpV2.methods.agent.session.new, { cwd: dir });
+        await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "run echo" }]
+        });
+
+        await waitFor(() =>
+          sessionUpdates.some(
+            (u) => u.sessionUpdate === "tool_call_update" && u.toolCallId === "call-cmd-1"
+          )
+        );
+
+        const toolUpdate = sessionUpdates.find(
+          (u) => u.sessionUpdate === "tool_call_update" && u.toolCallId === "call-cmd-1"
+        );
+        expect(toolUpdate).toBeDefined();
+        expect(toolUpdate.name).toBe("run_command");
+      } finally {
+        connection.close();
+        vi.restoreAllMocks();
+      }
+    });
+  });
+});
+

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1451,7 +1451,20 @@ describe("ACP v2 (experimental draft)", () => {
         env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
         spawnProcess: spawnAgyWritingConversation(dir, "conv-v2-replay", [
           { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "hi" }) },
-          { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "prior turn" }) }
+          {
+            idx: 1,
+            stepType: 8,
+            stepPayload: encodeStepPayload({
+              toolRun: encodeToolRun({
+                call: encodeToolCall({
+                  callId: "v2-replayed-view",
+                  namePrimary: "view_file",
+                  rawInputJson: '{"AbsolutePath":"/repo/README.md"}'
+                })
+              })
+            })
+          },
+          { idx: 2, stepType: 15, stepPayload: encodeStepPayload({ agentText: "prior turn" }) }
         ])
       };
 
@@ -1504,7 +1517,7 @@ describe("ACP v2 (experimental draft)", () => {
           await connection.agent.request(acpV2.methods.agent.initialize, {
             protocolVersion: 2,
             info: { name: "test-client", version: "0.0.0" },
-            capabilities: {}
+            capabilities: { _meta: { toolCallName: false } }
           });
           await connection.agent.request(acpV2.methods.agent.session.resume, {
             sessionId,
@@ -1524,6 +1537,17 @@ describe("ACP v2 (experimental draft)", () => {
               messageId: expect.any(String)
             })
           );
+          const replayedToolCall = updates.find(
+            (update) =>
+              (update as { sessionUpdate?: string; toolCallId?: string }).sessionUpdate ===
+                "tool_call_update" &&
+              (update as { toolCallId?: string }).toolCallId === "v2-replayed-view"
+          );
+          expect(replayedToolCall).toMatchObject({
+            sessionUpdate: "tool_call_update",
+            title: "Read README.md"
+          });
+          expect(replayedToolCall).not.toHaveProperty("name");
         } finally {
           connection.close();
         }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -23,6 +23,7 @@ import { encodeCommandResult, encodeStepPayload, encodeToolCall, encodeToolRun }
 import { createTerminalOutputTracker, createToolCallContentTracker, expandSessionUpdateToV2, sessionUpdateToV1, sessionUpdateToV2 } from "../src/acp/session/update-wire.js";
 import { filterUpdatesForReplayFrom } from "../src/acp/session/setup.js";
 import { terminalIdForToolCall } from "../src/acp/terminal/index.js";
+import { parseClientToolCallName } from "../src/acp/initialize.js";
 import type { SessionConfigOption, SessionUpdate } from "@agentclientprotocol/sdk";
 
 type SelectConfigOption = Extract<SessionConfigOption, { type: "select" }>;
@@ -47,6 +48,13 @@ describe("contentBlocksToText", () => {
 });
 
 describe("initialize", () => {
+  it("parses nested camel- and snake-case tool call name capabilities", () => {
+    expect(parseClientToolCallName({ toolCall: { name: true } }, false)).toEqual({ name: true });
+    expect(
+      parseClientToolCallName({ capabilities: { tool_call: { name: false } } }, true)
+    ).toEqual({ name: false });
+  });
+
   it("returns SDK-validated ACP capabilities", async () => {
     const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue(null);
     const connection = acpClient({ name: "test-client" }).connect(createAcpApp());

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -424,7 +424,20 @@ describe("session/load and session/resume", () => {
       const appOptions = {
         env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
         spawnProcess: spawnAgyWritingConversation(dir, "conv-persisted", [
-          { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hello from before" }) }
+          {
+            idx: 1,
+            stepType: 8,
+            stepPayload: encodeStepPayload({
+              toolRun: encodeToolRun({
+                call: encodeToolCall({
+                  callId: "replayed-view",
+                  namePrimary: "view_file",
+                  rawInputJson: '{"AbsolutePath":"/repo/README.md"}'
+                })
+              })
+            })
+          },
+          { idx: 2, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hello from before" }) }
         ])
       };
 
@@ -459,6 +472,10 @@ describe("session/load and session/resume", () => {
           });
         const connection = client.connect(createAcpApp(appOptions));
         try {
+          await connection.agent.request(methods.agent.initialize, {
+            protocolVersion: PROTOCOL_VERSION,
+            clientCapabilities: {}
+          });
           const response = await connection.agent.request(methods.agent.session.load, {
             sessionId,
             cwd: "/repo",
@@ -470,6 +487,16 @@ describe("session/load and session/resume", () => {
               content: { type: "text", text: "hello from before" }
             })
           );
+          const replayedToolCall = updates.find(
+            (update) =>
+              (update as { sessionUpdate?: string; toolCallId?: string }).sessionUpdate === "tool_call" &&
+              (update as { toolCallId?: string }).toolCallId === "replayed-view"
+          );
+          expect(replayedToolCall).toMatchObject({
+            sessionUpdate: "tool_call",
+            title: "Read README.md"
+          });
+          expect(replayedToolCall).not.toHaveProperty("name");
           expect(updates).toContainEqual(
             expect.objectContaining({ sessionUpdate: "available_commands_update" })
           );
@@ -2249,4 +2276,3 @@ describe("tool call name field (gh#52)", () => {
     });
   });
 });
-

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -26,7 +26,7 @@ import {
   permissionKeys,
   permissionOptions
 } from "../src/acp/tool-calls/permissions.js";
-import { requestPermissionV1 } from "../src/acp/session/request-permission.js";
+import { requestPermissionV1, requestPermissionV2 } from "../src/acp/session/request-permission.js";
 import { createConversationDb, insertStep, updateStep } from "./fixtures/conversation-db.js";
 import { encodePermissions, encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 
@@ -317,6 +317,48 @@ describe("permission bridge", () => {
       toolCall,
       "run_command",
       undefined,
+      undefined,
+      undefined,
+      { name: true }
+    );
+
+    expect(payloads[0]).not.toHaveProperty("name");
+    expect(payloads[1]).toHaveProperty("name", "run_command");
+  });
+
+  it("filters v2 requestPermission tool names when the client opts out", async () => {
+    const payloads: Record<string, unknown>[] = [];
+    const mockClient = {
+      request: vi.fn().mockImplementation(async (_method, params) => {
+        payloads.push(params.subject.toolCall);
+        return { outcome: { outcome: "selected", optionId: "allow-once" } };
+      })
+    };
+    const toolCall = {
+      sessionUpdate: "tool_call" as const,
+      toolCallId: "cmd-v2-name",
+      title: "echo hi",
+      kind: "execute" as const,
+      status: "pending" as const,
+      name: "run_command"
+    };
+
+    await requestPermissionV2(
+      mockClient as any,
+      "s1",
+      toolCall,
+      "run_command",
+      new AbortController().signal,
+      undefined,
+      undefined,
+      { name: false }
+    );
+    await requestPermissionV2(
+      mockClient as any,
+      "s1",
+      toolCall,
+      "run_command",
+      new AbortController().signal,
       undefined,
       undefined,
       { name: true }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -284,6 +284,48 @@ describe("permission bridge", () => {
     expect(capturedTitle).toBe("[Question 2/2] Second Question?");
   });
 
+  it("filters v1 requestPermission tool names unless the client negotiated them", async () => {
+    const payloads: Record<string, unknown>[] = [];
+    const mockClient = {
+      request: vi.fn().mockImplementation(async (_method, params) => {
+        payloads.push(params.toolCall);
+        return { outcome: { outcome: "selected", optionId: "allow-once" } };
+      })
+    };
+    const toolCall = {
+      sessionUpdate: "tool_call" as const,
+      toolCallId: "cmd-name",
+      title: "echo hi",
+      kind: "execute" as const,
+      status: "pending" as const,
+      name: "run_command"
+    };
+
+    await requestPermissionV1(
+      mockClient as any,
+      "s1",
+      toolCall,
+      "run_command",
+      undefined,
+      undefined,
+      undefined,
+      { name: false }
+    );
+    await requestPermissionV1(
+      mockClient as any,
+      "s1",
+      toolCall,
+      "run_command",
+      undefined,
+      undefined,
+      undefined,
+      { name: true }
+    );
+
+    expect(payloads[0]).not.toHaveProperty("name");
+    expect(payloads[1]).toHaveProperty("name", "run_command");
+  });
+
   it("bridges agy's ask_permission sandbox-bypass request as a command-style menu", () => {
     // agy 1.1.7 gates sandbox bypass (run a command / read a file outside the
     // sandbox) through a status-9 `ask_permission` step whose TUI menu is the

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -234,6 +234,59 @@ describe("Translator", () => {
     db.close();
   });
 
+  it("re-emits a progressive tool update when its decoded name changes", () => {
+    const db = createConversationDb(dir, "conv-progressive-tool-name");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 2,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "late-name",
+            rawInputJson: '{"CommandLine":"echo hi"}'
+          })
+        })
+      })
+    });
+
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const conn = ConversationDb.open(dir, "conv-progressive-tool-name")!;
+
+    expect(translator.translate(conn.readAfter(0))).toMatchObject([
+      {
+        sessionUpdate: "tool_call",
+        toolCallId: "late-name",
+        name: "run_command"
+      }
+    ]);
+
+    updateStepPayload(
+      db,
+      1,
+      encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "late-name",
+            nameSecondary: "resolved_command_tool",
+            rawInputJson: '{"CommandLine":"echo hi"}'
+          })
+        })
+      })
+    );
+
+    expect(translator.translate(conn.readAfter(0))).toMatchObject([
+      {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "late-name",
+        name: "resolved_command_tool"
+      }
+    ]);
+    expect(translator.translate(conn.readAfter(0))).toEqual([]);
+
+    conn.close();
+    db.close();
+  });
 
   it("emits tool_call then tool_call_update when status progresses on the same idx", () => {
     const db = createConversationDb(dir, "conv-tool-progress");

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2018,6 +2018,32 @@ describe("tool call name support (gh#52)", () => {
         })
       })
     });
+    insertStep(db, {
+      idx: 5,
+      stepType: 21,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "c5",
+            nameSecondary: "custom_command_tool",
+            rawInputJson: '{"CommandLine":"echo secondary"}'
+          })
+        })
+      })
+    });
+    insertStep(db, {
+      idx: 6,
+      stepType: 17,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "c6",
+            nameSecondary: "run_command",
+            rawInputJson: '{"CommandLine":"echo routed"}'
+          })
+        })
+      })
+    });
     db.close();
 
     const conn = ConversationDb.open(dir, "conv-name-test");
@@ -2036,5 +2062,11 @@ describe("tool call name support (gh#52)", () => {
 
     const genericUpdate = sessionUpdateFromStep(rows[3]) as any;
     expect(genericUpdate.name).toBe("custom_secondary_tool");
+
+    const executeUpdate = sessionUpdateFromStep(rows[4]) as any;
+    expect(executeUpdate.name).toBe("custom_command_tool");
+
+    const routedUpdate = sessionUpdateFromStep(rows[5]) as any;
+    expect(routedUpdate).toMatchObject({ name: "run_command", kind: "execute" });
   });
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -7,6 +7,7 @@ import { ReplayCache } from "../src/agy/db/replay.js";
 import { conversationSnapshot, newConversationId } from "../src/agy/db/scan.js";
 import { StreamPoller } from "../src/agy/db/streaming.js";
 import { Translator } from "../src/agy/db/translator.js";
+import { sessionUpdateFromStep } from "../src/agy/db/updates.js";
 import { createConversationDb, insertStep, updateStep, updateStepPayload } from "./fixtures/conversation-db.js";
 import {
   encodeAgentText,
@@ -1972,3 +1973,52 @@ describe("conversation scan", () => {
     expect(newConversationId(dir, before)).toBeNull();
   });
 });
+
+describe("tool call name support (gh#52)", () => {
+  it("emits programmatic tool call name on tool_call session updates", () => {
+    const db = createConversationDb(dir, "conv-name-test");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({ callId: "c1", namePrimary: "run_command", rawInputJson: '{"CommandLine":"echo hi"}' })
+        })
+      })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 8,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({ callId: "c2", namePrimary: "view_file", rawInputJson: '{"AbsolutePath":"/tmp/test.txt"}' })
+        })
+      })
+    });
+    insertStep(db, {
+      idx: 3,
+      stepType: 5,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({ callId: "c3", namePrimary: "replace_file_content", rawInputJson: '{"TargetFile":"/tmp/test.txt","TargetContent":"a","ReplacementContent":"b"}' })
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-name-test");
+    expect(conn).not.toBeNull();
+    const rows = conn!.readAfter(0);
+    conn!.close();
+
+    const execUpdate = sessionUpdateFromStep(rows[0]) as any;
+    expect(execUpdate.name).toBe("run_command");
+
+    const readUpdate = sessionUpdateFromStep(rows[1]) as any;
+    expect(readUpdate.name).toBe("view_file");
+
+    const editUpdate = sessionUpdateFromStep(rows[2]) as any;
+    expect(editUpdate.name).toBe("replace_file_content");
+  });
+});
+

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2004,6 +2004,20 @@ describe("tool call name support (gh#52)", () => {
         })
       })
     });
+    insertStep(db, {
+      idx: 4,
+      stepType: 132,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "c4",
+            nameSecondary: "custom_secondary_tool",
+            rawInputJson: '{"value":"test"}'
+          }),
+          titlePrimary: "Custom secondary tool"
+        })
+      })
+    });
     db.close();
 
     const conn = ConversationDb.open(dir, "conv-name-test");
@@ -2019,6 +2033,8 @@ describe("tool call name support (gh#52)", () => {
 
     const editUpdate = sessionUpdateFromStep(rows[2]) as any;
     expect(editUpdate.name).toBe("replace_file_content");
+
+    const genericUpdate = sessionUpdateFromStep(rows[3]) as any;
+    expect(genericUpdate.name).toBe("custom_secondary_tool");
   });
 });
-


### PR DESCRIPTION
## Description

Adds support for emitting the optional programmatic `name` field on `tool_call` (ACP v1) and `tool_call_update` (ACP v2) session updates derived from agy tool names (e.g. `run_command`, `write_to_file`, `replace_file_content`, `view_file`, `list_dir`, etc.). Advertises `toolCallName: {}` capability in initialize responses for both ACP v1 and v2, and gates wire delivery on client capability or ACP v2 draft protocol defaults.

## Related Issues

Fixes #52

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed