### PR TITLE
Support id-based incremental plan_update ops and plan_removed

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,7 +84,7 @@ Need interactive agy control plane or client terminal protocol beyond DB polling
 
 - [x] [`name`](https://agentclientprotocol.com/rfds/tool-call-name): optional programmatic tool-call name alongside `title` / `kind` (unstable)
 - [ ] [`ContentBlock`](https://agentclientprotocol.com/protocol/v1/content): agent-outbound images / richer blocks when agy produces them
-- [ ] [`plan_update`](https://agentclientprotocol.com/rfds/plan-operations): unstable id-based plan ops (+ `plan_removed`) if a client prefers that over classic `plan`
+- [x] [`plan_update`](https://agentclientprotocol.com/rfds/plan-operations): unstable id-based plan ops (+ `plan_removed`) if a client prefers that over classic `plan`
 
 ### Lower priority / unstable ACP
 
@@ -132,7 +132,7 @@ differs or is incomplete.
 - [x] [`ContentBlock`](https://agentclientprotocol.com/protocol/v2/content): prompt caps `image`, `embeddedContext`
 - [x] [`additionalDirectories`](https://agentclientprotocol.com/rfds/additional-directories): capability advertised
 - [x] [`terminal_update`](https://agentclientprotocol.com/rfds/v2/terminal-output): agent-owned execute terminals + `type: "terminal"` embeds (DB snapshots)
-- [x] [`plan_update`](https://agentclientprotocol.com/protocol/v2/agent-plan): brain plans ([`markdown`](https://agentclientprotocol.com/rfds/v2/plan-variants) preferred, else `items`); no `plan_removed`
+- [x] [`plan_update`](https://agentclientprotocol.com/protocol/v2/agent-plan): brain plans ([`markdown`](https://agentclientprotocol.com/rfds/v2/plan-variants) preferred, else `items`); `plan_removed` supported
 - [x] [`available_commands_update`](https://agentclientprotocol.com/protocol/v2/slash-commands): same curated list + config intercept as v1
 - [x] [`terminal_output_chunk`](https://agentclientprotocol.com/rfds/v2/terminal-output): incremental output while a command is actively running
 - [x] [`tool_call_content_chunk`](https://agentclientprotocol.com/protocol/v2/schema#toolcallcontentchunk): progressive tool call output and content updates

--- a/src/acp/agent-plan/index.ts
+++ b/src/acp/agent-plan/index.ts
@@ -53,11 +53,20 @@ export function isPlanFile(targetFile: string): boolean {
 export function parsePlanEntries(markdown: string): PlanEntry[] {
   const entries: PlanEntry[] = [];
   const contentCounts = new Map<string, number>();
+  const usedIds = new Set<string>();
 
   function makeId(content: string): string {
     const count = contentCounts.get(content) ?? 0;
     contentCounts.set(content, count + 1);
-    return entryIdFromContent(content, count);
+    let occurrence = count;
+    let id = entryIdFromContent(content, occurrence);
+    // Guarantee uniqueness even under rare 32-bit hash collisions.
+    while (usedIds.has(id)) {
+      occurrence += 1;
+      id = entryIdFromContent(content, occurrence);
+    }
+    usedIds.add(id);
+    return id;
   }
 
   for (const rawLine of markdown.split(/\r?\n/)) {
@@ -160,16 +169,19 @@ function firstMeaningfulLine(markdown: string): string {
 }
 
 /**
- * Derive a stable entry ID from the entry's text content.
- * Uses a simple djb2-style hash with occurrence index tracking so duplicate
- * plan rows receive distinct IDs while preserving identity across reordering.
+ * Derive a stable entry ID from the entry's text content and occurrence index.
+ * Occurrence is mixed in as a separate hash domain (not string-concatenated
+ * onto the content) so a second `A` cannot collide with a first `A#1`.
+ * Duplicate plan rows stay distinct; reordering of unique text keeps identity.
  */
 function entryIdFromContent(content: string, occurrence = 0): string {
-  const key = occurrence > 0 ? `${content}#${occurrence}` : content;
   let hash = 5381;
-  for (let i = 0; i < key.length; i++) {
-    hash = ((hash << 5) + hash + key.charCodeAt(i)) | 0;
+  for (let i = 0; i < content.length; i++) {
+    hash = ((hash << 5) + hash + content.charCodeAt(i)) | 0;
   }
+  // Domain separator + occurrence so content never collides with a synthetic key.
+  hash = ((hash << 5) + hash + 0) | 0;
+  hash = ((hash << 5) + hash + occurrence) | 0;
   // Convert to unsigned hex for a short, URL-safe id.
   return `entry_${(hash >>> 0).toString(16)}`;
 }

--- a/src/acp/agent-plan/index.ts
+++ b/src/acp/agent-plan/index.ts
@@ -115,9 +115,66 @@ export function parsePlanEntries(markdown: string): PlanEntry[] {
   ];
 }
 
+/**
+ * Reconcile freshly parsed entries against the previous snapshot of the same
+ * plan so entry IDs preserve task identity across successive list edits.
+ * Occurrence-based IDs alone reshuffle when a duplicate task is inserted
+ * before an existing one (the new row steals the old row's ID, and an ID-keyed
+ * client reads that as reverting the old task and appending a new one).
+ *
+ * Matching runs most-specific first:
+ *   1. same content AND same status — a status-stable duplicate keeps its ID
+ *      even when an identical task is inserted before it;
+ *   2. same content, any status — a checkbox flip keeps the entry's ID.
+ * Rows with no previous counterpart get a fresh content-hash ID, bumped until
+ * unique against every ID already claimed in this snapshot.
+ */
+export function reconcilePlanEntryIds(
+  previous: readonly PlanEntry[] | undefined,
+  next: PlanEntry[]
+): PlanEntry[] {
+  if (!previous || previous.length === 0) return next;
+
+  const remaining = previous.filter((p) => typeof p.id === "string" && p.id.length > 0);
+  const unmatched = new Set(next);
+
+  const claim = (entry: PlanEntry, withStatus: boolean): void => {
+    const idx = remaining.findIndex(
+      (p) => p.content === entry.content && (!withStatus || p.status === entry.status)
+    );
+    if (idx === -1) return;
+    const [matched] = remaining.splice(idx, 1);
+    entry.id = matched.id;
+    unmatched.delete(entry);
+  };
+
+  for (const entry of [...unmatched]) claim(entry, true);
+  for (const entry of [...unmatched]) claim(entry, false);
+
+  // Fresh rows: re-derive IDs so a claimed duplicate's original occurrence
+  // hash cannot collide with a new row's.
+  const used = new Set(next.filter((e) => !unmatched.has(e)).map((e) => e.id as string));
+  for (const entry of next) {
+    if (!unmatched.has(entry)) continue;
+    let occurrence = 0;
+    let id = entryIdFromContent(entry.content, occurrence);
+    while (used.has(id)) {
+      occurrence += 1;
+      id = entryIdFromContent(entry.content, occurrence);
+    }
+    entry.id = id;
+    used.add(id);
+  }
+  return next;
+}
+
 /** Build a classic ACP v1 `plan` session update from plan markdown. */
-export function planUpdateFromMarkdown(targetFile: string, markdown: string): SessionUpdate {
-  const entries = parsePlanEntries(markdown);
+export function planUpdateFromMarkdown(
+  targetFile: string,
+  markdown: string,
+  previous?: readonly PlanEntry[]
+): SessionUpdate {
+  const entries = reconcilePlanEntryIds(previous, parsePlanEntries(markdown));
   // Stash path for v2 planId mapping / progressive snapshot keys without
   // inventing a non-schema field on the wire — clients ignore unknown keys? 
   // Actually ACP forbids assumptions on unknown keys but _meta is reserved.

--- a/src/acp/agent-plan/index.ts
+++ b/src/acp/agent-plan/index.ts
@@ -52,6 +52,13 @@ export function isPlanFile(targetFile: string): boolean {
  */
 export function parsePlanEntries(markdown: string): PlanEntry[] {
   const entries: PlanEntry[] = [];
+  const contentCounts = new Map<string, number>();
+
+  function makeId(content: string): string {
+    const count = contentCounts.get(content) ?? 0;
+    contentCounts.set(content, count + 1);
+    return entryIdFromContent(content, count);
+  }
 
   for (const rawLine of markdown.split(/\r?\n/)) {
     const line = rawLine.replace(/\s+$/, "");
@@ -62,7 +69,7 @@ export function parsePlanEntries(markdown: string): PlanEntry[] {
       const content = checkbox[2].trim();
       if (!content) continue;
       entries.push({
-        id: entryIdFromContent(content),
+        id: makeId(content),
         content,
         priority: defaultPriority(entries.length),
         status: checkboxStatus(checkbox[1])
@@ -78,7 +85,7 @@ export function parsePlanEntries(markdown: string): PlanEntry[] {
       // Ignore list markers that are really horizontal rules / separators.
       if (/^[-*_]{3,}$/.test(content)) continue;
       entries.push({
-        id: entryIdFromContent(content),
+        id: makeId(content),
         content,
         priority: defaultPriority(entries.length),
         status: "pending"
@@ -91,7 +98,7 @@ export function parsePlanEntries(markdown: string): PlanEntry[] {
   const fallback = firstMeaningfulLine(markdown);
   return [
     {
-      id: entryIdFromContent(fallback),
+      id: makeId(fallback),
       content: fallback,
       priority: "medium",
       status: "pending"
@@ -154,13 +161,14 @@ function firstMeaningfulLine(markdown: string): string {
 
 /**
  * Derive a stable entry ID from the entry's text content.
- * Uses a simple djb2-style hash so that entries keep their identity
- * across insertions, removals, and reordering in the plan markdown.
+ * Uses a simple djb2-style hash with occurrence index tracking so duplicate
+ * plan rows receive distinct IDs while preserving identity across reordering.
  */
-function entryIdFromContent(content: string): string {
+function entryIdFromContent(content: string, occurrence = 0): string {
+  const key = occurrence > 0 ? `${content}#${occurrence}` : content;
   let hash = 5381;
-  for (let i = 0; i < content.length; i++) {
-    hash = ((hash << 5) + hash + content.charCodeAt(i)) | 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = ((hash << 5) + hash + key.charCodeAt(i)) | 0;
   }
   // Convert to unsigned hex for a short, URL-safe id.
   return `entry_${(hash >>> 0).toString(16)}`;

--- a/src/acp/agent-plan/index.ts
+++ b/src/acp/agent-plan/index.ts
@@ -62,7 +62,7 @@ export function parsePlanEntries(markdown: string): PlanEntry[] {
       const content = checkbox[2].trim();
       if (!content) continue;
       entries.push({
-        id: `entry_${entries.length + 1}`,
+        id: entryIdFromContent(content),
         content,
         priority: defaultPriority(entries.length),
         status: checkboxStatus(checkbox[1])
@@ -78,7 +78,7 @@ export function parsePlanEntries(markdown: string): PlanEntry[] {
       // Ignore list markers that are really horizontal rules / separators.
       if (/^[-*_]{3,}$/.test(content)) continue;
       entries.push({
-        id: `entry_${entries.length + 1}`,
+        id: entryIdFromContent(content),
         content,
         priority: defaultPriority(entries.length),
         status: "pending"
@@ -91,7 +91,7 @@ export function parsePlanEntries(markdown: string): PlanEntry[] {
   const fallback = firstMeaningfulLine(markdown);
   return [
     {
-      id: "entry_1",
+      id: entryIdFromContent(fallback),
       content: fallback,
       priority: "medium",
       status: "pending"
@@ -150,4 +150,18 @@ function firstMeaningfulLine(markdown: string): string {
     if (withoutHeading) return withoutHeading.slice(0, 500);
   }
   return "Plan";
+}
+
+/**
+ * Derive a stable entry ID from the entry's text content.
+ * Uses a simple djb2-style hash so that entries keep their identity
+ * across insertions, removals, and reordering in the plan markdown.
+ */
+function entryIdFromContent(content: string): string {
+  let hash = 5381;
+  for (let i = 0; i < content.length; i++) {
+    hash = ((hash << 5) + hash + content.charCodeAt(i)) | 0;
+  }
+  // Convert to unsigned hex for a short, URL-safe id.
+  return `entry_${(hash >>> 0).toString(16)}`;
 }

--- a/src/acp/agent-plan/index.ts
+++ b/src/acp/agent-plan/index.ts
@@ -10,7 +10,9 @@
 // no live task-progress channel from agy, so in-progress/completed only update
 // when the plan file itself is rewritten with new markers.
 
-import type { PlanEntry, PlanEntryPriority, PlanEntryStatus, SessionUpdate } from "@agentclientprotocol/sdk";
+import type { PlanEntry as ACPPlanEntry, PlanEntryPriority, PlanEntryStatus, SessionUpdate } from "@agentclientprotocol/sdk";
+
+export type PlanEntry = ACPPlanEntry & { id?: string };
 
 /** Stable plan id derived from the absolute brain file path. */
 export function planIdForPath(targetFile: string): string {
@@ -60,6 +62,7 @@ export function parsePlanEntries(markdown: string): PlanEntry[] {
       const content = checkbox[2].trim();
       if (!content) continue;
       entries.push({
+        id: `entry_${entries.length + 1}`,
         content,
         priority: defaultPriority(entries.length),
         status: checkboxStatus(checkbox[1])
@@ -75,6 +78,7 @@ export function parsePlanEntries(markdown: string): PlanEntry[] {
       // Ignore list markers that are really horizontal rules / separators.
       if (/^[-*_]{3,}$/.test(content)) continue;
       entries.push({
+        id: `entry_${entries.length + 1}`,
         content,
         priority: defaultPriority(entries.length),
         status: "pending"
@@ -87,6 +91,7 @@ export function parsePlanEntries(markdown: string): PlanEntry[] {
   const fallback = firstMeaningfulLine(markdown);
   return [
     {
+      id: "entry_1",
       content: fallback,
       priority: "medium",
       status: "pending"
@@ -108,6 +113,18 @@ export function planUpdateFromMarkdown(targetFile: string, markdown: string): Se
       "agy-acp/planId": planIdForPath(targetFile),
       "agy-acp/planPath": targetFile,
       "agy-acp/planMarkdown": markdown
+    }
+  } as SessionUpdate;
+}
+
+/** Build an ACP `plan_removed` session update when plan artifact is cleared/deleted. */
+export function planRemovedFromPath(targetFile: string): SessionUpdate {
+  return {
+    sessionUpdate: "plan_removed",
+    planId: planIdForPath(targetFile),
+    _meta: {
+      "agy-acp/planId": planIdForPath(targetFile),
+      "agy-acp/planPath": targetFile
     }
   } as SessionUpdate;
 }

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -251,6 +251,14 @@ export function sessionUpdateToV1(
     const { _meta: _drop, ...rest } = raw;
     return rest as V1SessionUpdate;
   }
+  // plan_removed is v2-only; v1 clients don't support it.
+  // Translate to an empty plan update so v1 clients clear their plan UI.
+  if (raw.sessionUpdate === "plan_removed") {
+    return {
+      sessionUpdate: "plan",
+      entries: []
+    } as V1SessionUpdate;
+  }
   return update;
 }
 
@@ -334,14 +342,16 @@ function planToV2(raw: Record<string, unknown>): V2SessionUpdate {
   const entries = Array.isArray(raw.entries) ? raw.entries : [];
 
   // Prefer markdown when available (full fidelity of the brain artifact);
-  // otherwise fall back to item entries from the classic plan shape.
+  // also include entries with stable IDs so clients that want incremental
+  // reconciliation can use them.
   if (markdown !== null && markdown.length > 0) {
     return {
       sessionUpdate: "plan_update",
       plan: {
         type: "markdown",
         planId,
-        content: markdown
+        content: markdown,
+        entries
       }
     } as V2SessionUpdate;
   }

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -302,10 +302,22 @@ export function sessionUpdateToV2(
     return raw as V2SessionUpdate;
   }
 
-  // Classic v1 `plan` → draft v2 `plan_update` with structured items.
+  // Classic v1 `plan` / `plan_update` → draft v2 `plan_update` with structured items or markdown.
   // Prefer markdown content when the translator stashed it in _meta.
-  if (raw.sessionUpdate === "plan") {
+  if (raw.sessionUpdate === "plan" || (raw.sessionUpdate === "plan_update" && !raw.plan)) {
     return planToV2(raw);
+  }
+
+  if (raw.sessionUpdate === "plan_removed") {
+    const meta = asRecord(raw._meta);
+    const planId =
+      (typeof raw.planId === "string" && raw.planId) ||
+      (typeof meta?.["agy-acp/planId"] === "string" && meta["agy-acp/planId"]) ||
+      "agy-plan";
+    return {
+      sessionUpdate: "plan_removed",
+      planId
+    } as V2SessionUpdate;
   }
 
   return raw as V2SessionUpdate;

--- a/src/acp/session/update-wire.ts
+++ b/src/acp/session/update-wire.ts
@@ -341,17 +341,27 @@ function planToV2(raw: Record<string, unknown>): V2SessionUpdate {
     typeof meta?.["agy-acp/planMarkdown"] === "string" ? meta["agy-acp/planMarkdown"] : null;
   const entries = Array.isArray(raw.entries) ? raw.entries : [];
 
-  // Prefer markdown when available (full fidelity of the brain artifact);
-  // also include entries with stable IDs so clients that want incremental
-  // reconciliation can use them.
+  // When structured entries with IDs are available, emit the schema-defined
+  // `items` variant so v2 clients receive entry IDs.
+  if (entries.length > 0) {
+    return {
+      sessionUpdate: "plan_update",
+      plan: {
+        type: "items",
+        planId,
+        entries
+      }
+    } as V2SessionUpdate;
+  }
+
+  // Fall back to markdown variant when no structured entries exist.
   if (markdown !== null && markdown.length > 0) {
     return {
       sessionUpdate: "plan_update",
       plan: {
         type: "markdown",
         planId,
-        content: markdown,
-        entries
+        content: markdown
       }
     } as V2SessionUpdate;
   }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -580,8 +580,12 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   const fullContent = asStr(pick(rawInput, "CodeContent", "codeContent"));
 
   // Brain plan artifacts → structured plan session update (v1 `plan` / v2 plan_update / plan_removed).
-  if (isPlanFile(targetFile)) {
-    if (fullContent === null || fullContent.trim().length === 0) {
+  // Only write_to_file carries CodeContent; replace/multi_replace carry ReplacementChunks instead.
+  // When CodeContent is present but empty, the plan was cleared → emit plan_removed.
+  // When CodeContent is null, this is a partial edit (replace_file_content) → fall through to
+  // the normal edit handler; the plan file itself still exists.
+  if (isPlanFile(targetFile) && fullContent !== null) {
+    if (fullContent.trim().length === 0) {
       return planRemovedFromPath(targetFile);
     }
     return planUpdateFromMarkdown(targetFile, fullContent);

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -630,9 +630,9 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
 
   // Brain plan artifacts → structured plan session update (v1 `plan` / v2 plan_update / plan_removed).
   // Only write_to_file carries CodeContent; replace/multi_replace carry ReplacementChunks instead.
-  // Replacement-derived plan bodies (and cache writes) only apply after status completed so a
-  // denied/failed replace cannot overwrite the live plan or poison the content cache.
-  // write_to_file still publishes requested CodeContent immediately (requested full body).
+  // Cache writes only after status completed so denied/failed edits cannot poison later replace
+  // derivation. Replacement-derived plan bodies also require completed. write_to_file still
+  // publishes requested CodeContent immediately (requested full body) without caching until done.
   // Empty body + completed write/replace → plan_removed; incomplete empty edits fall through.
   if (isPlanFile(targetFile)) {
     const isReplaceEdit = fullContent === null;
@@ -651,7 +651,10 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
         }
         // Incomplete/failed empty edit: preserve tool_call lifecycle, do not remove plan.
       } else if (!isReplaceEdit || status === "completed") {
-        fileContents?.set(path.resolve(resolvedTarget), planBody);
+        // Only successful writes update the content cache used by later replace derivation.
+        if (status === "completed") {
+          fileContents?.set(path.resolve(resolvedTarget), planBody);
+        }
         return planUpdateFromMarkdown(targetFile, planBody);
       }
       // Incomplete/failed replace with a nonempty speculative body: keep tool lifecycle.
@@ -675,7 +678,10 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
       const cacheKey = path.resolve(resolvedTarget);
       const prior = fileContents?.get(cacheKey) ?? null;
       content.push({ type: "diff", path: targetFile, oldText: prior, newText: fullContent });
-      fileContents?.set(cacheKey, fullContent);
+      // Plan-file incomplete writes must not poison the cache used by replace derivation.
+      if (!isPlanFile(targetFile) || status === "completed") {
+        fileContents?.set(cacheKey, fullContent);
+      }
       if (isReadableLocation(resolvedTarget, ctx)) locations.push({ path: resolvedTarget });
     }
   } else {

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { SessionUpdate, ToolKind } from "@agentclientprotocol/sdk";
 import type { ErrorDetails, PermissionInfo, TaskDetails } from "./columns.js";
-import { isPlanFile, planUpdateFromMarkdown } from "../../acp/agent-plan/index.js";
+import { isPlanFile, planRemovedFromPath, planUpdateFromMarkdown } from "../../acp/agent-plan/index.js";
 import type { SearchHit } from "./step-payload.js";
 import type { StepRow } from "./types.js";
 
@@ -579,9 +579,11 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   const resolvedTarget = resolvePath(targetFile, displayCwd) ?? targetFile;
   const fullContent = asStr(pick(rawInput, "CodeContent", "codeContent"));
 
-  // Brain plan artifacts → structured plan session update (v1 `plan` / v2 plan_update).
+  // Brain plan artifacts → structured plan session update (v1 `plan` / v2 plan_update / plan_removed).
   if (isPlanFile(targetFile)) {
-    if (fullContent === null || fullContent.length === 0) return [];
+    if (fullContent === null || fullContent.trim().length === 0) {
+      return planRemovedFromPath(targetFile);
+    }
     return planUpdateFromMarkdown(targetFile, fullContent);
   }
 

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -7,7 +7,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { SessionUpdate, ToolKind } from "@agentclientprotocol/sdk";
 import type { ErrorDetails, PermissionInfo, TaskDetails } from "./columns.js";
-import { isPlanFile, planRemovedFromPath, planUpdateFromMarkdown } from "../../acp/agent-plan/index.js";
+import {
+  isPlanFile,
+  planIdForPath,
+  planRemovedFromPath,
+  planUpdateFromMarkdown,
+  type PlanEntry
+} from "../../acp/agent-plan/index.js";
 import type { SearchHit } from "./step-payload.js";
 import type { StepRow } from "./types.js";
 
@@ -19,6 +25,8 @@ export interface UpdateContext {
   cwd?: string;
   /** Prior file contents for full-file write diffs. */
   fileContents?: FileContentCache;
+  /** Plan id -> entries of the previous plan snapshot (stable entry-id reconciliation). */
+  planEntries?: Map<string, PlanEntry[]>;
   /** Candidate location path -> readability observed while translating. */
   locationReadability?: Map<string, boolean>;
 }
@@ -644,9 +652,12 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
     }
 
     if (planBody !== null) {
+      const planId = planIdForPath(targetFile);
       if (planBody.trim().length === 0) {
         if (status === "completed") {
           fileContents?.set(path.resolve(resolvedTarget), planBody);
+          // Removal ends the plan's entry-id lineage; a re-created plan starts fresh.
+          ctx?.planEntries?.delete(planId);
           return planRemovedFromPath(targetFile);
         }
         // Incomplete/failed empty edit: preserve tool_call lifecycle, do not remove plan.
@@ -655,7 +666,11 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
         if (status === "completed") {
           fileContents?.set(path.resolve(resolvedTarget), planBody);
         }
-        return planUpdateFromMarkdown(targetFile, planBody);
+        // Reconcile entry ids against the previous snapshot so duplicate-row
+        // inserts/reorders do not reshuffle ids of surviving tasks.
+        const update = planUpdateFromMarkdown(targetFile, planBody, ctx?.planEntries?.get(planId));
+        ctx?.planEntries?.set(planId, (update as unknown as { entries: PlanEntry[] }).entries);
+        return update;
       }
       // Incomplete/failed replace with a nonempty speculative body: keep tool lifecycle.
     }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -630,11 +630,14 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
 
   // Brain plan artifacts → structured plan session update (v1 `plan` / v2 plan_update / plan_removed).
   // Only write_to_file carries CodeContent; replace/multi_replace carry ReplacementChunks instead.
-  // Empty body + completed write/replace → plan_removed. Pending/failed/cancelled empty edits must
-  // not discard an existing plan; fall through to the normal edit tool lifecycle instead.
+  // Replacement-derived plan bodies (and cache writes) only apply after status completed so a
+  // denied/failed replace cannot overwrite the live plan or poison the content cache.
+  // write_to_file still publishes requested CodeContent immediately (requested full body).
+  // Empty body + completed write/replace → plan_removed; incomplete empty edits fall through.
   if (isPlanFile(targetFile)) {
+    const isReplaceEdit = fullContent === null;
     let planBody: string | null = null;
-    if (fullContent !== null) {
+    if (!isReplaceEdit) {
       planBody = fullContent;
     } else {
       planBody = planBodyAfterReplacementEdits(stepRow, resolvedTarget, fileContents, rawInput);
@@ -647,10 +650,11 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
           return planRemovedFromPath(targetFile);
         }
         // Incomplete/failed empty edit: preserve tool_call lifecycle, do not remove plan.
-      } else {
+      } else if (!isReplaceEdit || status === "completed") {
         fileContents?.set(path.resolve(resolvedTarget), planBody);
         return planUpdateFromMarkdown(targetFile, planBody);
       }
+      // Incomplete/failed replace with a nonempty speculative body: keep tool lifecycle.
     }
   }
 

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -581,14 +581,20 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
 
   // Brain plan artifacts → structured plan session update (v1 `plan` / v2 plan_update / plan_removed).
   // Only write_to_file carries CodeContent; replace/multi_replace carry ReplacementChunks instead.
-  // When CodeContent is present but empty, the plan was cleared → emit plan_removed.
+  // When CodeContent is present but empty *and* the write completed successfully, the plan was
+  // cleared → emit plan_removed. Pending (status 9), failed, or cancelled empty writes must not
+  // discard an existing plan; fall through to the normal edit tool lifecycle instead.
   // When CodeContent is null, this is a partial edit (replace_file_content) → fall through to
   // the normal edit handler; the plan file itself still exists.
   if (isPlanFile(targetFile) && fullContent !== null) {
     if (fullContent.trim().length === 0) {
-      return planRemovedFromPath(targetFile);
+      if (toolCallStatus(stepRow) === "completed") {
+        return planRemovedFromPath(targetFile);
+      }
+      // Incomplete/failed empty write: preserve tool_call lifecycle, do not remove plan.
+    } else {
+      return planUpdateFromMarkdown(targetFile, fullContent);
     }
-    return planUpdateFromMarkdown(targetFile, fullContent);
   }
 
   const shown = targetFile ? toDisplayPath(targetFile, displayCwd) : "";

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -652,13 +652,16 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
     }
 
     if (planBody !== null) {
-      const planId = planIdForPath(targetFile);
+      // Derive plan identity from the normalized absolute path so relative and
+      // absolute references to the same artifact share one plan id (and one
+      // entry-id lineage) instead of splitting into divergent plans.
+      const planId = planIdForPath(resolvedTarget);
       if (planBody.trim().length === 0) {
         if (status === "completed") {
           fileContents?.set(path.resolve(resolvedTarget), planBody);
           // Removal ends the plan's entry-id lineage; a re-created plan starts fresh.
           ctx?.planEntries?.delete(planId);
-          return planRemovedFromPath(targetFile);
+          return planRemovedFromPath(resolvedTarget);
         }
         // Incomplete/failed empty edit: preserve tool_call lifecycle, do not remove plan.
       } else if (!isReplaceEdit || status === "completed") {
@@ -668,7 +671,7 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
         }
         // Reconcile entry ids against the previous snapshot so duplicate-row
         // inserts/reorders do not reshuffle ids of surviving tasks.
-        const update = planUpdateFromMarkdown(targetFile, planBody, ctx?.planEntries?.get(planId));
+        const update = planUpdateFromMarkdown(resolvedTarget, planBody, ctx?.planEntries?.get(planId));
         ctx?.planEntries?.set(planId, (update as unknown as { entries: PlanEntry[] }).entries);
         return update;
       }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -566,6 +566,54 @@ export function fetchUpdate(stepRow: StepRow): SessionUpdate {
   return update;
 }
 
+/**
+ * Apply replace/multi_replace chunks to a prior plan body (first-occurrence
+ * replacements, matching agy replace_file_content semantics).
+ */
+function applyReplacementChunks(prior: string, chunks: unknown[]): string | null {
+  let body = prior;
+  for (const chunk of chunks) {
+    const newText = asStr(pick(chunk, "ReplacementContent", "replacementContent"));
+    if (newText === null) return null;
+    const oldText = asStr(pick(chunk, "TargetContent", "targetContent"));
+    if (oldText === null) return null;
+    const idx = body.indexOf(oldText);
+    if (idx === -1) return null;
+    body = body.slice(0, idx) + newText + body.slice(idx + oldText.length);
+  }
+  return body;
+}
+
+/** Best-effort post-edit plan body for replace_file_content / multi_replace. */
+function planBodyAfterReplacementEdits(
+  stepRow: StepRow,
+  resolvedTarget: string,
+  fileContents: FileContentCache | undefined,
+  rawInput: unknown
+): string | null {
+  const chunksRaw = pick(rawInput, "ReplacementChunks", "replacementChunks");
+  const chunks = Array.isArray(chunksRaw) ? chunksRaw : [rawInput];
+  const cacheKey = path.resolve(resolvedTarget);
+  const prior = fileContents?.get(cacheKey);
+
+  if (prior !== undefined) {
+    const applied = applyReplacementChunks(prior, chunks);
+    if (applied !== null) return applied;
+  }
+
+  // Completed replaces: on-disk artifact is the source of truth after agy applies the edit.
+  if (toolCallStatus(stepRow) === "completed") {
+    try {
+      if (fs.existsSync(resolvedTarget) && fs.statSync(resolvedTarget).isFile()) {
+        return fs.readFileSync(resolvedTarget, "utf8");
+      }
+    } catch {
+      // ignore unreadable paths
+    }
+  }
+  return null;
+}
+
 /** Step type 5 (write_to_file|replace_file_content|multi_replace_file_content),
  *  and step 17 artifact writes (e.g. a generated `plan.md` for user review).
  *  Brain plan markdown becomes a structured ACP `plan` update (not an edit tool). */
@@ -578,22 +626,31 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
   const targetFile = fsPath(asStr(pick(rawInput, "TargetFile", "targetFile"))) ?? "";
   const resolvedTarget = resolvePath(targetFile, displayCwd) ?? targetFile;
   const fullContent = asStr(pick(rawInput, "CodeContent", "codeContent"));
+  const status = toolCallStatus(stepRow);
 
   // Brain plan artifacts → structured plan session update (v1 `plan` / v2 plan_update / plan_removed).
   // Only write_to_file carries CodeContent; replace/multi_replace carry ReplacementChunks instead.
-  // When CodeContent is present but empty *and* the write completed successfully, the plan was
-  // cleared → emit plan_removed. Pending (status 9), failed, or cancelled empty writes must not
-  // discard an existing plan; fall through to the normal edit tool lifecycle instead.
-  // When CodeContent is null, this is a partial edit (replace_file_content) → fall through to
-  // the normal edit handler; the plan file itself still exists.
-  if (isPlanFile(targetFile) && fullContent !== null) {
-    if (fullContent.trim().length === 0) {
-      if (toolCallStatus(stepRow) === "completed") {
-        return planRemovedFromPath(targetFile);
-      }
-      // Incomplete/failed empty write: preserve tool_call lifecycle, do not remove plan.
+  // Empty body + completed write/replace → plan_removed. Pending/failed/cancelled empty edits must
+  // not discard an existing plan; fall through to the normal edit tool lifecycle instead.
+  if (isPlanFile(targetFile)) {
+    let planBody: string | null = null;
+    if (fullContent !== null) {
+      planBody = fullContent;
     } else {
-      return planUpdateFromMarkdown(targetFile, fullContent);
+      planBody = planBodyAfterReplacementEdits(stepRow, resolvedTarget, fileContents, rawInput);
+    }
+
+    if (planBody !== null) {
+      if (planBody.trim().length === 0) {
+        if (status === "completed") {
+          fileContents?.set(path.resolve(resolvedTarget), planBody);
+          return planRemovedFromPath(targetFile);
+        }
+        // Incomplete/failed empty edit: preserve tool_call lifecycle, do not remove plan.
+      } else {
+        fileContents?.set(path.resolve(resolvedTarget), planBody);
+        return planUpdateFromMarkdown(targetFile, planBody);
+      }
     }
   }
 

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -15,6 +15,7 @@
 // inside it.
 
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import type { PlanEntry } from "../../acp/agent-plan/index.js";
 import { filterNarration, isNarration } from "./narration.js";
 import { isSystemMessage, isSystemMessagePrefix } from "./system-message.js";
 import type { FileContentCache } from "./tool-call-updates.js";
@@ -97,6 +98,8 @@ export class Translator {
   private readonly toolSnapshots = new Map<string, string>();
   // Stream + replay: last known file bodies from view_file / write_to_file (for diffs).
   private readonly fileContents: FileContentCache = new Map();
+  // Stream + replay: previous plan entries keyed by plan id (stable entry-id reconciliation).
+  private readonly planEntries: Map<string, PlanEntry[]> = new Map();
   // Candidate ACP location paths and their readability during the latest translation.
   readonly locationReadability = new Map<string, boolean>();
   // Replay: buffered consecutive agent-text parts, flushed at boundaries.
@@ -194,6 +197,7 @@ export class Translator {
     const update = sessionUpdateFromStep(row, {
       cwd: this.opts.cwd,
       fileContents: this.fileContents,
+      planEntries: this.planEntries,
       locationReadability: this.locationReadability
     });
     if (Array.isArray(update)) {

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -94,7 +94,8 @@ export class Translator {
   private readonly thoughtTextLengths = new Map<string, number>();
   // Stream + replay: final provider-error messages already emitted.
   private readonly emittedProviderErrorMessageIds = new Set<string>();
-  // Stream + replay: last emitted snapshot keyed by tool call id / plan id (tool progressive lifecycle).
+  // Stream + replay: last emitted snapshot keyed by tool call id, or by plan id
+  // + source row for plans (progressive lifecycle without cross-row replay).
   private readonly toolSnapshots = new Map<string, string>();
   // Stream + replay: last known file bodies from view_file / write_to_file (for diffs).
   private readonly fileContents: FileContentCache = new Map();
@@ -234,7 +235,10 @@ export class Translator {
         (typeof raw.planId === "string" && raw.planId) ||
         (typeof meta?.["agy-acp/planId"] === "string" && (meta["agy-acp/planId"] as string)) ||
         undefined;
-      const key = planId ? `plan:${planId}` : `plan:${stepIdx}`;
+      // Scope dedupe to the source row: StreamPoller rereads all rows since the
+      // turn began on every DB change, so a plan-level shared key would replay
+      // each historical state (rollback) whenever a later row changes.
+      const key = planId ? `plan:${planId}:${stepIdx}` : `plan:${stepIdx}`;
       const previous = this.toolSnapshots.get(key);
       if (previous === snapshot) return;
       this.toolSnapshots.set(key, snapshot);

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -225,7 +225,12 @@ export class Translator {
 
     if (kind === "plan" || kind === "plan_update" || kind === "plan_removed") {
       const snapshot = updateSnapshot(stamped);
-      const key = typeof raw.planId === "string" && raw.planId ? `plan:${raw.planId}` : `plan:${stepIdx}`;
+      const meta = raw._meta && typeof raw._meta === "object" ? (raw._meta as Record<string, unknown>) : null;
+      const planId =
+        (typeof raw.planId === "string" && raw.planId) ||
+        (typeof meta?.["agy-acp/planId"] === "string" && (meta["agy-acp/planId"] as string)) ||
+        undefined;
+      const key = planId ? `plan:${planId}` : `plan:${stepIdx}`;
       const previous = this.toolSnapshots.get(key);
       if (previous === snapshot) return;
       this.toolSnapshots.set(key, snapshot);

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1600,20 +1600,42 @@ describe("ACP v2 (experimental draft)", () => {
 
     const v2Update = sessionUpdateToV2(update) as Record<string, unknown>;
     expect(v2Update.sessionUpdate).toBe("plan_update");
-    const plan = v2Update.plan as Record<string, unknown>;
-    expect(plan.type).toBe("markdown");
-    expect(plan.planId).toBe("file:/tmp/brain/plan.md");
-    expect(plan.content).toBe(markdown);
-    // Entries with IDs are included alongside markdown for incremental reconciliation
-    expect(plan.entries).toEqual([
-      { content: "One", priority: "high", status: "pending" },
-      { content: "Two", priority: "high", status: "completed" }
-    ]);
+    expect(v2Update.plan).toEqual({
+      type: "items",
+      planId: "file:/tmp/brain/plan.md",
+      entries: [
+        { content: "One", priority: "high", status: "pending" },
+        { content: "Two", priority: "high", status: "completed" }
+      ]
+    });
 
     const v1Wire = sessionUpdateToV1(update) as Record<string, unknown>;
     expect(v1Wire.sessionUpdate).toBe("plan");
     expect(v1Wire.entries).toHaveLength(2);
     expect(v1Wire._meta).toBeUndefined();
+  });
+
+  it("maps classic plan to v2 plan_update markdown when entries is empty", () => {
+    const markdown = "# Plan\n\nNo items\n";
+    const update = {
+      sessionUpdate: "plan",
+      entries: [],
+      _meta: {
+        "agy-acp/planId": "file:/tmp/brain/plan.md",
+        "agy-acp/planPath": "/tmp/brain/plan.md",
+        "agy-acp/planMarkdown": markdown
+      }
+    } as SessionUpdate;
+
+    const v2Update = sessionUpdateToV2(update) as Record<string, unknown>;
+    expect(v2Update).toEqual({
+      sessionUpdate: "plan_update",
+      plan: {
+        type: "markdown",
+        planId: "file:/tmp/brain/plan.md",
+        content: markdown
+      }
+    });
   });
 
   it("maps classic plan to v2 plan_update items without markdown meta", () => {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1615,8 +1615,8 @@ describe("ACP v2 (experimental draft)", () => {
   it("maps classic plan to v2 plan_update items without markdown meta", () => {
     const update = {
       sessionUpdate: "plan",
-      entries: [{ content: "Ship it", priority: "medium", status: "pending" }]
-    } as SessionUpdate;
+      entries: [{ id: "entry_1", content: "Ship it", priority: "medium", status: "pending" }]
+    } as unknown as SessionUpdate;
 
     const v2Update = sessionUpdateToV2(update) as Record<string, unknown>;
     expect(v2Update).toEqual({
@@ -1624,8 +1624,21 @@ describe("ACP v2 (experimental draft)", () => {
       plan: {
         type: "items",
         planId: "agy-plan",
-        entries: [{ content: "Ship it", priority: "medium", status: "pending" }]
+        entries: [{ id: "entry_1", content: "Ship it", priority: "medium", status: "pending" }]
       }
+    });
+  });
+
+  it("maps plan_removed to v2 plan_removed update with planId", () => {
+    const update = {
+      sessionUpdate: "plan_removed",
+      planId: "file:/tmp/brain/plan.md"
+    } as SessionUpdate;
+
+    const v2Update = sessionUpdateToV2(update) as Record<string, unknown>;
+    expect(v2Update).toEqual({
+      sessionUpdate: "plan_removed",
+      planId: "file:/tmp/brain/plan.md"
     });
   });
 

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1600,11 +1600,15 @@ describe("ACP v2 (experimental draft)", () => {
 
     const v2Update = sessionUpdateToV2(update) as Record<string, unknown>;
     expect(v2Update.sessionUpdate).toBe("plan_update");
-    expect(v2Update.plan).toEqual({
-      type: "markdown",
-      planId: "file:/tmp/brain/plan.md",
-      content: markdown
-    });
+    const plan = v2Update.plan as Record<string, unknown>;
+    expect(plan.type).toBe("markdown");
+    expect(plan.planId).toBe("file:/tmp/brain/plan.md");
+    expect(plan.content).toBe(markdown);
+    // Entries with IDs are included alongside markdown for incremental reconciliation
+    expect(plan.entries).toEqual([
+      { content: "One", priority: "high", status: "pending" },
+      { content: "Two", priority: "high", status: "completed" }
+    ]);
 
     const v1Wire = sessionUpdateToV1(update) as Record<string, unknown>;
     expect(v1Wire.sessionUpdate).toBe("plan");
@@ -1615,7 +1619,7 @@ describe("ACP v2 (experimental draft)", () => {
   it("maps classic plan to v2 plan_update items without markdown meta", () => {
     const update = {
       sessionUpdate: "plan",
-      entries: [{ id: "entry_1", content: "Ship it", priority: "medium", status: "pending" }]
+      entries: [{ id: "entry_f323ded6", content: "Ship it", priority: "medium", status: "pending" }]
     } as unknown as SessionUpdate;
 
     const v2Update = sessionUpdateToV2(update) as Record<string, unknown>;
@@ -1624,7 +1628,7 @@ describe("ACP v2 (experimental draft)", () => {
       plan: {
         type: "items",
         planId: "agy-plan",
-        entries: [{ id: "entry_1", content: "Ship it", priority: "medium", status: "pending" }]
+        entries: [{ id: "entry_f323ded6", content: "Ship it", priority: "medium", status: "pending" }]
       }
     });
   });
@@ -1640,6 +1644,17 @@ describe("ACP v2 (experimental draft)", () => {
       sessionUpdate: "plan_removed",
       planId: "file:/tmp/brain/plan.md"
     });
+  });
+
+  it("translates plan_removed to empty plan on v1 wire", () => {
+    const update = {
+      sessionUpdate: "plan_removed",
+      planId: "file:/tmp/brain/plan.md"
+    } as SessionUpdate;
+
+    const v1Wire = sessionUpdateToV1(update) as Record<string, unknown>;
+    expect(v1Wire.sessionUpdate).toBe("plan");
+    expect(v1Wire.entries).toEqual([]);
   });
 
   it("expands execute tool calls into terminal_update + tool_call_update", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1517,9 +1517,46 @@ describe("Translator", () => {
     expect(second).toHaveLength(0);
     const entries = (first[0] as { entries: Array<{ content: string; status: string }> }).entries;
     expect(entries).toEqual([
-      { content: "One", priority: "high", status: "pending" },
-      { content: "Two", priority: "high", status: "completed" }
+      { id: "entry_1", content: "One", priority: "high", status: "pending" },
+      { id: "entry_2", content: "Two", priority: "high", status: "completed" }
     ]);
+  });
+
+  it("emits plan_removed session update when brain plan file is cleared", () => {
+    const planPath = path.join(dir, ".gemini", "antigravity-cli", "brain", "conv-plan-empty", "plan.md");
+    fs.mkdirSync(path.dirname(planPath), { recursive: true });
+    fs.writeFileSync(planPath, "");
+
+    const db = createConversationDb(dir, "conv-plan-empty");
+    insertStep(db, {
+      idx: 1,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-empty-1",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({
+              TargetFile: planPath,
+              CodeContent: ""
+            })
+          })
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-plan-empty")!;
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({
+      sessionUpdate: "plan_removed",
+      planId: `file:${planPath}`
+    });
   });
 
   it("buffers consecutive agent-text parts into one message in replay mode", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1526,6 +1526,74 @@ describe("Translator", () => {
     }
   });
 
+  it("keeps plan entry ids stable when a duplicate task is inserted before an existing one", () => {
+    const planPath =
+      "/Users/me/.gemini/antigravity-cli/brain/abc/.system_generated/steps/1/implementation_plan.md";
+    const db = createConversationDb(dir, "conv-plan-dup-insert");
+    insertStep(db, {
+      idx: 1,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-dup-1",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({
+              TargetFile: planPath,
+              CodeContent: "- [x] Deploy\n"
+            })
+          })
+        })
+      })
+    });
+
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const conn = ConversationDb.open(dir, "conv-plan-dup-insert")!;
+
+    const first = translator.translate(conn.readAfter(0));
+    expect(first).toHaveLength(1);
+    const firstEntries = (first[0] as { entries: Array<{ id?: string; status: string }> }).entries;
+    expect(firstEntries).toHaveLength(1);
+    const deployId = firstEntries[0].id;
+    expect(deployId).toBeDefined();
+
+    // Next poll: an identical pending task is inserted before the completed row.
+    insertStep(db, {
+      idx: 2,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-dup-2",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({
+              TargetFile: planPath,
+              CodeContent: "- [ ] Deploy\n- [x] Deploy\n"
+            })
+          })
+        })
+      })
+    });
+
+    const second = translator.translate(conn.readAfter(1));
+    conn.close();
+    db.close();
+
+    expect(second).toHaveLength(1);
+    expect(second[0]).toMatchObject({ sessionUpdate: "plan" });
+    const entries = (second[0] as { entries: Array<{ id?: string; status: string }> }).entries;
+    expect(entries).toHaveLength(2);
+    // The existing completed row keeps its original id; the inserted pending
+    // row gets a fresh, distinct id (not the old row's occurrence hash).
+    expect(entries[0].status).toBe("pending");
+    expect(entries[0].id).toBeDefined();
+    expect(entries[0].id).not.toBe(deployId);
+    expect(entries[1].status).toBe("completed");
+    expect(entries[1].id).toBe(deployId);
+  });
+
   it("emits plan_removed session update when brain plan file is cleared", () => {
     const planPath = path.join(dir, ".gemini", "antigravity-cli", "brain", "conv-plan-empty", "plan.md");
     fs.mkdirSync(path.dirname(planPath), { recursive: true });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1611,6 +1611,125 @@ describe("Translator", () => {
     }
   });
 
+  it("emits plan_removed when a completed replace clears the plan file", () => {
+    const planPath = path.join(dir, ".gemini", "antigravity-cli", "brain", "conv-plan-replace-clear", "plan.md");
+    fs.mkdirSync(path.dirname(planPath), { recursive: true });
+    const prior = "- [ ] Keep me\n- [x] Done\n";
+    fs.writeFileSync(planPath, prior);
+
+    const db = createConversationDb(dir, "conv-plan-replace-clear");
+    // Seed cache via an earlier full write of the plan.
+    insertStep(db, {
+      idx: 1,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-seed",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({
+              TargetFile: planPath,
+              CodeContent: prior
+            })
+          })
+        })
+      })
+    });
+    // Completed replace that deletes the entire plan body.
+    insertStep(db, {
+      idx: 2,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-replace-clear",
+            namePrimary: "replace_file_content",
+            rawInputJson: JSON.stringify({
+              TargetFile: planPath,
+              TargetContent: prior,
+              ReplacementContent: ""
+            })
+          })
+        })
+      })
+    });
+    // Mirror agy applying the edit on disk.
+    fs.writeFileSync(planPath, "");
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-plan-replace-clear")!;
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(2);
+    expect(updates[0]).toMatchObject({ sessionUpdate: "plan" });
+    expect(updates[1]).toMatchObject({
+      sessionUpdate: "plan_removed",
+      planId: `file:${planPath}`
+    });
+  });
+
+  it("does not emit plan_removed for incomplete replace that would clear the plan", () => {
+    const planPath = path.join(dir, ".gemini", "antigravity-cli", "brain", "conv-plan-replace-pending", "plan.md");
+    fs.mkdirSync(path.dirname(planPath), { recursive: true });
+    const prior = "- [ ] Keep me\n";
+    fs.writeFileSync(planPath, prior);
+
+    const db = createConversationDb(dir, "conv-plan-replace-pending");
+    insertStep(db, {
+      idx: 1,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-seed-pending",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({
+              TargetFile: planPath,
+              CodeContent: prior
+            })
+          })
+        })
+      })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 5,
+      status: 9,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-replace-pending",
+            namePrimary: "replace_file_content",
+            rawInputJson: JSON.stringify({
+              TargetFile: planPath,
+              TargetContent: prior,
+              ReplacementContent: ""
+            })
+          })
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-plan-replace-pending")!;
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    expect(updates).toHaveLength(2);
+    expect(updates[0]).toMatchObject({ sessionUpdate: "plan" });
+    expect(updates[1]).toMatchObject({
+      sessionUpdate: "tool_call",
+      name: "replace_file_content",
+      status: "pending"
+    });
+  });
+
   it("buffers consecutive agent-text parts into one message in replay mode", () => {
     const db = createConversationDb(dir, "conv-4");
     insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "Hello" }) });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1594,6 +1594,115 @@ describe("Translator", () => {
     expect(entries[1].id).toBe(deployId);
   });
 
+  it("does not replay prior plan states when a later row triggers a reread", () => {
+    const planPath =
+      "/Users/me/.gemini/antigravity-cli/brain/abc/.system_generated/steps/1/implementation_plan.md";
+    const db = createConversationDb(dir, "conv-plan-reread");
+    // Two rows update the same plan: v1, then v2.
+    insertStep(db, {
+      idx: 1,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-reread-1",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({ TargetFile: planPath, CodeContent: "- [ ] One\n" })
+          })
+        })
+      })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-reread-2",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({ TargetFile: planPath, CodeContent: "- [ ] One\n- [ ] Two\n" })
+          })
+        })
+      })
+    });
+
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const conn = ConversationDb.open(dir, "conv-plan-reread")!;
+
+    // First poll emits both successive plan states.
+    const first = translator.translate(conn.readAfter(0));
+    expect(first.map((u) => u.sessionUpdate)).toEqual(["plan", "plan"]);
+
+    // A later unrelated row makes the poller reread rows 1-2; the historical
+    // plan states must not be re-emitted (no rollback to v1, no repeat of v2).
+    insertStep(db, { idx: 3, stepType: 15, stepPayload: encodeStepPayload({ agentText: "done" }) });
+    const second = translator.translate(conn.readAfter(0));
+    expect(second).toEqual([
+      { sessionUpdate: "agent_message_chunk", messageId: "3", content: { type: "text", text: "done" } }
+    ]);
+
+    conn.close();
+    db.close();
+  });
+
+  it("derives one plan id for relative and absolute references to the same file", () => {
+    const absPlanPath = path.join(dir, ".gemini", "antigravity-cli", "brain", "conv-plan-rel", "plan.md");
+    fs.mkdirSync(path.dirname(absPlanPath), { recursive: true });
+    fs.writeFileSync(absPlanPath, "- [ ] Keep\n");
+    const relPlanPath = path.relative(dir, absPlanPath);
+
+    const db = createConversationDb(dir, "conv-plan-rel");
+    // Write the plan via a relative path, then clear it via the absolute path.
+    insertStep(db, {
+      idx: 1,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-rel-1",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({ TargetFile: relPlanPath, CodeContent: "- [ ] Keep\n" })
+          })
+        })
+      })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-rel-2",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({ TargetFile: absPlanPath, CodeContent: "" })
+          })
+        })
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-plan-rel")!;
+    const translator = new Translator({ mode: "stream", skipNarration: false, cwd: dir });
+    const updates = translator.translate(conn.readAfter(-1));
+    conn.close();
+
+    // Both updates reference the same canonical plan id, so the removal clears
+    // the plan the first update created instead of targeting a divergent id.
+    expect(updates).toHaveLength(2);
+    expect(updates[0]).toMatchObject({ sessionUpdate: "plan" });
+    expect((updates[0] as { _meta?: Record<string, unknown> })._meta?.["agy-acp/planId"]).toBe(
+      `file:${absPlanPath}`
+    );
+    expect(updates[1]).toMatchObject({
+      sessionUpdate: "plan_removed",
+      planId: `file:${absPlanPath}`
+    });
+  });
+
   it("emits plan_removed session update when brain plan file is cleared", () => {
     const planPath = path.join(dir, ".gemini", "antigravity-cli", "brain", "conv-plan-empty", "plan.md");
     fs.mkdirSync(path.dirname(planPath), { recursive: true });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1563,6 +1563,54 @@ describe("Translator", () => {
     });
   });
 
+  it("does not emit plan_removed for empty plan writes that are not completed", () => {
+    const planPath = path.join(dir, ".gemini", "antigravity-cli", "brain", "conv-plan-empty-pending", "plan.md");
+    fs.mkdirSync(path.dirname(planPath), { recursive: true });
+    fs.writeFileSync(planPath, "- [ ] Keep me\n");
+
+    // status 9 = permission pending, 7 = failed, 6 = cancelled
+    for (const { status, label, expectedStatus } of [
+      { status: 9, label: "pending", expectedStatus: "pending" },
+      { status: 7, label: "failed", expectedStatus: "failed" },
+      { status: 6, label: "cancelled", expectedStatus: "cancelled" }
+    ] as const) {
+      const convId = `conv-plan-empty-${label}`;
+      const db = createConversationDb(dir, convId);
+      insertStep(db, {
+        idx: 1,
+        stepType: 5,
+        status,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: `plan-empty-${label}`,
+              namePrimary: "write_to_file",
+              rawInputJson: JSON.stringify({
+                TargetFile: planPath,
+                CodeContent: ""
+              })
+            })
+          })
+        })
+      });
+      db.close();
+
+      const conn = ConversationDb.open(dir, convId)!;
+      const translator = new Translator({ mode: "stream", skipNarration: false });
+      const updates = translator.translate(conn.readAfter(-1));
+      conn.close();
+
+      expect(updates, label).toHaveLength(1);
+      expect(updates[0], label).toMatchObject({
+        sessionUpdate: "tool_call",
+        name: "write_to_file",
+        kind: "edit",
+        status: expectedStatus
+      });
+      expect((updates[0] as { sessionUpdate: string }).sessionUpdate, label).not.toBe("plan_removed");
+    }
+  });
+
   it("buffers consecutive agent-text parts into one message in replay mode", () => {
     const db = createConversationDb(dir, "conv-4");
     insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "Hello" }) });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1730,6 +1730,91 @@ describe("Translator", () => {
     });
   });
 
+  it("does not apply speculative plan updates for incomplete nonempty replaces", () => {
+    const planPath = path.join(dir, ".gemini", "antigravity-cli", "brain", "conv-plan-replace-speculative", "plan.md");
+    fs.mkdirSync(path.dirname(planPath), { recursive: true });
+    const prior = "- [ ] Keep me\n";
+    const next = "- [x] Keep me\n";
+    fs.writeFileSync(planPath, prior);
+
+    const replacePayload = encodeStepPayload({
+      toolRun: encodeToolRun({
+        call: encodeToolCall({
+          callId: "plan-replace-speculative",
+          namePrimary: "replace_file_content",
+          rawInputJson: JSON.stringify({
+            TargetFile: planPath,
+            TargetContent: prior,
+            ReplacementContent: next
+          })
+        })
+      })
+    });
+
+    const db = createConversationDb(dir, "conv-plan-replace-speculative");
+    insertStep(db, {
+      idx: 1,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "plan-seed-speculative",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({
+              TargetFile: planPath,
+              CodeContent: prior
+            })
+          })
+        })
+      })
+    });
+    // Permission-pending replace that would mark the task completed if applied.
+    insertStep(db, {
+      idx: 2,
+      stepType: 5,
+      status: 9,
+      stepPayload: replacePayload
+    });
+
+    const conn = ConversationDb.open(dir, "conv-plan-replace-speculative")!;
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+
+    const pending = translator.translate(conn.readAfter(-1));
+    expect(pending).toHaveLength(2);
+    expect(pending[0]).toMatchObject({ sessionUpdate: "plan" });
+    expect((pending[0] as { entries: Array<{ content: string; status: string }> }).entries).toMatchObject([
+      { content: "Keep me", status: "pending" }
+    ]);
+    expect(pending[1]).toMatchObject({
+      sessionUpdate: "tool_call",
+      name: "replace_file_content",
+      status: "pending"
+    });
+
+    // Denial/failure must not rewrite the plan or poison the content cache.
+    updateStep(db, 2, { status: 7, stepPayload: replacePayload });
+    const failed = translator.translate(conn.readAfter(-1));
+    expect(failed).toMatchObject([
+      { sessionUpdate: "tool_call_update", name: "replace_file_content", status: "failed" }
+    ]);
+    expect(failed.some((u) => (u as { sessionUpdate: string }).sessionUpdate === "plan")).toBe(false);
+
+    // A later successful replace still derives from the original cached plan body.
+    updateStep(db, 2, { status: 3, stepPayload: replacePayload });
+    fs.writeFileSync(planPath, next);
+    const completed = translator.translate(conn.readAfter(-1));
+    expect(completed).toMatchObject([
+      {
+        sessionUpdate: "plan",
+        entries: [{ content: "Keep me", status: "completed" }]
+      }
+    ]);
+
+    conn.close();
+    db.close();
+  });
+
   it("buffers consecutive agent-text parts into one message in replay mode", () => {
     const db = createConversationDb(dir, "conv-4");
     insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "Hello" }) });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1516,10 +1516,14 @@ describe("Translator", () => {
     expect(first).toHaveLength(1);
     expect(second).toHaveLength(0);
     const entries = (first[0] as { entries: Array<{ content: string; status: string }> }).entries;
-    expect(entries).toEqual([
-      { id: "entry_1", content: "One", priority: "high", status: "pending" },
-      { id: "entry_2", content: "Two", priority: "high", status: "completed" }
+    expect(entries).toMatchObject([
+      { content: "One", priority: "high", status: "pending" },
+      { content: "Two", priority: "high", status: "completed" }
     ]);
+    // Entries have content-hash-based IDs
+    for (const e of entries) {
+      expect((e as Record<string, unknown>).id).toMatch(/^entry_[0-9a-f]+$/);
+    }
   });
 
   it("emits plan_removed session update when brain plan file is cleared", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1730,6 +1730,91 @@ describe("Translator", () => {
     });
   });
 
+  it("does not cache unsuccessful full plan writes for later replace derivation", () => {
+    const planPath = path.join(dir, ".gemini", "antigravity-cli", "brain", "conv-plan-write-cache", "plan.md");
+    fs.mkdirSync(path.dirname(planPath), { recursive: true });
+    const real = "- [ ] Real plan\n";
+    const rejected = "- [x] Speculative\n";
+    const bogusFromRejected = "- [ ] From rejected cache\n";
+    fs.writeFileSync(planPath, real);
+
+    const seedPayload = encodeStepPayload({
+      toolRun: encodeToolRun({
+        call: encodeToolCall({
+          callId: "plan-seed-cache",
+          namePrimary: "write_to_file",
+          rawInputJson: JSON.stringify({ TargetFile: planPath, CodeContent: real })
+        })
+      })
+    });
+    const rejectedWritePayload = encodeStepPayload({
+      toolRun: encodeToolRun({
+        call: encodeToolCall({
+          callId: "plan-write-rejected",
+          namePrimary: "write_to_file",
+          rawInputJson: JSON.stringify({ TargetFile: planPath, CodeContent: rejected })
+        })
+      })
+    });
+    // Replace targets the rejected body. If the failed write poisoned the cache, this would
+    // succeed and emit a plan derived from the never-applied write. With a clean cache it
+    // cannot apply and falls back to the on-disk real plan.
+    const replacePayload = encodeStepPayload({
+      toolRun: encodeToolRun({
+        call: encodeToolCall({
+          callId: "plan-replace-after-reject",
+          namePrimary: "replace_file_content",
+          rawInputJson: JSON.stringify({
+            TargetFile: planPath,
+            TargetContent: rejected,
+            ReplacementContent: bogusFromRejected
+          })
+        })
+      })
+    });
+
+    const db = createConversationDb(dir, "conv-plan-write-cache");
+    insertStep(db, { idx: 1, stepType: 5, status: 3, stepPayload: seedPayload });
+    insertStep(db, { idx: 2, stepType: 5, status: 9, stepPayload: rejectedWritePayload });
+
+    const conn = ConversationDb.open(dir, "conv-plan-write-cache")!;
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+
+    const first = translator.translate(conn.readAfter(-1));
+    expect(first[0]).toMatchObject({ sessionUpdate: "plan" });
+    expect((first[0] as { entries: Array<{ content: string }> }).entries[0].content).toBe("Real plan");
+    // Pending write may still publish requested content for UX, but must not cache it.
+    expect(first[1]).toMatchObject({ sessionUpdate: "plan" });
+    expect((first[1] as { entries: Array<{ content: string }> }).entries[0].content).toBe("Speculative");
+
+    updateStep(db, 2, { status: 7, stepPayload: rejectedWritePayload });
+    // Re-translate the failed row only (status transition); plan snapshot stays speculative UX.
+    translator.translate(conn.readAfter(1));
+
+    insertStep(db, { idx: 3, stepType: 5, status: 3, stepPayload: replacePayload });
+    // File on disk never received the rejected write.
+    fs.writeFileSync(planPath, real);
+    // Translate only the new replace row so a prior failed write is not re-published.
+    const afterReplace = translator.translate(conn.readAfter(2));
+
+    // Poisoned cache would apply TargetContent=rejected and emit "From rejected cache".
+    // With a clean cache the replace cannot apply; disk fallback keeps the real plan
+    // (and progressive dedupe may emit nothing if the snapshot is unchanged).
+    const planUpdates = afterReplace.filter((u) => (u as { sessionUpdate: string }).sessionUpdate === "plan");
+    for (const u of planUpdates) {
+      const entries = (u as { entries: Array<{ content: string }> }).entries;
+      expect(entries.some((e) => e.content === "From rejected cache")).toBe(false);
+      expect(entries.map((e) => e.content)).toEqual(["Real plan"]);
+    }
+    // Even if no plan re-emit (deduped), we must not have published the rejected-derived body.
+    expect(planUpdates.some((u) =>
+      (u as { entries: Array<{ content: string }> }).entries.some((e) => e.content === "From rejected cache")
+    )).toBe(false);
+
+    conn.close();
+    db.close();
+  });
+
   it("does not apply speculative plan updates for incomplete nonempty replaces", () => {
     const planPath = path.join(dir, ".gemini", "antigravity-cli", "brain", "conv-plan-replace-speculative", "plan.md");
     fs.mkdirSync(path.dirname(planPath), { recursive: true });

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -26,31 +26,49 @@ describe("isPlanFile", () => {
 });
 
 describe("parsePlanEntries", () => {
-  it("parses numbered and bulleted items with stable ids", () => {
+  it("parses numbered and bulleted items with stable content-hash ids", () => {
     const entries = parsePlanEntries("# Plan\n\n1. First\n2. Second\n- Third\n");
     expect(entries.map((e) => e.content)).toEqual(["First", "Second", "Third"]);
-    expect(entries.map((e) => (e as Record<string, unknown>).id)).toEqual([
-      "entry_1",
-      "entry_2",
-      "entry_3"
-    ]);
+    // IDs are content-hash-based, not ordinal
+    for (const e of entries) {
+      expect((e as Record<string, unknown>).id).toMatch(/^entry_[0-9a-f]+$/);
+    }
   });
 
-  it("maps checkbox markers to status with ids", () => {
-    expect(
-      parsePlanEntries("- [ ] open\n- [x] done\n- [~] mid\n- [X] DONE2\n")
-    ).toEqual([
-      { id: "entry_1", content: "open", priority: "high", status: "pending" },
-      { id: "entry_2", content: "done", priority: "high", status: "completed" },
-      { id: "entry_3", content: "mid", priority: "high", status: "in_progress" },
-      { id: "entry_4", content: "DONE2", priority: "medium", status: "completed" }
+  it("maps checkbox markers to status with content-hash ids", () => {
+    const entries = parsePlanEntries("- [ ] open\n- [x] done\n- [~] mid\n- [X] DONE2\n");
+    expect(entries).toMatchObject([
+      { content: "open", priority: "high", status: "pending" },
+      { content: "done", priority: "high", status: "completed" },
+      { content: "mid", priority: "high", status: "in_progress" },
+      { content: "DONE2", priority: "medium", status: "completed" }
     ]);
+    // Each entry has a content-hash id
+    for (const e of entries) {
+      expect((e as Record<string, unknown>).id).toMatch(/^entry_[0-9a-f]+$/);
+    }
+  });
+
+  it("preserves entry identity when items are reordered", () => {
+    const before = parsePlanEntries("- [ ] alpha\n- [x] beta\n");
+    const after = parsePlanEntries("- [x] beta\n- [ ] alpha\n");
+    const idOf = (e: Record<string, unknown>) => e.id;
+    // alpha keeps same id regardless of position
+    expect(idOf(before[0] as Record<string, unknown>)).toBe(
+      idOf(after[1] as Record<string, unknown>)
+    );
+    // beta keeps same id regardless of position
+    expect(idOf(before[1] as Record<string, unknown>)).toBe(
+      idOf(after[0] as Record<string, unknown>)
+    );
   });
 
   it("falls back to the first heading when there is no list", () => {
-    expect(parsePlanEntries("# Ship the feature\n\nSome prose only.\n")).toEqual([
-      { id: "entry_1", content: "Ship the feature", priority: "medium", status: "pending" }
+    const entries = parsePlanEntries("# Ship the feature\n\nSome prose only.\n");
+    expect(entries).toMatchObject([
+      { content: "Ship the feature", priority: "medium", status: "pending" }
     ]);
+    expect((entries[0] as Record<string, unknown>).id).toMatch(/^entry_[0-9a-f]+$/);
   });
 });
 

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isPlanFile, parsePlanEntries, planIdForPath, planUpdateFromMarkdown } from "../src/acp/agent-plan/index.js";
+import { isPlanFile, parsePlanEntries, planIdForPath, planRemovedFromPath, planUpdateFromMarkdown } from "../src/acp/agent-plan/index.js";
 
 describe("isPlanFile", () => {
   it("matches agy brain markdown paths", () => {
@@ -26,32 +26,36 @@ describe("isPlanFile", () => {
 });
 
 describe("parsePlanEntries", () => {
-  it("parses numbered and bulleted items", () => {
-    expect(
-      parsePlanEntries("# Plan\n\n1. First\n2. Second\n- Third\n").map((e) => e.content)
-    ).toEqual(["First", "Second", "Third"]);
+  it("parses numbered and bulleted items with stable ids", () => {
+    const entries = parsePlanEntries("# Plan\n\n1. First\n2. Second\n- Third\n");
+    expect(entries.map((e) => e.content)).toEqual(["First", "Second", "Third"]);
+    expect(entries.map((e) => (e as Record<string, unknown>).id)).toEqual([
+      "entry_1",
+      "entry_2",
+      "entry_3"
+    ]);
   });
 
-  it("maps checkbox markers to status", () => {
+  it("maps checkbox markers to status with ids", () => {
     expect(
       parsePlanEntries("- [ ] open\n- [x] done\n- [~] mid\n- [X] DONE2\n")
     ).toEqual([
-      { content: "open", priority: "high", status: "pending" },
-      { content: "done", priority: "high", status: "completed" },
-      { content: "mid", priority: "high", status: "in_progress" },
-      { content: "DONE2", priority: "medium", status: "completed" }
+      { id: "entry_1", content: "open", priority: "high", status: "pending" },
+      { id: "entry_2", content: "done", priority: "high", status: "completed" },
+      { id: "entry_3", content: "mid", priority: "high", status: "in_progress" },
+      { id: "entry_4", content: "DONE2", priority: "medium", status: "completed" }
     ]);
   });
 
   it("falls back to the first heading when there is no list", () => {
     expect(parsePlanEntries("# Ship the feature\n\nSome prose only.\n")).toEqual([
-      { content: "Ship the feature", priority: "medium", status: "pending" }
+      { id: "entry_1", content: "Ship the feature", priority: "medium", status: "pending" }
     ]);
   });
 });
 
-describe("planUpdateFromMarkdown", () => {
-  it("builds a classic plan update with stable meta", () => {
+describe("planUpdateFromMarkdown & planRemovedFromPath", () => {
+  it("builds a classic plan update with stable meta and entry ids", () => {
     const path = "/Users/me/.gemini/antigravity-cli/brain/c/plan.md";
     const md = "1. A\n2. B\n";
     const update = planUpdateFromMarkdown(path, md) as {
@@ -63,5 +67,17 @@ describe("planUpdateFromMarkdown", () => {
     expect(update.entries).toHaveLength(2);
     expect(update._meta?.["agy-acp/planId"]).toBe(planIdForPath(path));
     expect(update._meta?.["agy-acp/planMarkdown"]).toBe(md);
+  });
+
+  it("builds a plan_removed update for empty/deleted plans", () => {
+    const path = "/Users/me/.gemini/antigravity-cli/brain/c/plan.md";
+    const update = planRemovedFromPath(path) as {
+      sessionUpdate: string;
+      planId: string;
+      _meta?: Record<string, unknown>;
+    };
+    expect(update.sessionUpdate).toBe("plan_removed");
+    expect(update.planId).toBe(planIdForPath(path));
+    expect(update._meta?.["agy-acp/planId"]).toBe(planIdForPath(path));
   });
 });

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -70,6 +70,14 @@ describe("parsePlanEntries", () => {
     expect(new Set(ids).size).toBe(3);
   });
 
+  it("keeps IDs unique when content matches an occurrence-style suffix", () => {
+    // Second "A" must not collide with a first-occurrence literal "A#1".
+    const entries = parsePlanEntries("- [ ] A\n- [ ] A\n- [ ] A#1\n");
+    const ids = entries.map((e) => (e as Record<string, unknown>).id as string);
+    expect(ids).toHaveLength(3);
+    expect(new Set(ids).size).toBe(3);
+  });
+
   it("falls back to the first heading when there is no list", () => {
     const entries = parsePlanEntries("# Ship the feature\n\nSome prose only.\n");
     expect(entries).toMatchObject([

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { isPlanFile, parsePlanEntries, planIdForPath, planRemovedFromPath, planUpdateFromMarkdown } from "../src/acp/agent-plan/index.js";
+import {
+  isPlanFile,
+  parsePlanEntries,
+  planIdForPath,
+  planRemovedFromPath,
+  planUpdateFromMarkdown,
+  reconcilePlanEntryIds,
+  type PlanEntry
+} from "../src/acp/agent-plan/index.js";
 
 describe("isPlanFile", () => {
   it("matches agy brain markdown paths", () => {
@@ -87,6 +95,50 @@ describe("parsePlanEntries", () => {
   });
 });
 
+describe("reconcilePlanEntryIds", () => {
+  const idOf = (e: PlanEntry) => e.id as string;
+
+  it("keeps a completed duplicate's id when an identical task is inserted before it", () => {
+    // Regression: occurrence-only ids reassigned the old row's id to the new row.
+    const before = parsePlanEntries("- [x] Deploy\n");
+    const after = reconcilePlanEntryIds(before, parsePlanEntries("- [ ] Deploy\n- [x] Deploy\n"));
+    expect(after).toMatchObject([
+      { content: "Deploy", status: "pending" },
+      { content: "Deploy", status: "completed" }
+    ]);
+    // The existing completed row keeps its id; the inserted pending row is fresh.
+    expect(idOf(after[1])).toBe(idOf(before[0]));
+    expect(idOf(after[0])).not.toBe(idOf(before[0]));
+    expect(new Set(after.map(idOf)).size).toBe(2);
+  });
+
+  it("keeps entry ids when a checkbox flips", () => {
+    const before = parsePlanEntries("- [ ] alpha\n- [ ] beta\n");
+    const after = reconcilePlanEntryIds(before, parsePlanEntries("- [x] alpha\n- [ ] beta\n"));
+    expect(after.map(idOf)).toEqual(before.map(idOf));
+    expect(after[0].status).toBe("completed");
+  });
+
+  it("keeps the surviving duplicate's id when one copy is removed", () => {
+    const before = parsePlanEntries("- [ ] A\n- [ ] A\n");
+    const after = reconcilePlanEntryIds(before, parsePlanEntries("- [ ] A\n"));
+    expect(idOf(after[0])).toBe(idOf(before[0]));
+  });
+
+  it("keeps all ids unique when fresh duplicates join claimed rows", () => {
+    const before = parsePlanEntries("- [ ] A\n- [ ] A\n");
+    const after = reconcilePlanEntryIds(before, parsePlanEntries("- [ ] A\n- [ ] A\n- [ ] A\n"));
+    expect(after.slice(0, 2).map(idOf)).toEqual(before.map(idOf));
+    expect(new Set(after.map(idOf)).size).toBe(3);
+  });
+
+  it("matches a fresh parse when there is no previous snapshot", () => {
+    const md = "- [ ] A\n- [ ] A\n- [x] B\n";
+    const reconciled = reconcilePlanEntryIds(undefined, parsePlanEntries(md));
+    expect(reconciled.map(idOf)).toEqual(parsePlanEntries(md).map(idOf));
+  });
+});
+
 describe("planUpdateFromMarkdown & planRemovedFromPath", () => {
   it("builds a classic plan update with stable meta and entry ids", () => {
     const path = "/Users/me/.gemini/antigravity-cli/brain/c/plan.md";
@@ -100,6 +152,17 @@ describe("planUpdateFromMarkdown & planRemovedFromPath", () => {
     expect(update.entries).toHaveLength(2);
     expect(update._meta?.["agy-acp/planId"]).toBe(planIdForPath(path));
     expect(update._meta?.["agy-acp/planMarkdown"]).toBe(md);
+  });
+
+  it("reconciles entry ids against a previous snapshot when given one", () => {
+    const path = "/Users/me/.gemini/antigravity-cli/brain/c/plan.md";
+    const first = planUpdateFromMarkdown(path, "- [x] Deploy\n") as unknown as { entries: PlanEntry[] };
+    const second = planUpdateFromMarkdown(path, "- [ ] Deploy\n- [x] Deploy\n", first.entries) as unknown as {
+      entries: PlanEntry[];
+    };
+    // Inserted pending duplicate gets a fresh id; the completed row keeps its own.
+    expect(second.entries[1].id).toBe(first.entries[0].id);
+    expect(second.entries[0].id).not.toBe(first.entries[0].id);
   });
 
   it("builds a plan_removed update for empty/deleted plans", () => {

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -63,6 +63,13 @@ describe("parsePlanEntries", () => {
     );
   });
 
+  it("assigns distinct entry IDs to duplicate task text", () => {
+    const entries = parsePlanEntries("- [ ] Run tests\n- [ ] Build\n- [ ] Run tests\n");
+    const ids = entries.map((e) => (e as Record<string, unknown>).id);
+    expect(ids[0]).not.toBe(ids[2]);
+    expect(new Set(ids).size).toBe(3);
+  });
+
   it("falls back to the first heading when there is no list", () => {
     const entries = parsePlanEntries("# Ship the feature\n\nSome prose only.\n");
     expect(entries).toMatchObject([


### PR DESCRIPTION
## Description

Adds support for id-based incremental `plan_update` operations and `plan_removed` notifications as specified in issue #60.

Key changes:
- Extended `PlanEntry` to include stable per-entry `id` fields (`entry_1`, `entry_2`, ...) generated by `parsePlanEntries()`.
- Added `planRemovedFromPath()` helper and updated `editUpdate()` in DB poller to emit `plan_removed` when plan artifact files are cleared.
- Updated `Translator`'s progressive snapshot key logic to track plan updates by plan ID.
- Mapped `plan_removed` updates and entry IDs through `sessionUpdateToV2` at the ACP protocol boundary.

## Related Issues

Closes #60

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed