### PR TITLE
Keep agent turns open during background task execution

### DIFF
--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -1,5 +1,10 @@
 // ACP Content: map prompt ContentBlock[] (text / image / resource) onto agy input.
 // Docs: https://agentclientprotocol.com/protocol/v1/content
+//
+// Only encodes blocks from the ACP client's session/prompt payload — never invents
+// conversational turns. Minimal structural framing is used so non-text blocks can
+// be represented as a single agy prompt string (images → @path; text resources
+// keep a short "Resource <uri>:" label around client-supplied body text).
 
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";

--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -1,10 +1,10 @@
 // ACP Content: map prompt ContentBlock[] (text / image / resource) onto agy input.
 // Docs: https://agentclientprotocol.com/protocol/v1/content
 //
-// Only encodes blocks from the ACP client's session/prompt payload — never invents
-// conversational turns. Minimal structural framing is used so non-text blocks can
-// be represented as a single agy prompt string (images → @path; text resources
-// keep a short "Resource <uri>:" label around client-supplied body text).
+// Zero prompt injection: every substring forwarded to agy must come from the ACP
+// client's session/prompt content (or be agy's native attachment transport for
+// client-provided image bytes). Never invent conversational labels, instructions,
+// follow-ups ("continue"), or framing prose around client data.
 
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
@@ -14,11 +14,22 @@ import type { ContentBlock } from "@agentclientprotocol/sdk";
 
 const ATTACHMENTS_DIR = ".agy-acp/attachments";
 
+/**
+ * Encode client ContentBlocks into a single agy prompt string.
+ *
+ * - text → block.text as-is
+ * - image / image resource → write bytes, reference with agy `@path` transport
+ * - resource_link (non-image) → uri only (client-supplied)
+ * - embedded text resource → resource.text only (client-supplied body)
+ * - non-image blobs → omitted (no invented "blob omitted" copy)
+ *
+ * Parts are joined with newlines; empty parts are dropped.
+ */
 export async function contentBlocksToPrompt(blocks: ContentBlock[], cwd: string): Promise<string> {
   const parts: string[] = [];
   for (const block of blocks) {
     if (block.type === "text") {
-      parts.push(block.text);
+      if (block.text.length > 0) parts.push(block.text);
       continue;
     }
 
@@ -35,31 +46,34 @@ export async function contentBlocksToPrompt(blocks: ContentBlock[], cwd: string)
     if (block.type === "resource_link") {
       if (isImageMimeType(block.mimeType) && block.uri) {
         parts.push(agyAttachmentReference(filePathFromUri(block.uri)));
-      } else {
-        parts.push(`Referenced resource: ${block.uri}`);
+      } else if (block.uri) {
+        // Client-supplied URI only — no adapter prose.
+        parts.push(block.uri);
       }
       continue;
     }
 
     if (block.type === "resource") {
-      parts.push(await resourceBlockToPrompt(block, cwd));
+      const encoded = await resourceBlockToPrompt(block, cwd);
+      if (encoded.length > 0) parts.push(encoded);
     }
   }
   return parts.join("\n");
 }
 
+/** Flatten client content to plain text for display/logging — no invented copy. */
 export function contentBlocksToText(blocks: ContentBlock[]): string {
   const parts: string[] = [];
   for (const block of blocks) {
     if (block.type === "text") {
-      parts.push(block.text);
+      if (block.text.length > 0) parts.push(block.text);
     } else if (block.type === "resource_link") {
-      parts.push(`Referenced resource: ${block.uri}`);
+      if (block.uri) parts.push(block.uri);
     } else if (block.type === "resource") {
-      parts.push(resourceBlockToText(block));
-    } else if (block.type === "image") {
-      parts.push(`[image: ${block.mimeType}]`);
+      const text = resourceBlockClientText(block);
+      if (text.length > 0) parts.push(text);
     }
+    // image blocks have no client text payload for display
   }
   return parts.join("\n");
 }
@@ -77,17 +91,22 @@ async function resourceBlockToPrompt(
     );
     return agyAttachmentReference(filePath);
   }
-  return resourceBlockToText(block);
+  return resourceBlockClientText(block);
 }
 
-function resourceBlockToText(block: Extract<ContentBlock, { type: "resource" }>): string {
+/** Client-authored body only; never wrap with URI labels or omission notices. */
+function resourceBlockClientText(block: Extract<ContentBlock, { type: "resource" }>): string {
   const resource = block.resource;
-  if ("text" in resource) {
-    return `Resource ${resource.uri}:\n${resource.text}`;
+  if ("text" in resource && typeof resource.text === "string") {
+    return resource.text;
   }
-  return `Resource ${resource.uri}: [${resource.mimeType ?? "application/octet-stream"} blob omitted]`;
+  return "";
 }
 
+/**
+ * agy native file-attachment transport for client-provided image bytes.
+ * `@` + absolute path is how agy attaches files — not conversational prose.
+ */
 function agyAttachmentReference(filePath: string): string {
   return `@${path.resolve(filePath)}`;
 }

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -19,7 +19,12 @@ import type { ClientToolCallNameCapability } from "../initialize.js";
 import type { SessionModeId } from "../../agy/cli.js";
 import { contentBlocksToPrompt } from "../content/index.js";
 import type { ClientFileSystem } from "../../agy/edit/bridge.js";
-import { interpretSlashCommand, parseSlashCommand, resolveModelValue } from "../slash-commands/index.js";
+import {
+  interpretSlashCommand,
+  isClientTextSlashPrompt,
+  parseSlashCommand,
+  resolveModelValue
+} from "../slash-commands/index.js";
 import { MODEL_CONFIG_ID } from "./config-options.js";
 import { MODE_CONFIG_ID } from "./modes.js";
 import { requestPermissionV1, requestPermissionV2 } from "./request-permission.js";
@@ -114,23 +119,27 @@ export async function handlePromptV1(
   const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
 
   // Curated slash commands → config options; do not spawn agy for those.
-  const handled = await applyCuratedSlashCommand(
-    params.sessionId,
-    prompt,
-    {
-      // ACP transition: send both legacy current_mode_update (modes-API clients)
-      // and config_option_update (configOptions clients) on slash-command mode changes.
-      modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
-      configChanged: async () => {
-        await deps.notifyConfigOptionUpdateV1(
-          client,
-          params.sessionId,
-          deps.requireSession(params.sessionId)
-        );
-      }
-    },
-    deps
-  );
+  // Only intercept pure client text blocks (not resource/image payloads whose
+  // flattened body happens to look like `/plan`).
+  const handled =
+    isClientTextSlashPrompt(params.prompt) &&
+    (await applyCuratedSlashCommand(
+      params.sessionId,
+      prompt,
+      {
+        // ACP transition: send both legacy current_mode_update (modes-API clients)
+        // and config_option_update (configOptions clients) on slash-command mode changes.
+        modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
+        configChanged: async () => {
+          await deps.notifyConfigOptionUpdateV1(
+            client,
+            params.sessionId,
+            deps.requireSession(params.sessionId)
+          );
+        }
+      },
+      deps
+    ));
   if (handled) {
     return { stopReason: signal?.aborted ? "cancelled" : "end_turn" };
   }
@@ -239,7 +248,9 @@ async function runV2PromptTurn(
     });
   };
 
-  const parsedSlash = parseSlashCommand(promptText);
+  // Only treat pure client text as a slash-menu selection (not resource bodies).
+  const clientSlash = isClientTextSlashPrompt(params.prompt as v1.ContentBlock[]);
+  const parsedSlash = clientSlash ? parseSlashCommand(promptText) : null;
   const slashResult = parsedSlash ? interpretSlashCommand(parsedSlash) : null;
   const userMessageId =
     slashResult && slashResult.kind !== "pass"
@@ -259,16 +270,18 @@ async function runV2PromptTurn(
     await notify({ sessionUpdate: "state_update", state: "running" });
 
     // Curated slash commands → config options (no agy spawn).
-    const slashHandled = await applyCuratedSlashCommand(
-      params.sessionId,
-      promptText,
-      {
-        configChanged: async () => {
-          await deps.notifyConfigOptionUpdateV2(client, params.sessionId, deps.requireSession(params.sessionId));
-        }
-      },
-      deps
-    );
+    const slashHandled =
+      clientSlash &&
+      (await applyCuratedSlashCommand(
+        params.sessionId,
+        promptText,
+        {
+          configChanged: async () => {
+            await deps.notifyConfigOptionUpdateV2(client, params.sessionId, deps.requireSession(params.sessionId));
+          }
+        },
+        deps
+      ));
     if (slashHandled) {
       await notify({
         sessionUpdate: "state_update",

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -94,7 +94,12 @@ export async function applyCuratedSlashCommand(
   return true;
 }
 
-/** v1 `session/prompt`: response carries stopReason after the full turn. */
+/**
+ * v1 `session/prompt`: response carries stopReason after the full turn.
+ *
+ * Only the ACP client's `params.prompt` is forwarded to agy (after content-block
+ * encoding). The adapter never synthesizes conversational follow-ups.
+ */
 export async function handlePromptV1(
   params: V1PromptRequest,
   client: V1AgentContext,
@@ -178,6 +183,9 @@ export async function handlePromptV1(
 /**
  * v2 `session/prompt`: respond `{}` immediately on acceptance. Foreground
  * progress and stopReason arrive as `state_update` notifications.
+ *
+ * Only the ACP client's `params.prompt` is forwarded to agy (after content-block
+ * encoding). The adapter never synthesizes conversational follow-ups.
  */
 export async function handlePromptV2(
   params: V2PromptRequest,

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -97,8 +97,8 @@ export async function applyCuratedSlashCommand(
 /**
  * v1 `session/prompt`: response carries stopReason after the full turn.
  *
- * Only the ACP client's `params.prompt` is forwarded to agy (after content-block
- * encoding). The adapter never synthesizes conversational follow-ups.
+ * Zero prompt injection: only client `params.prompt` content is encoded and
+ * forwarded to agy. No adapter-authored labels, instructions, or follow-ups.
  */
 export async function handlePromptV1(
   params: V1PromptRequest,
@@ -184,8 +184,8 @@ export async function handlePromptV1(
  * v2 `session/prompt`: respond `{}` immediately on acceptance. Foreground
  * progress and stopReason arrive as `state_update` notifications.
  *
- * Only the ACP client's `params.prompt` is forwarded to agy (after content-block
- * encoding). The adapter never synthesizes conversational follow-ups.
+ * Zero prompt injection: only client `params.prompt` content is encoded and
+ * forwarded to agy. No adapter-authored labels, instructions, or follow-ups.
  */
 export async function handlePromptV2(
   params: V2PromptRequest,

--- a/src/acp/slash-commands/index.ts
+++ b/src/acp/slash-commands/index.ts
@@ -8,7 +8,7 @@
 // session config surfaces already mapped to `agy --mode` / `--model` / `--effort`.
 // Full TUI palette (/settings, /mcp, /help overlays, …) is intentionally omitted.
 
-import type { AvailableCommand, SessionUpdate } from "@agentclientprotocol/sdk";
+import type { AvailableCommand, ContentBlock, SessionUpdate } from "@agentclientprotocol/sdk";
 
 export const MODE_SLASH = "mode";
 export const PLAN_SLASH = "plan";
@@ -72,6 +72,29 @@ export function parseSlashCommand(promptText: string): ParsedSlashCommand | null
     name: match[1].toLowerCase(),
     input: (match[2] ?? "").trim()
   };
+}
+
+/**
+ * True when the client's original ContentBlocks are a pure text slash command
+ * (exactly one non-empty text block, no images/resources/links).
+ *
+ * Slash interception must not fire on flattened resource bodies that merely
+ * contain text like `/plan` — those should be forwarded to agy as normal
+ * prompt content.
+ */
+export function isClientTextSlashPrompt(blocks: ContentBlock[]): boolean {
+  let textBlock: Extract<ContentBlock, { type: "text" }> | undefined;
+  for (const block of blocks) {
+    if (block.type === "text") {
+      if (block.text.trim().length === 0) continue;
+      if (textBlock) return false;
+      textBlock = block;
+      continue;
+    }
+    // Any non-text block means this is not a client slash-menu selection.
+    return false;
+  }
+  return textBlock !== undefined;
 }
 
 export type SlashConfigAction = {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -558,8 +558,9 @@ export class AgyCliSession {
         if (candidateRevision === poller.revision && this.#ptyIdleMarkerCount >= requiredIdleMarkerCount) {
           // Background work can finish after the TUI looks idle. Stay on this
           // user turn and keep polling — do not inject a synthetic "continue".
+          // Do not re-arm deadline here: only poller revision progress (above)
+          // refreshes the timeout, so a missing completion cannot hang forever.
           if (poller.hasActiveBackgroundTasks && !this.#cancelled) {
-            deadline = Date.now() + timeoutMs;
             const exited = await Promise.race([activePtyExit.then(() => true), sleep(POLL_INTERVAL_MS).then(() => false)]);
             if (exited && !this.#cancelled) throw new AgyCliError(`agy interactive PTY exited unexpectedly: ${this.#ptyOutput.trim() || "<no output>"}`, [this.config.agyPath], null, this.#ptyOutput);
             continue;
@@ -801,11 +802,14 @@ export class AgyCliSession {
       await this.stopPty();
       return;
     }
+    // Always mark cancelled first: print-mode may still be draining background
+    // task rows after the child has already exited, and that loop only checks
+    // `#cancelled` (the process handle alone is no longer enough to interrupt).
+    this.#cancelled = true;
     const child = this.#process;
     if (!child || child.exitCode !== null) {
       return;
     }
-    this.#cancelled = true;
     const exitPromise = once(child, "exit");
     // SIGINT (rather than SIGTERM) gives agy a chance to flush its last
     // conversation-database write before exiting. Windows has no real SIGINT,

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -283,6 +283,12 @@ export class AgyCliSession {
    * appended steps while the process runs, and invoke `onUpdate` with the
    * translated ACP updates in order. Resolves once the process exits and a few
    * trailing polls have drained any steps flushed right around exit.
+   *
+   * Invariant: `prompt` must be client-originated user content only. Never
+   * invent follow-ups (e.g. "continue") for background-task wakeups — keep the
+   * turn open and poll instead. PTY writes during a turn are permission keys
+   * (or the same user `prompt` when reusing an interactive TUI), not adapter
+   * prose.
    */
   async prompt(
     prompt: string,
@@ -549,8 +555,17 @@ export class AgyCliSession {
           if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
           if (normalizePermissionChoice(choice) === "agy-reject-once") revertEditToolCall(toolCall);
         }
-        if (this.#cancelled) break;
-        if (candidateRevision === poller.revision && this.#ptyIdleMarkerCount >= requiredIdleMarkerCount) break;
+        if (candidateRevision === poller.revision && this.#ptyIdleMarkerCount >= requiredIdleMarkerCount) {
+          // Background work can finish after the TUI looks idle. Stay on this
+          // user turn and keep polling — do not inject a synthetic "continue".
+          if (poller.hasActiveBackgroundTasks && !this.#cancelled) {
+            deadline = Date.now() + timeoutMs;
+            const exited = await Promise.race([activePtyExit.then(() => true), sleep(POLL_INTERVAL_MS).then(() => false)]);
+            if (exited && !this.#cancelled) throw new AgyCliError(`agy interactive PTY exited unexpectedly: ${this.#ptyOutput.trim() || "<no output>"}`, [this.config.agyPath], null, this.#ptyOutput);
+            continue;
+          }
+          break;
+        }
         const exited = await Promise.race([activePtyExit.then(() => true), sleep(POLL_INTERVAL_MS).then(() => false)]);
         if (exited && !this.#cancelled) throw new AgyCliError(`agy interactive PTY exited unexpectedly: ${this.#ptyOutput.trim() || "<no output>"}`, [this.config.agyPath], null, this.#ptyOutput);
       }
@@ -672,6 +687,17 @@ export class AgyCliSession {
           exitCode,
           stderr
         );
+      }
+
+      // Print-mode child may exit before background task rows finish writing.
+      // Keep draining the DB for this user turn only — no synthetic prompts.
+      if (poller.hasActiveBackgroundTasks && !this.#cancelled) {
+        while (poller.hasActiveBackgroundTasks && !this.#cancelled) {
+          await sleep(POLL_INTERVAL_MS);
+          for (const update of poller.poll()) {
+            await onUpdate(update);
+          }
+        }
       }
 
       return { stopReason: this.#cancelled ? "cancelled" : "end_turn" };

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -284,11 +284,11 @@ export class AgyCliSession {
    * translated ACP updates in order. Resolves once the process exits and a few
    * trailing polls have drained any steps flushed right around exit.
    *
-   * Invariant: `prompt` must be client-originated user content only. Never
-   * invent follow-ups (e.g. "continue") for background-task wakeups — keep the
-   * turn open and poll instead. PTY writes during a turn are permission keys
-   * (or the same user `prompt` when reusing an interactive TUI), not adapter
-   * prose.
+   * Invariant (zero prompt injection): `prompt` is only client-originated
+   * content from ACP session/prompt. Never invent labels, instructions, or
+   * follow-ups (e.g. "continue") — for background wakeups, keep the turn open
+   * and poll instead. PTY writes during a turn are permission keys (or the same
+   * user `prompt` when reusing an interactive TUI), never adapter prose.
    */
   async prompt(
     prompt: string,
@@ -691,11 +691,21 @@ export class AgyCliSession {
 
       // Print-mode child may exit before background task rows finish writing.
       // Keep draining the DB for this user turn only — no synthetic prompts.
+      // Re-arm the deadline on DB progress so long tasks can finish; still
+      // bound idle silence by printTimeout so a missing completion cannot hang.
       if (poller.hasActiveBackgroundTasks && !this.#cancelled) {
+        const timeoutMs = parsePrintTimeoutMs(this.config.printTimeout);
+        let deadline = Date.now() + timeoutMs;
+        let seenRevision = poller.revision;
         while (poller.hasActiveBackgroundTasks && !this.#cancelled) {
+          if (Date.now() >= deadline) break;
           await sleep(POLL_INTERVAL_MS);
           for (const update of poller.poll()) {
             await onUpdate(update);
+          }
+          if (poller.revision !== seenRevision) {
+            seenRevision = poller.revision;
+            deadline = Date.now() + timeoutMs;
           }
         }
       }

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -699,7 +699,14 @@ export class AgyCliSession {
         let deadline = Date.now() + timeoutMs;
         let seenRevision = poller.revision;
         while (poller.hasActiveBackgroundTasks && !this.#cancelled) {
-          if (Date.now() >= deadline) break;
+          if (Date.now() >= deadline) {
+            throw new AgyCliError(
+              `agy print turn timed out after ${this.config.printTimeout} while waiting for background tasks to complete`,
+              command,
+              null,
+              Buffer.concat(stderrChunks).toString("utf8")
+            );
+          }
           await sleep(POLL_INTERVAL_MS);
           for (const update of poller.poll()) {
             await onUpdate(update);

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -165,7 +165,12 @@ export class StreamPoller {
       ) {
         this._hasBackgroundWaiting = true;
       }
-      if (row.stepType === 101 || isSystemMessage(text)) {
+      // Defer completion tracking until the lifecycle row is terminal so a
+      // still-streaming system-message envelope cannot close the wait early.
+      if (
+        (row.stepType === 101 || isSystemMessage(text)) &&
+        isTerminalStepStatus(row.status)
+      ) {
         this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
         let matchedTask = false;
         for (const taskId of this._launchedTaskIds) {
@@ -269,3 +274,9 @@ function isBackgroundWaitAgentText(text: string): boolean {
   // Slight variants still seen with task_details present.
   return /waiting for.*background|preserving context while waiting/i.test(trimmed);
 }
+
+/** status 3/6/7 — completed, cancelled/aborted, or failed. */
+function isTerminalStepStatus(status: number): boolean {
+  return status === 3 || status === 6 || status === 7;
+}
+

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -5,6 +5,7 @@
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { ConversationDb } from "./database.js";
 import { newConversationId } from "./scan.js";
+import { isSystemMessage } from "./system-message.js";
 import { toolCallId } from "./tool-call-updates.js";
 import { Translator } from "./translator.js";
 import type { StepRow } from "./types.js";
@@ -50,6 +51,11 @@ export class StreamPoller {
   private rowSnapshot = "";
   private readonly activePending = new Map<string, PendingInteraction>();
   private readonly observedUserStepIdxs = new Set<number>();
+  private _lastUserStepIdx = -1;
+  private _latestSystemMessageStepIdx = -1;
+  private _hasBackgroundWaiting = false;
+  private readonly _launchedTaskIds = new Set<string>();
+  private readonly _completedTaskIds = new Set<string>();
 
   constructor(private readonly opts: StreamOptions) {
     this.boundId = opts.conversationId;
@@ -75,6 +81,23 @@ export class StreamPoller {
   /** User-prompt rows observed during this prompt-scoped polling session. */
   get userStepIdxs(): number[] {
     return [...this.observedUserStepIdxs];
+  }
+
+  get lastUserStepIdx(): number {
+    return this._lastUserStepIdx;
+  }
+
+  get latestSystemMessageStepIdx(): number {
+    return this._latestSystemMessageStepIdx;
+  }
+
+  get hasUnansweredSystemMessage(): boolean {
+    return this._latestSystemMessageStepIdx > this._lastUserStepIdx && this._latestSystemMessageStepIdx !== -1;
+  }
+
+  get hasActiveBackgroundTasks(): boolean {
+    if (this._launchedTaskIds.size > this._completedTaskIds.size) return true;
+    return this._hasBackgroundWaiting && !this.hasUnansweredSystemMessage;
   }
 
   /** Newly observed status-9 tool calls from the most recent poll. */
@@ -117,7 +140,26 @@ export class StreamPoller {
 
     const rows = this.db.readAfter(this.opts.baseStepIdx);
     for (const row of rows) {
-      if (row.stepType === 14) this.observedUserStepIdxs.add(row.idx);
+      if (row.stepType === 14) {
+        this.observedUserStepIdxs.add(row.idx);
+        this._lastUserStepIdx = Math.max(this._lastUserStepIdx, row.idx);
+        this._hasBackgroundWaiting = false;
+      }
+      if (row.task?.taskId) {
+        this._launchedTaskIds.add(row.task.taskId);
+      }
+      const text = row.stepPayload.agentText?.text ?? "";
+      if (text && /waiting for.*background|preserving context/i.test(text)) {
+        this._hasBackgroundWaiting = true;
+      }
+      if (row.stepType === 101 || isSystemMessage(text)) {
+        this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
+        for (const taskId of this._launchedTaskIds) {
+          if (text.includes(taskId)) {
+            this._completedTaskIds.add(taskId);
+          }
+        }
+      }
     }
     if (!rows.hasDecodeError) {
       this.dataVersion = dataVersion;

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -174,7 +174,7 @@ export class StreamPoller {
         this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
         let matchedTask = false;
         for (const taskId of this._launchedTaskIds) {
-          if (taskId && text.includes(taskId)) {
+          if (taskId && textMentionsTaskId(text, taskId)) {
             this._completedTaskIds.add(taskId);
             matchedTask = true;
           }
@@ -280,3 +280,21 @@ function isTerminalStepStatus(status: number): boolean {
   return status === 3 || status === 6 || status === 7;
 }
 
+/**
+ * True when `text` contains `taskId` as a whole token (not a prefix of a longer
+ * id). Avoids `task-1` matching inside `task-10`.
+ */
+function textMentionsTaskId(text: string, taskId: string): boolean {
+  if (!taskId || !text) return false;
+  let from = 0;
+  while (from <= text.length) {
+    const index = text.indexOf(taskId, from);
+    if (index < 0) return false;
+    const before = index === 0 ? "" : text[index - 1]!;
+    const after = text[index + taskId.length] ?? "";
+    const boundary = (ch: string) => ch === "" || !/[\w-]/.test(ch);
+    if (boundary(before) && boundary(after)) return true;
+    from = index + 1;
+  }
+  return false;
+}

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -95,6 +95,12 @@ export class StreamPoller {
     return this._latestSystemMessageStepIdx > this._lastUserStepIdx && this._latestSystemMessageStepIdx !== -1;
   }
 
+  /**
+   * True while this user turn should stay open for background work.
+   * Prefer explicit task_details launch/completion tracking; fall back to the
+   * "preserving context / waiting for background" agent text plus a later
+   * system/lifecycle message. Never requires injecting a synthetic prompt.
+   */
   get hasActiveBackgroundTasks(): boolean {
     if (this._launchedTaskIds.size > this._completedTaskIds.size) return true;
     return this._hasBackgroundWaiting && !this.hasUnansweredSystemMessage;
@@ -154,8 +160,18 @@ export class StreamPoller {
       }
       if (row.stepType === 101 || isSystemMessage(text)) {
         this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
+        let matchedTask = false;
         for (const taskId of this._launchedTaskIds) {
-          if (text.includes(taskId)) {
+          if (taskId && text.includes(taskId)) {
+            this._completedTaskIds.add(taskId);
+            matchedTask = true;
+          }
+        }
+        // Lifecycle/system wake without an embedded task id (common for stop_hook
+        // type 101): close every still-pending launch so the turn cannot hang
+        // forever waiting for a match that never arrives.
+        if (!matchedTask) {
+          for (const taskId of this._launchedTaskIds) {
             this._completedTaskIds.add(taskId);
           }
         }

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -54,7 +54,8 @@ export class StreamPoller {
   private _lastUserStepIdx = -1;
   private _latestSystemMessageStepIdx = -1;
   private _hasBackgroundWaiting = false;
-  private readonly _launchedTaskIds = new Set<string>();
+  /** Launched background task id -> idx of the first row that carried it. */
+  private readonly _launchedTaskIdxs = new Map<string, number>();
   private readonly _completedTaskIds = new Set<string>();
 
   constructor(private readonly opts: StreamOptions) {
@@ -102,7 +103,7 @@ export class StreamPoller {
    * system/lifecycle message. Never requires injecting a synthetic prompt.
    */
   get hasActiveBackgroundTasks(): boolean {
-    if (this._launchedTaskIds.size > this._completedTaskIds.size) return true;
+    if (this._launchedTaskIdxs.size > this._completedTaskIds.size) return true;
     return this._hasBackgroundWaiting && !this.hasUnansweredSystemMessage;
   }
 
@@ -151,15 +152,15 @@ export class StreamPoller {
         this._lastUserStepIdx = Math.max(this._lastUserStepIdx, row.idx);
         this._hasBackgroundWaiting = false;
       }
-      if (row.task?.taskId) {
-        this._launchedTaskIds.add(row.task.taskId);
+      if (row.task?.taskId && !this._launchedTaskIdxs.has(row.task.taskId)) {
+        this._launchedTaskIdxs.set(row.task.taskId, row.idx);
       }
       const text = row.stepPayload.agentText?.text ?? "";
       // Only enter the background-wait path with corroborating task evidence.
       // A bare prose mention of "preserving context" must not pin the turn open
       // (and eventually time out) when no background task was launched.
       if (
-        this._launchedTaskIds.size > 0 &&
+        this._launchedTaskIdxs.size > 0 &&
         text &&
         isBackgroundWaitAgentText(text)
       ) {
@@ -172,8 +173,14 @@ export class StreamPoller {
         isTerminalStepStatus(row.status)
       ) {
         this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
+        // Rows are re-read on every poll, so an id-less lifecycle row observed
+        // before a later launch would otherwise close that newer task on the
+        // next revision. Only tasks launched BEFORE this row can complete here.
+        const launchedBefore = [...this._launchedTaskIdxs]
+          .filter(([, launchIdx]) => launchIdx < row.idx)
+          .map(([taskId]) => taskId);
         let matchedTask = false;
-        for (const taskId of this._launchedTaskIds) {
+        for (const taskId of launchedBefore) {
           if (taskId && textMentionsTaskId(text, taskId)) {
             this._completedTaskIds.add(taskId);
             matchedTask = true;
@@ -183,7 +190,7 @@ export class StreamPoller {
         // type 101): close every still-pending launch so the turn cannot hang
         // forever waiting for a match that never arrives.
         if (!matchedTask) {
-          for (const taskId of this._launchedTaskIds) {
+          for (const taskId of launchedBefore) {
             this._completedTaskIds.add(taskId);
           }
         }

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -155,7 +155,14 @@ export class StreamPoller {
         this._launchedTaskIds.add(row.task.taskId);
       }
       const text = row.stepPayload.agentText?.text ?? "";
-      if (text && /waiting for.*background|preserving context/i.test(text)) {
+      // Only enter the background-wait path with corroborating task evidence.
+      // A bare prose mention of "preserving context" must not pin the turn open
+      // (and eventually time out) when no background task was launched.
+      if (
+        this._launchedTaskIds.size > 0 &&
+        text &&
+        isBackgroundWaitAgentText(text)
+      ) {
         this._hasBackgroundWaiting = true;
       }
       if (row.stepType === 101 || isSystemMessage(text)) {
@@ -250,4 +257,15 @@ export class StreamPoller {
     this.db?.close();
     this.db = null;
   }
+}
+
+/** agy's known lifecycle prose when it parks a turn on a background task. */
+const BACKGROUND_WAIT_SENTINEL =
+  "Preserving context while waiting for background command output...";
+
+function isBackgroundWaitAgentText(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed === BACKGROUND_WAIT_SENTINEL) return true;
+  // Slight variants still seen with task_details present.
+  return /waiting for.*background|preserving context while waiting/i.test(trimmed);
 }

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -131,10 +131,12 @@ function titleUpdate(stepRow: StepRow): SessionUpdate[] {
 }
 
 /**
- * Step type 14 — the user's prompt/input that opened a turn. Text is wrapped
- * in `<user_text>`/`<resource_link>`/`<embedded_resource>` tags by our own
- * prompt encoder (see prompt-content.ts); unwrap them back into ACP content
- * blocks for replay.
+ * Step type 14 — the user's prompt/input that opened a turn.
+ *
+ * Live encoding (`contentBlocksToPrompt`) sends plain text plus `@path` image
+ * refs. Older tagged envelopes (`<user_text>`, `<resource_link>`,
+ * `<embedded_resource>`) are still unwrapped when present so historical
+ * conversation DBs replay cleanly; otherwise the raw text is one text block.
  */
 function userPromptUpdate(stepRow: StepRow): SessionUpdate[] {
   const up = stepRow.stepPayload.userPrompt;

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -135,9 +135,12 @@ function titleUpdate(stepRow: StepRow): SessionUpdate[] {
  *
  * Live encoding (`contentBlocksToPrompt`) forwards client text/URI/body only
  * plus agy `@path` image transport — no adapter framing prose. Older tagged
- * envelopes (`<user_text>`, `<resource_link>`, `<embedded_resource>`) are still
- * unwrapped when present so historical conversation DBs replay cleanly;
- * otherwise the raw text is one text block.
+ * envelopes (`<user_text>`, `<resource_link>`, `<embedded_resource>`) wrapped
+ * EVERY block of the prompt, so a historical row consists solely of envelope
+ * tags joined by newlines. Only unwrap when the envelopes cover the entire
+ * text; a raw prompt that merely quotes a legacy-looking tag among other
+ * prose must replay verbatim instead of being shredded into resource blocks
+ * with the surrounding text discarded.
  */
 function userPromptUpdate(stepRow: StepRow): SessionUpdate[] {
   const up = stepRow.stepPayload.userPrompt;
@@ -146,19 +149,24 @@ function userPromptUpdate(stepRow: StepRow): SessionUpdate[] {
   const blockPattern =
     /<user_text>\n([\s\S]*?)\n<\/user_text>|<resource_link uri="(.*?)" title="(.*?)"\/>|<embedded_resource uri="(.*?)">\n([\s\S]*?)\n<\/embedded_resource>/g;
 
+  const matches = [...text.matchAll(blockPattern)];
+  const isLegacyEnvelope = matches.length > 0 && text.replace(blockPattern, "").trim().length === 0;
+
   const blocks: Record<string, unknown>[] = [];
-  for (const match of text.matchAll(blockPattern)) {
-    if (match[1] !== undefined) {
-      blocks.push({ type: "text", text: match[1] });
-    } else if (match[2] !== undefined) {
-      const uri = match[2].replace(/&quot;/g, '"');
-      const title = (match[3] || "").replace(/&quot;/g, '"');
-      blocks.push({ type: "resource_link", uri, name: title, title });
-    } else if (match[4] !== undefined) {
-      blocks.push({
-        type: "resource",
-        resource: { uri: match[4].replace(/&quot;/g, '"'), text: match[5] || "" }
-      });
+  if (isLegacyEnvelope) {
+    for (const match of matches) {
+      if (match[1] !== undefined) {
+        blocks.push({ type: "text", text: match[1] });
+      } else if (match[2] !== undefined) {
+        const uri = match[2].replace(/&quot;/g, '"');
+        const title = (match[3] || "").replace(/&quot;/g, '"');
+        blocks.push({ type: "resource_link", uri, name: title, title });
+      } else if (match[4] !== undefined) {
+        blocks.push({
+          type: "resource",
+          resource: { uri: match[4].replace(/&quot;/g, '"'), text: match[5] || "" }
+        });
+      }
     }
   }
   if (blocks.length === 0) blocks.push({ type: "text", text });

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -133,10 +133,11 @@ function titleUpdate(stepRow: StepRow): SessionUpdate[] {
 /**
  * Step type 14 — the user's prompt/input that opened a turn.
  *
- * Live encoding (`contentBlocksToPrompt`) sends plain text plus `@path` image
- * refs. Older tagged envelopes (`<user_text>`, `<resource_link>`,
- * `<embedded_resource>`) are still unwrapped when present so historical
- * conversation DBs replay cleanly; otherwise the raw text is one text block.
+ * Live encoding (`contentBlocksToPrompt`) forwards client text/URI/body only
+ * plus agy `@path` image transport — no adapter framing prose. Older tagged
+ * envelopes (`<user_text>`, `<resource_link>`, `<embedded_resource>`) are still
+ * unwrapped when present so historical conversation DBs replay cleanly;
+ * otherwise the raw text is one text block.
  */
 function userPromptUpdate(stepRow: StepRow): SessionUpdate[] {
   const up = stepRow.stepPayload.userPrompt;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1477,6 +1477,43 @@ describe("cancel", () => {
     expect((await pending).stopReason).toBe("cancelled");
   });
 
+  it("fails the print-mode turn when background drain exceeds printTimeout", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-print-bg-timeout-"));
+    try {
+      const session = new AgyCliSession(
+        { ...defaultConfig(), conversationsDir: dir, printTimeout: "200ms" },
+        (command, args, options) => {
+          const db = createConversationDb(dir, "print-bg-timeout");
+          insertStep(db, {
+            idx: 1,
+            stepType: 21,
+            status: 3,
+            stepPayload: encodeStepPayload({
+              commandResult: encodeCommandResult({ command: "sleep 999 &", output: "Task task-to launched" })
+            }),
+            task: encodeTaskDetails({ taskId: "task-to", logUri: "", description: "Background task" })
+          });
+          insertStep(db, {
+            idx: 2,
+            stepType: 15,
+            status: 3,
+            stepPayload: encodeStepPayload({
+              agentText: "Preserving context while waiting for background command output..."
+            })
+          });
+          db.close();
+          return new FakeProcess([]).spawnFactory([])(command, args, options);
+        }
+      );
+
+      await expect(collectUpdates(session, "run bg")).rejects.toThrow(
+        /timed out after 200ms while waiting for background tasks/
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("cancels print-mode background drain after the child has already exited", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-print-bg-cancel-"));
     try {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -569,7 +569,7 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("maintains turn execution while background tasks are active until completed", async () => {
+  it("maintains turn execution while background tasks are active until completed (gh#68)", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-"));
     const pty = new FakePty(() => {
       const db = createConversationDb(dir, "bg-test");
@@ -588,6 +588,8 @@ describe("permission bridge", () => {
       });
       db.close();
 
+      // Fresh TUI needs two idle markers. Emit the turn-complete marker early;
+      // without hasActiveBackgroundTasks the prompt would resolve here.
       setTimeout(() => {
         pty.emitData("? for shortcuts");
         setTimeout(async () => {
@@ -601,22 +603,32 @@ describe("permission bridge", () => {
             })
           });
           db2.close();
-        }, 80);
+        }, 250);
       }, 20);
     });
 
     const session = interactiveSession(dir, pty);
     const updates: any[] = [];
-    const outcome = await session.prompt("run bg", async (update) => {
+    let resolved = false;
+    const pending = session.prompt("run bg", async (update) => {
       updates.push(update);
-    }, async () => "agy-allow-once");
+    }, async () => "agy-allow-once").then((value) => {
+      resolved = true;
+      return value;
+    });
 
+    // Idle marker has fired and "preserving context" is on disk, but the
+    // background task is still active — turn must stay open (gh#68).
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(resolved).toBe(false);
+
+    const outcome = await pending;
     expect(outcome.stopReason).toBe("end_turn");
+    expect(resolved).toBe(true);
     expect(updates.some(u => u.sessionUpdate === "agent_message_chunk" && u.content.text.includes("Preserving context"))).toBe(true);
-    // Background wait must not invent follow-up prompts (e.g. "continue").
+    // Zero prompt injection: never invent follow-ups (e.g. "continue").
     // Fresh interactive spawn puts the user prompt in argv; PTY writes stay empty.
     expect(pty.writes).toEqual([]);
-    expect(pty.writes.some((w) => /continue/i.test(w))).toBe(false);
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -569,6 +569,41 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("times out while waiting for background completion when no DB progress arrives", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-timeout-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "bg-timeout");
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          commandResult: encodeCommandResult({ command: "sleep 999 &", output: "Task task-t launched" })
+        }),
+        task: encodeTaskDetails({ taskId: "task-t", logUri: "", description: "Background task" })
+      });
+      insertStep(db, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          agentText: "Preserving context while waiting for background command output..."
+        })
+      });
+      db.close();
+      // Idle markers arrive, but no completion row — deadline must still expire.
+      setTimeout(() => pty.emitData("? for shortcuts"), 20);
+    });
+
+    const session = interactiveSession(dir, pty, "250ms");
+    await expect(
+      session.prompt("run bg", async () => {}, async () => "agy-allow-once")
+    ).rejects.toThrow(/timed out after 250ms/);
+    expect(pty.writes).toEqual([]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("maintains turn execution while background tasks are active until completed (gh#68)", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-"));
     const pty = new FakePty(() => {
@@ -1440,6 +1475,48 @@ describe("cancel", () => {
     expect(fake.killedWith).toBe("SIGINT");
     expect(session.wasCancelled).toBe(true);
     expect((await pending).stopReason).toBe("cancelled");
+  });
+
+  it("cancels print-mode background drain after the child has already exited", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-print-bg-cancel-"));
+    try {
+      const session = new AgyCliSession(
+        { ...defaultConfig(), conversationsDir: dir, printTimeout: "5s" },
+        (command, args, options) => {
+          // Child exits immediately, but background task rows remain incomplete.
+          const db = createConversationDb(dir, "print-bg-cancel");
+          insertStep(db, {
+            idx: 1,
+            stepType: 21,
+            status: 3,
+            stepPayload: encodeStepPayload({
+              commandResult: encodeCommandResult({ command: "sleep 999 &", output: "Task task-c launched" })
+            }),
+            task: encodeTaskDetails({ taskId: "task-c", logUri: "", description: "Background task" })
+          });
+          insertStep(db, {
+            idx: 2,
+            stepType: 15,
+            status: 3,
+            stepPayload: encodeStepPayload({
+              agentText: "Preserving context while waiting for background command output..."
+            })
+          });
+          db.close();
+          return new FakeProcess([]).spawnFactory([])(command, args, options);
+        }
+      );
+
+      const pending = collectUpdates(session, "run bg");
+      // Let the child exit and enter the post-exit background drain loop.
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      await session.cancel();
+
+      expect(session.wasCancelled).toBe(true);
+      expect((await pending).stopReason).toBe("cancelled");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -28,7 +28,7 @@ import {
 } from "../src/acp/tool-calls/permissions.js";
 import { requestPermissionV1, requestPermissionV2 } from "../src/acp/session/request-permission.js";
 import { createConversationDb, insertStep, updateStep } from "./fixtures/conversation-db.js";
-import { encodePermissions, encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
+import { encodeCommandResult, encodePermissions, encodeStepPayload, encodeTaskDetails, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 
 /** Collects updates via the `onUpdate` callback `AgyCliSession.prompt` takes. */
 async function collectUpdates(
@@ -565,6 +565,58 @@ describe("permission bridge", () => {
     expect(resolved).toBe(false);
     pty.emitData("? for shortcuts");
     expect((await result).stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("maintains turn execution while background tasks are active until completed", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "bg-test");
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "sleep 10 &", output: "Task task-1 launched" }) }),
+        task: encodeTaskDetails({ taskId: "task-1", logUri: "", description: "Background task" })
+      });
+      insertStep(db, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "Preserving context while waiting for background command output..." })
+      });
+      db.close();
+
+      setTimeout(() => {
+        pty.emitData("? for shortcuts");
+        setTimeout(async () => {
+          const db2 = new (await import("better-sqlite3")).default(path.join(dir, "bg-test.db"));
+          insertStep(db2, {
+            idx: 3,
+            stepType: 15,
+            status: 3,
+            stepPayload: encodeStepPayload({
+              agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-1 content=Task id "task-1" finished'
+            })
+          });
+          db2.close();
+        }, 80);
+      }, 20);
+    });
+
+    const session = interactiveSession(dir, pty);
+    const updates: any[] = [];
+    const outcome = await session.prompt("run bg", async (update) => {
+      updates.push(update);
+    }, async () => "agy-allow-once");
+
+    expect(outcome.stopReason).toBe("end_turn");
+    expect(updates.some(u => u.sessionUpdate === "agent_message_chunk" && u.content.text.includes("Preserving context"))).toBe(true);
+    // Background wait must not invent follow-up prompts (e.g. "continue").
+    // Fresh interactive spawn puts the user prompt in argv; PTY writes stay empty.
+    expect(pty.writes).toEqual([]);
+    expect(pty.writes.some((w) => /continue/i.test(w))).toBe(false);
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2121,6 +2121,49 @@ describe("StreamPoller", () => {
     poller.close();
     db.close();
   });
+
+  it("clears background wait on stop_hook type 101 even without task id in text", () => {
+    const db = createConversationDb(dir, "conv-bg-stop-hook");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "sleep 1 &", output: "launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-42", logUri: "", description: "bg" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Preserving context while waiting for background command output..."
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-stop-hook",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    insertStep(db, {
+      idx: 3,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({})
+    });
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
 });
 
 describe("ReplayCache", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2304,6 +2304,70 @@ describe("StreamPoller", () => {
     poller.close();
     db.close();
   });
+
+  it("does not close tasks launched after an id-less terminal lifecycle row", () => {
+    const db = createConversationDb(dir, "conv-bg-lifecycle-precedes-launch");
+    // Auto-proceed stop_hook with no embedded task id, written BEFORE the launch.
+    insertStep(db, {
+      idx: 1,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({})
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "sleep 10 &", output: "launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-b", logUri: "", description: "bg" })
+    });
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Preserving context while waiting for background command output..."
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-lifecycle-precedes-launch",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    // Any later revision re-reads the old id-less lifecycle row; it must not
+    // close task-b, which launched after that row was written.
+    insertStep(db, {
+      idx: 4,
+      stepType: 15,
+      status: 1,
+      stepPayload: encodeStepPayload({ agentText: "still working" })
+    });
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    // The genuine completion message still closes it.
+    insertStep(db, {
+      idx: 5,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-b content=Task id "task-b" finished'
+      })
+    });
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
 });
 
 describe("ReplayCache", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2596,3 +2596,46 @@ describe("tool call name support (gh#52)", () => {
     expect(routedUpdate).toMatchObject({ name: "run_command", kind: "execute" });
   });
 });
+
+describe("user prompt envelope replay", () => {
+  function promptUpdates(id: string, text: string): Array<Record<string, unknown>> {
+    const db = createConversationDb(dir, id);
+    insertStep(db, { idx: 1, stepType: 14, status: 3, stepPayload: encodeStepPayload({ userPrompt: text }) });
+    db.close();
+    const conn = ConversationDb.open(dir, id);
+    const rows = conn!.readAfter(-1);
+    conn!.close();
+    return sessionUpdateFromStep(rows[0]) as unknown as Array<Record<string, unknown>>;
+  }
+
+  it("unwraps a fully-tagged legacy envelope row", () => {
+    const updates = promptUpdates(
+      "conv-legacy-envelope",
+      '<user_text>\nhello\n</user_text>\n<embedded_resource uri="file:///x.ts">\nbody\n</embedded_resource>'
+    );
+    expect(updates).toEqual([
+      { sessionUpdate: "user_message_chunk", messageId: "1", content: { type: "text", text: "hello" } },
+      {
+        sessionUpdate: "user_message_chunk",
+        messageId: "1",
+        content: { type: "resource", resource: { uri: "file:///x.ts", text: "body" } }
+      }
+    ]);
+  });
+
+  it("replays verbatim a raw prompt that quotes a legacy-looking tag among other text", () => {
+    const raw = 'what does <embedded_resource uri="x">\nfoo\n</embedded_resource> do?';
+    const updates = promptUpdates("conv-raw-quoted-envelope", raw);
+    expect(updates).toEqual([
+      { sessionUpdate: "user_message_chunk", messageId: "1", content: { type: "text", text: raw } }
+    ]);
+  });
+
+  it("replays verbatim a raw prompt with an envelope-shaped prefix and trailing text", () => {
+    const raw = '<user_text>\nhello\n</user_text>\nwait, ignore that tag';
+    const updates = promptUpdates("conv-raw-envelope-prefix", raw);
+    expect(updates).toEqual([
+      { sessionUpdate: "user_message_chunk", messageId: "1", content: { type: "text", text: raw } }
+    ]);
+  });
+});

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2122,6 +2122,31 @@ describe("StreamPoller", () => {
     db.close();
   });
 
+  it("does not treat prose about preserving context as a background wait without a task", () => {
+    const db = createConversationDb(dir, "conv-bg-prose-only");
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Preserving context while waiting for background command output..."
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-prose-only",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
+
   it("clears background wait on stop_hook type 101 even without task id in text", () => {
     const db = createConversationDb(dir, "conv-bg-stop-hook");
     insertStep(db, {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -17,6 +17,7 @@ import {
   encodePermissions,
   encodeSearchHit,
   encodeStepPayload,
+  encodeTaskDetails,
   encodeToolCall,
   encodeToolRun,
   encodeUrlContentResult,
@@ -2067,6 +2068,55 @@ describe("StreamPoller", () => {
     });
     expect(poller.poll()).toHaveLength(1);
     expect(poller.turnCompleteCandidate).toBe(true);
+
+    poller.close();
+    db.close();
+  });
+
+  it("tracks background tasks as active until completion system message, without requiring a new user prompt", () => {
+    const db = createConversationDb(dir, "conv-bg-active");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "sleep 10 &", output: "Task task-9 launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-9", logUri: "", description: "bg" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Preserving context while waiting for background command output..."
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-active",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+    expect(poller.hasUnansweredSystemMessage).toBe(false);
+
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-9 content=Task id "task-9" finished'
+      })
+    });
+    const afterDone = poller.poll();
+    // SYSTEM_MESSAGE is filtered from client updates; completion is poller state only.
+    expect(afterDone.some((u) => (u as { sessionUpdate?: string }).sessionUpdate === "agent_message_chunk")).toBe(false);
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+    expect(poller.hasUnansweredSystemMessage).toBe(true);
 
     poller.close();
     db.close();

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2174,6 +2174,69 @@ describe("StreamPoller", () => {
     db.close();
   });
 
+  it("matches completed task ids with token boundaries, not prefixes", () => {
+    const db = createConversationDb(dir, "conv-bg-task-prefix");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "a &", output: "launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-1", logUri: "", description: "one" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "b &", output: "launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-10", logUri: "", description: "ten" })
+    });
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Preserving context while waiting for background command output..."
+      })
+    });
+    insertStep(db, {
+      idx: 4,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-10 content=Task id "task-10" finished'
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-task-prefix",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    // task-10 completed; task-1 must remain active (includes() would false-complete it).
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    insertStep(db, {
+      idx: 5,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-1 content=Task id "task-1" finished'
+      })
+    });
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
+
   it("does not treat prose about preserving context as a background wait without a task", () => {
     const db = createConversationDb(dir, "conv-bg-prose-only");
     insertStep(db, {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2122,6 +2122,58 @@ describe("StreamPoller", () => {
     db.close();
   });
 
+  it("does not complete launched tasks from a non-terminal system message row", () => {
+    const db = createConversationDb(dir, "conv-bg-nonterminal-sys");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "sleep 1 &", output: "launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-nt", logUri: "", description: "bg" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Preserving context while waiting for background command output..."
+      })
+    });
+    // Streaming system envelope (status still active) must not end the wait.
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 1,
+      stepPayload: encodeStepPayload({
+        agentText: "<SYSTEM_MESSAGE>\n[Message] partial"
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-nonterminal-sys",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    updateStep(db, 3, {
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-nt content=Task id "task-nt" finished'
+      })
+    });
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
+
   it("does not treat prose about preserving context as a background wait without a task", () => {
     const db = createConversationDb(dir, "conv-bg-prose-only");
     insertStep(db, {

--- a/tests/fixtures/conversation-db.ts
+++ b/tests/fixtures/conversation-db.ts
@@ -23,17 +23,19 @@ export function insertStep(
     stepPayload: Uint8Array;
     permissions?: Uint8Array;
     errorDetails?: Uint8Array;
+    task?: Uint8Array;
   }
 ): void {
   db.prepare(
-    "INSERT INTO steps (idx, step_type, status, step_payload, permissions, error_details) VALUES (?, ?, ?, ?, ?, ?)"
+    "INSERT INTO steps (idx, step_type, status, step_payload, permissions, error_details, task_details) VALUES (?, ?, ?, ?, ?, ?, ?)"
   ).run(
     row.idx,
     row.stepType,
     row.status ?? 3,
     Buffer.from(row.stepPayload),
     row.permissions ? Buffer.from(row.permissions) : null,
-    row.errorDetails ? Buffer.from(row.errorDetails) : null
+    row.errorDetails ? Buffer.from(row.errorDetails) : null,
+    row.task ? Buffer.from(row.task) : null
   );
 }
 

--- a/tests/fixtures/step-encoder.ts
+++ b/tests/fixtures/step-encoder.ts
@@ -172,6 +172,14 @@ export function encodeGrepSearchResult(result: {
   return w.finish();
 }
 
+export function encodeTaskDetails(task: { taskId?: string; logUri?: string; description?: string }): Uint8Array {
+  const w = new BinaryWriter();
+  if (task.taskId) w.tag(1, 2).string(task.taskId);
+  if (task.logUri) w.tag(2, 2).string(task.logUri);
+  if (task.description) w.tag(3, 2).string(task.description);
+  return w.finish();
+}
+
 /** permissions column: { 2: { 1: { 1: kind, 2: value }, 2: decision } }. */
 export function encodePermissions(info: { kind?: string; value?: string; decision?: number }): Uint8Array {
   const target = new BinaryWriter();

--- a/tests/prompt-content.test.ts
+++ b/tests/prompt-content.test.ts
@@ -2,11 +2,38 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { contentBlocksToPrompt } from "../src/acp/content/index.js";
+import { contentBlocksToPrompt, contentBlocksToText } from "../src/acp/content/index.js";
 
 const PNG_PIXEL = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
 
+/** Adapter must never invent conversational framing around client content. */
+const INJECTED_PROSE = [
+  /Referenced resource:/i,
+  /Resource\s+\S+:/,
+  /blob omitted/i,
+  /\[image:/i,
+  /\bcontinue\b/i,
+  /\/fast\b/i
+];
+
+function assertNoInjectedProse(prompt: string): void {
+  for (const pattern of INJECTED_PROSE) {
+    expect(prompt, `must not contain injected prose matching ${pattern}`).not.toMatch(pattern);
+  }
+}
+
 describe("contentBlocksToPrompt", () => {
+  it("passes text blocks through unmodified", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agy-acp-prompt-"));
+    try {
+      const prompt = await contentBlocksToPrompt([{ type: "text", text: "hello user" }], cwd);
+      expect(prompt).toBe("hello user");
+      assertNoInjectedProse(prompt);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("writes image blocks to the session workspace and references them for agy", async () => {
     const cwd = await mkdtemp(path.join(os.tmpdir(), "agy-acp-prompt-"));
     try {
@@ -19,6 +46,7 @@ describe("contentBlocksToPrompt", () => {
       const imagePath = prompt.split("\n")[1].slice(1);
       expect(imagePath).toContain(`${path.join(cwd, ".agy-acp", "attachments")}`);
       expect(await readFile(imagePath)).toEqual(Buffer.from(PNG_PIXEL, "base64"));
+      assertNoInjectedProse(prompt);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -37,8 +65,95 @@ describe("contentBlocksToPrompt", () => {
       ], cwd);
 
       expect(prompt).toBe(`@${path.resolve("/tmp/example.png")}`);
+      assertNoInjectedProse(prompt);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  it("forwards non-image resource_link URI without adapter framing", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agy-acp-prompt-"));
+    try {
+      const prompt = await contentBlocksToPrompt([
+        { type: "text", text: "see also" },
+        {
+          type: "resource_link",
+          uri: "file:///repo/src/main.ts",
+          name: "main.ts",
+          mimeType: "text/typescript"
+        }
+      ], cwd);
+
+      expect(prompt).toBe("see also\nfile:///repo/src/main.ts");
+      assertNoInjectedProse(prompt);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("forwards embedded resource text body without URI labels", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agy-acp-prompt-"));
+    try {
+      const prompt = await contentBlocksToPrompt([
+        { type: "text", text: "review" },
+        {
+          type: "resource",
+          resource: { uri: "file:///repo/notes.md", text: "line one\nline two", mimeType: "text/markdown" }
+        }
+      ], cwd);
+
+      expect(prompt).toBe("review\nline one\nline two");
+      assertNoInjectedProse(prompt);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("omits non-image blobs instead of inventing omission copy", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agy-acp-prompt-"));
+    try {
+      const prompt = await contentBlocksToPrompt([
+        { type: "text", text: "attach" },
+        {
+          type: "resource",
+          resource: {
+            uri: "file:///repo/data.bin",
+            blob: Buffer.from("binary").toString("base64"),
+            mimeType: "application/octet-stream"
+          }
+        }
+      ], cwd);
+
+      expect(prompt).toBe("attach");
+      assertNoInjectedProse(prompt);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("contentBlocksToText", () => {
+  it("joins client text without invented labels", () => {
+    expect(contentBlocksToText([
+      { type: "text", text: "first" },
+      { type: "text", text: "second" }
+    ])).toBe("first\nsecond");
+  });
+
+  it("uses client URI and resource body only", () => {
+    const text = contentBlocksToText([
+      {
+        type: "resource_link",
+        uri: "file:///x.ts",
+        name: "x.ts"
+      },
+      {
+        type: "resource",
+        resource: { uri: "file:///y.ts", text: "export {}", mimeType: "text/typescript" }
+      },
+      { type: "image", mimeType: "image/png", data: PNG_PIXEL }
+    ]);
+    expect(text).toBe("file:///x.ts\nexport {}");
+    assertNoInjectedProse(text);
   });
 });

--- a/tests/slash-commands.test.ts
+++ b/tests/slash-commands.test.ts
@@ -3,6 +3,7 @@ import {
   AVAILABLE_COMMANDS,
   availableCommandsUpdate,
   interpretSlashCommand,
+  isClientTextSlashPrompt,
   parseSlashCommand,
   resolveModelValue
 } from "../src/acp/slash-commands/index.js";
@@ -21,6 +22,35 @@ describe("parseSlashCommand", () => {
     expect(parseSlashCommand("hello")).toBeNull();
     expect(parseSlashCommand("/mode plan\nand more")).toBeNull();
     expect(parseSlashCommand("use /mode later")).toBeNull();
+  });
+});
+
+describe("isClientTextSlashPrompt", () => {
+  it("accepts a single non-empty text block", () => {
+    expect(isClientTextSlashPrompt([{ type: "text", text: "/plan" }])).toBe(true);
+    expect(isClientTextSlashPrompt([{ type: "text", text: "  /mode plan  " }])).toBe(true);
+  });
+
+  it("rejects resource, image, or multi-block prompts", () => {
+    expect(
+      isClientTextSlashPrompt([
+        {
+          type: "resource",
+          resource: { uri: "file:///notes.md", text: "/plan", mimeType: "text/markdown" }
+        }
+      ])
+    ).toBe(false);
+    expect(
+      isClientTextSlashPrompt([
+        { type: "text", text: "/plan" },
+        { type: "resource_link", uri: "file:///x.ts", name: "x.ts" }
+      ])
+    ).toBe(false);
+    expect(
+      isClientTextSlashPrompt([
+        { type: "image", mimeType: "image/png", data: "aa" }
+      ])
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Description

Fixes ACP turns going idle while `agy` is still waiting on background work (for example a background `run_command`). The adapter now keeps the current user turn open, polls for completion (system message / stop_hook), and only then returns `end_turn`.

Also enforces zero prompt injection: content-block encoding forwards only client-supplied text, URIs, and resource bodies (plus native `@path` image transport). No adapter-authored labels, instructions, or synthetic follow-ups such as `continue` are sent to agy.

Related hardening:
- Unmatched lifecycle/system messages close still-pending launched tasks so turns cannot hang forever.
- Print-mode background drain re-arms only on DB progress and stops after `printTimeout` of idle silence.

## Related Issues

Fixes #68

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed