### PR TITLE
Detect in-place SQLite updates in ReplayCache staleness check

### DIFF
--- a/src/agy/db/database.ts
+++ b/src/agy/db/database.ts
@@ -6,6 +6,7 @@
 // that's needed.
 
 import Database from "better-sqlite3";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { decodeErrorDetails, decodePermissions, decodeTaskDetails } from "./columns.js";
@@ -64,42 +65,26 @@ export interface DbStat {
   journalSize?: number;
   changeCounter: number;
   /**
-   * WAL header "generation" fields (checkpoint sequence number + salts). In WAL
-   * mode the main-file change counter only advances on checkpoint, and a
-   * RESTART checkpoint can leave the WAL file at the same size/mtime while its
-   * frames are overwritten in place. That reset bumps the checkpoint sequence
-   * and salts, so folding them into the fingerprint catches such same-size,
-   * same-mtime WAL rewrites that the metadata alone would miss.
+   * Hash of the full WAL file content. In WAL mode the main-file change
+   * counter only advances on checkpoint, and WAL metadata alone cannot prove
+   * the content is unchanged: a RESTART checkpoint can leave the file at the
+   * same size/mtime while frames are rewritten, and a rolled-back transaction's
+   * spilled frames stay allocated so a later smaller commit overwrites that
+   * tail without even bumping the header salts or checkpoint sequence. Hashing
+   * the content catches any such same-size, same-mtime, same-generation rewrite.
+   * A torn read while a writer is mid-append only causes a spurious rebuild
+   * (safe direction), never a stale hit.
    */
-  walCheckpointSeq?: number;
-  walSalt1?: number;
-  walSalt2?: number;
+  walHash?: string;
 }
 
-/** Read the WAL header generation fields, or undefined when absent/too short. */
-function readWalGeneration(walPath: string): {
-  checkpointSeq: number;
-  salt1: number;
-  salt2: number;
-} | null {
+/** Hash the WAL file's full content, or undefined when absent/unreadable. */
+function readWalContentHash(walPath: string): string | undefined {
   try {
-    const fd = fs.openSync(walPath, "r");
-    try {
-      const buf = Buffer.alloc(24);
-      if (fs.readSync(fd, buf, 0, 24, 0) === 24) {
-        return {
-          checkpointSeq: buf.readUInt32BE(12),
-          salt1: buf.readUInt32BE(16),
-          salt2: buf.readUInt32BE(20)
-        };
-      }
-    } finally {
-      fs.closeSync(fd);
-    }
+    return createHash("sha256").update(fs.readFileSync(walPath)).digest("hex");
   } catch {
-    // no readable wal header
+    return undefined;
   }
-  return null;
 }
 
 /** Stat a conversation DB, or null if it doesn't exist. */
@@ -110,20 +95,13 @@ export function statConversation(dir: string, id: string): DbStat | null {
 
     let walMtimeMs: number | undefined;
     let walSize: number | undefined;
-    let walCheckpointSeq: number | undefined;
-    let walSalt1: number | undefined;
-    let walSalt2: number | undefined;
+    let walHash: string | undefined;
     try {
       const walPath = `${dbPath}-wal`;
       const ws = fs.statSync(walPath);
       walMtimeMs = ws.mtimeMs;
       walSize = ws.size;
-      const gen = readWalGeneration(walPath);
-      if (gen) {
-        walCheckpointSeq = gen.checkpointSeq;
-        walSalt1 = gen.salt1;
-        walSalt2 = gen.salt2;
-      }
+      walHash = readWalContentHash(walPath);
     } catch {
       // no wal file
     }
@@ -158,9 +136,7 @@ export function statConversation(dir: string, id: string): DbStat | null {
       size: s.size,
       walMtimeMs,
       walSize,
-      walCheckpointSeq,
-      walSalt1,
-      walSalt2,
+      walHash,
       journalMtimeMs,
       journalSize,
       changeCounter

--- a/src/agy/db/database.ts
+++ b/src/agy/db/database.ts
@@ -58,13 +58,63 @@ export function conversationDbPath(dir: string, id: string): string {
 export interface DbStat {
   mtimeMs: number;
   size: number;
+  walMtimeMs?: number;
+  walSize?: number;
+  journalMtimeMs?: number;
+  journalSize?: number;
+  changeCounter: number;
 }
 
 /** Stat a conversation DB, or null if it doesn't exist. */
 export function statConversation(dir: string, id: string): DbStat | null {
+  const dbPath = conversationDbPath(dir, id);
   try {
-    const s = fs.statSync(conversationDbPath(dir, id));
-    return { mtimeMs: s.mtimeMs, size: s.size };
+    const s = fs.statSync(dbPath);
+
+    let walMtimeMs: number | undefined;
+    let walSize: number | undefined;
+    try {
+      const ws = fs.statSync(`${dbPath}-wal`);
+      walMtimeMs = ws.mtimeMs;
+      walSize = ws.size;
+    } catch {
+      // no wal file
+    }
+
+    let journalMtimeMs: number | undefined;
+    let journalSize: number | undefined;
+    try {
+      const js = fs.statSync(`${dbPath}-journal`);
+      journalMtimeMs = js.mtimeMs;
+      journalSize = js.size;
+    } catch {
+      // no journal file
+    }
+
+    let changeCounter = 0;
+    try {
+      const fd = fs.openSync(dbPath, "r");
+      try {
+        const buf = Buffer.alloc(4);
+        if (fs.readSync(fd, buf, 0, 4, 24) === 4) {
+          changeCounter = buf.readUInt32BE(0);
+        }
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      // ignore read errors
+    }
+
+    return {
+      mtimeMs: s.mtimeMs,
+      size: s.size,
+      walMtimeMs,
+      walSize,
+      journalMtimeMs,
+      journalSize,
+      changeCounter
+    };
   } catch {
     return null;
   }

--- a/src/agy/db/database.ts
+++ b/src/agy/db/database.ts
@@ -63,6 +63,43 @@ export interface DbStat {
   journalMtimeMs?: number;
   journalSize?: number;
   changeCounter: number;
+  /**
+   * WAL header "generation" fields (checkpoint sequence number + salts). In WAL
+   * mode the main-file change counter only advances on checkpoint, and a
+   * RESTART checkpoint can leave the WAL file at the same size/mtime while its
+   * frames are overwritten in place. That reset bumps the checkpoint sequence
+   * and salts, so folding them into the fingerprint catches such same-size,
+   * same-mtime WAL rewrites that the metadata alone would miss.
+   */
+  walCheckpointSeq?: number;
+  walSalt1?: number;
+  walSalt2?: number;
+}
+
+/** Read the WAL header generation fields, or undefined when absent/too short. */
+function readWalGeneration(walPath: string): {
+  checkpointSeq: number;
+  salt1: number;
+  salt2: number;
+} | null {
+  try {
+    const fd = fs.openSync(walPath, "r");
+    try {
+      const buf = Buffer.alloc(24);
+      if (fs.readSync(fd, buf, 0, 24, 0) === 24) {
+        return {
+          checkpointSeq: buf.readUInt32BE(12),
+          salt1: buf.readUInt32BE(16),
+          salt2: buf.readUInt32BE(20)
+        };
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    // no readable wal header
+  }
+  return null;
 }
 
 /** Stat a conversation DB, or null if it doesn't exist. */
@@ -73,10 +110,20 @@ export function statConversation(dir: string, id: string): DbStat | null {
 
     let walMtimeMs: number | undefined;
     let walSize: number | undefined;
+    let walCheckpointSeq: number | undefined;
+    let walSalt1: number | undefined;
+    let walSalt2: number | undefined;
     try {
-      const ws = fs.statSync(`${dbPath}-wal`);
+      const walPath = `${dbPath}-wal`;
+      const ws = fs.statSync(walPath);
       walMtimeMs = ws.mtimeMs;
       walSize = ws.size;
+      const gen = readWalGeneration(walPath);
+      if (gen) {
+        walCheckpointSeq = gen.checkpointSeq;
+        walSalt1 = gen.salt1;
+        walSalt2 = gen.salt2;
+      }
     } catch {
       // no wal file
     }
@@ -111,6 +158,9 @@ export function statConversation(dir: string, id: string): DbStat | null {
       size: s.size,
       walMtimeMs,
       walSize,
+      walCheckpointSeq,
+      walSalt1,
+      walSalt2,
       journalMtimeMs,
       journalSize,
       changeCounter

--- a/src/agy/db/database.ts
+++ b/src/agy/db/database.ts
@@ -6,7 +6,6 @@
 // that's needed.
 
 import Database from "better-sqlite3";
-import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { decodeErrorDetails, decodePermissions, decodeTaskDetails } from "./columns.js";
@@ -65,25 +64,48 @@ export interface DbStat {
   journalSize?: number;
   changeCounter: number;
   /**
-   * Hash of the full WAL file content. In WAL mode the main-file change
-   * counter only advances on checkpoint, and WAL metadata alone cannot prove
-   * the content is unchanged: a RESTART checkpoint can leave the file at the
-   * same size/mtime while frames are rewritten, and a rolled-back transaction's
-   * spilled frames stay allocated so a later smaller commit overwrites that
-   * tail without even bumping the header salts or checkpoint sequence. Hashing
-   * the content catches any such same-size, same-mtime, same-generation rewrite.
-   * A torn read while a writer is mid-append only causes a spurious rebuild
-   * (safe direction), never a stale hit.
+   * Committed WAL state from the wal-index (`-shm`) header: the committed frame
+   * count (mxFrame) and the cumulative checksum chain through that frame. In
+   * WAL mode the main-file change counter only advances on checkpoint, and WAL
+   * file metadata/content cannot prove the committed state is unchanged: commit
+   * frames reach the file before mxFrame is published, RESTART checkpoints
+   * leave the file allocated, and rolled-back spill frames are reused without
+   * bumping header salts. The wal-index is the same publication point SQLite
+   * readers consult, so keying on it ties the fingerprint to exactly the
+   * snapshot a replay build reads. A torn shm read only causes a spurious
+   * rebuild (safe direction), never a stale hit.
    */
-  walHash?: string;
+  walMxFrame?: number;
+  walFrameCksum0?: number;
+  walFrameCksum1?: number;
 }
 
-/** Hash the WAL file's full content, or undefined when absent/unreadable. */
-function readWalContentHash(walPath: string): string | undefined {
+/** Known wal-index format version (WalIndexHdr.iVersion). */
+const WAL_INDEX_VERSION = 3007000;
+
+/** Read committed WAL state from the wal-index (`-shm`) header, or null when
+ *  absent/short/unparseable. Fixed 48-byte read; never reads the WAL itself. */
+function readWalIndexState(shmPath: string): {
+  mxFrame: number;
+  frameCksum0: number;
+  frameCksum1: number;
+} | null {
   try {
-    return createHash("sha256").update(fs.readFileSync(walPath)).digest("hex");
+    const fd = fs.openSync(shmPath, "r");
+    try {
+      const buf = Buffer.alloc(48);
+      if (fs.readSync(fd, buf, 0, 48, 0) !== 48) return null;
+      // The wal-index uses the writer's native byte order; detect it via the
+      // known iVersion constant at offset 0.
+      const little = buf.readUInt32LE(0) === WAL_INDEX_VERSION;
+      if (!little && buf.readUInt32BE(0) !== WAL_INDEX_VERSION) return null;
+      const u32 = (off: number): number => (little ? buf.readUInt32LE(off) : buf.readUInt32BE(off));
+      return { mxFrame: u32(16), frameCksum0: u32(24), frameCksum1: u32(28) };
+    } finally {
+      fs.closeSync(fd);
+    }
   } catch {
-    return undefined;
+    return null;
   }
 }
 
@@ -95,13 +117,19 @@ export function statConversation(dir: string, id: string): DbStat | null {
 
     let walMtimeMs: number | undefined;
     let walSize: number | undefined;
-    let walHash: string | undefined;
+    let walMxFrame: number | undefined;
+    let walFrameCksum0: number | undefined;
+    let walFrameCksum1: number | undefined;
     try {
-      const walPath = `${dbPath}-wal`;
-      const ws = fs.statSync(walPath);
+      const ws = fs.statSync(`${dbPath}-wal`);
       walMtimeMs = ws.mtimeMs;
       walSize = ws.size;
-      walHash = readWalContentHash(walPath);
+      const walIndex = readWalIndexState(`${dbPath}-shm`);
+      if (walIndex) {
+        walMxFrame = walIndex.mxFrame;
+        walFrameCksum0 = walIndex.frameCksum0;
+        walFrameCksum1 = walIndex.frameCksum1;
+      }
     } catch {
       // no wal file
     }
@@ -136,7 +164,9 @@ export function statConversation(dir: string, id: string): DbStat | null {
       size: s.size,
       walMtimeMs,
       walSize,
-      walHash,
+      walMxFrame,
+      walFrameCksum0,
+      walFrameCksum1,
       journalMtimeMs,
       journalSize,
       changeCounter

--- a/src/agy/db/lru.ts
+++ b/src/agy/db/lru.ts
@@ -25,6 +25,14 @@ export class Lru<K, V> {
     }
   }
 
+  delete(key: K): boolean {
+    return this.map.delete(key);
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+
   get size(): number {
     return this.map.size;
   }

--- a/src/agy/db/replay.ts
+++ b/src/agy/db/replay.ts
@@ -1,9 +1,10 @@
 // Full conversation-history replay for session/load, with a validated cache.
 //
-// Replays are cached per conversation and validated by file (mtime, size). On
-// an exact cache hit the result is returned without touching SQLite. Any file
-// change triggers a full rebuild so replay message grouping and mutable step
-// snapshots do not depend on prior cache state.
+// Replays are cached per conversation and validated by a file fingerprint
+// (main-file mtime/size/change counter, journal stats, and committed wal-index
+// state). On an exact cache hit the result is returned without touching
+// SQLite. Any fingerprint change triggers a full rebuild so replay message
+// grouping and mutable step snapshots do not depend on prior cache state.
 
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { ConversationDb, type DbStat, statConversation } from "./database.js";
@@ -57,7 +58,9 @@ export function isDbStatUnchanged(a: DbStat, b: DbStat): boolean {
     a.size === b.size &&
     a.walMtimeMs === b.walMtimeMs &&
     a.walSize === b.walSize &&
-    a.walHash === b.walHash &&
+    a.walMxFrame === b.walMxFrame &&
+    a.walFrameCksum0 === b.walFrameCksum0 &&
+    a.walFrameCksum1 === b.walFrameCksum1 &&
     a.journalMtimeMs === b.journalMtimeMs &&
     a.journalSize === b.journalSize &&
     a.changeCounter === b.changeCounter

--- a/src/agy/db/replay.ts
+++ b/src/agy/db/replay.ts
@@ -50,6 +50,18 @@ function buildReplay(dir: string, id: string, opts: ReplayOptions): BuiltReplay 
   }
 }
 
+function isDbStatUnchanged(a: DbStat, b: DbStat): boolean {
+  return (
+    a.mtimeMs === b.mtimeMs &&
+    a.size === b.size &&
+    a.walMtimeMs === b.walMtimeMs &&
+    a.walSize === b.walSize &&
+    a.journalMtimeMs === b.journalMtimeMs &&
+    a.journalSize === b.journalSize &&
+    a.changeCounter === b.changeCounter
+  );
+}
+
 /**
  * Replays conversations into ACP updates, caching results so repeat loads of an
  * unchanged conversation are cheap.
@@ -74,7 +86,7 @@ export class ReplayCache {
       const locationStateUnchanged = [...entry.locationReadability].every(
         ([filePath, wasReadable]) => isReadableFile(filePath) === wasReadable
       );
-      if (entry.stat.mtimeMs === stat.mtimeMs && entry.stat.size === stat.size && locationStateUnchanged) {
+      if (isDbStatUnchanged(entry.stat, stat) && locationStateUnchanged) {
         return { updates: entry.updates, maxIdx: entry.maxIdx };
       }
     }
@@ -84,5 +96,15 @@ export class ReplayCache {
     if (!built) return null;
     this.cache.set(id, { ...built, stat, skipNarration: opts.skipNarration, cwd: opts.cwd });
     return { updates: built.updates, maxIdx: built.maxIdx };
+  }
+
+  /** Manually invalidate cache for a specific conversation ID. */
+  invalidate(id: string): void {
+    this.cache.delete(id);
+  }
+
+  /** Clear all cached conversations. */
+  clear(): void {
+    this.cache.clear();
   }
 }

--- a/src/agy/db/replay.ts
+++ b/src/agy/db/replay.ts
@@ -57,9 +57,7 @@ export function isDbStatUnchanged(a: DbStat, b: DbStat): boolean {
     a.size === b.size &&
     a.walMtimeMs === b.walMtimeMs &&
     a.walSize === b.walSize &&
-    a.walCheckpointSeq === b.walCheckpointSeq &&
-    a.walSalt1 === b.walSalt1 &&
-    a.walSalt2 === b.walSalt2 &&
+    a.walHash === b.walHash &&
     a.journalMtimeMs === b.journalMtimeMs &&
     a.journalSize === b.journalSize &&
     a.changeCounter === b.changeCounter

--- a/src/agy/db/replay.ts
+++ b/src/agy/db/replay.ts
@@ -50,12 +50,16 @@ function buildReplay(dir: string, id: string, opts: ReplayOptions): BuiltReplay 
   }
 }
 
-function isDbStatUnchanged(a: DbStat, b: DbStat): boolean {
+/** True when two DB fingerprints are identical across every tracked field. */
+export function isDbStatUnchanged(a: DbStat, b: DbStat): boolean {
   return (
     a.mtimeMs === b.mtimeMs &&
     a.size === b.size &&
     a.walMtimeMs === b.walMtimeMs &&
     a.walSize === b.walSize &&
+    a.walCheckpointSeq === b.walCheckpointSeq &&
+    a.walSalt1 === b.walSalt1 &&
+    a.walSalt2 === b.walSalt2 &&
     a.journalMtimeMs === b.journalMtimeMs &&
     a.journalSize === b.journalSize &&
     a.changeCounter === b.changeCounter

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2798,45 +2798,42 @@ describe("ReplayCache", () => {
     expect(second?.updates).not.toBe(first?.updates);
   });
 
-  it("detects a same-size, same-mtime WAL generation change (RESTART checkpoint rewrite)", () => {
-    const db = createConversationDb(dir, "conv-wal-gen");
+  it("detects a same-size, same-mtime WAL rewrite that keeps the WAL generation", () => {
+    const db = createConversationDb(dir, "conv-wal-rewrite");
     insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hi" }) });
     db.close();
 
-    // Synthesize a WAL sidecar. In WAL mode a RESTART checkpoint can leave the
-    // WAL file at the same size/mtime while rewriting its frames; only the WAL
-    // header's checkpoint sequence + salts change. The main-file change counter
-    // does not advance until checkpoint, so the fingerprint must key on these.
-    const walPath = path.join(dir, "conv-wal-gen.db-wal");
-    const header = Buffer.alloc(32);
-    header.writeUInt32BE(0x377f0682, 0); // WAL magic (little-endian variant)
-    header.writeUInt32BE(1, 12); // checkpoint sequence
-    header.writeUInt32BE(0xaaaaaaaa, 16); // salt-1
-    header.writeUInt32BE(0x00000001, 20); // salt-2
-    fs.writeFileSync(walPath, header);
+    // Synthesize a WAL sidecar. When a spilled WAL transaction rolls back, its
+    // uncommitted frames stay allocated; a later smaller commit overwrites that
+    // tail without restarting the WAL, so the size, mtime (same tick), header
+    // salts, and checkpoint sequence all stay fixed while committed content
+    // changes. Only a content fingerprint catches this.
+    const walPath = path.join(dir, "conv-wal-rewrite.db-wal");
+    const wal = Buffer.alloc(64);
+    wal.writeUInt32BE(0x377f0682, 0); // WAL magic (little-endian variant)
+    wal.writeUInt32BE(1, 12); // checkpoint sequence
+    wal.writeUInt32BE(0xaaaaaaaa, 16); // salt-1
+    wal.writeUInt32BE(0x00000001, 20); // salt-2
+    wal.fill(0x11, 32); // frame bytes
+    fs.writeFileSync(walPath, wal);
     const pinnedTime = new Date(2020, 0, 1, 0, 0, 0);
     fs.utimesSync(walPath, pinnedTime, pinnedTime);
 
-    const before = statConversation(dir, "conv-wal-gen");
-    expect(before?.walCheckpointSeq).toBe(1);
-    expect(before?.walSalt1).toBe(0xaaaaaaaa);
-    expect(before?.walSalt2).toBe(1);
+    const before = statConversation(dir, "conv-wal-rewrite");
+    expect(before?.walHash).toBeDefined();
 
-    // Rewrite the header in place (RESTART bumps sequence + salts), same length.
-    header.writeUInt32BE(2, 12);
-    header.writeUInt32BE(0xbbbbbbbb, 16);
-    header.writeUInt32BE(0x00000002, 20);
-    fs.writeFileSync(walPath, header);
+    // Overwrite the frame tail in place: same length, same header generation.
+    wal.fill(0x22, 32);
+    fs.writeFileSync(walPath, wal);
     fs.utimesSync(walPath, pinnedTime, pinnedTime);
 
-    const after = statConversation(dir, "conv-wal-gen");
-    // Metadata the old check relied on is identical...
+    const after = statConversation(dir, "conv-wal-rewrite");
+    // Every metadata field the fingerprint previously relied on is identical...
     expect(after?.walMtimeMs).toBe(before?.walMtimeMs);
     expect(after?.walSize).toBe(before?.walSize);
     expect(after?.changeCounter).toBe(before?.changeCounter);
-    // ...but the WAL generation moved, so the fingerprint reports a change.
-    expect(after?.walCheckpointSeq).toBe(2);
-    expect(after?.walSalt1).toBe(0xbbbbbbbb);
+    // ...but the content hash moved, so the fingerprint reports a change.
+    expect(after?.walHash).not.toBe(before?.walHash);
     expect(isDbStatUnchanged(before as DbStat, after as DbStat)).toBe(false);
   });
 
@@ -2846,23 +2843,19 @@ describe("ReplayCache", () => {
       size: 4096,
       walMtimeMs: 200,
       walSize: 32,
-      walCheckpointSeq: 1,
-      walSalt1: 0xaaaaaaaa,
-      walSalt2: 2,
+      walHash: "aaa",
       journalMtimeMs: undefined,
       journalSize: undefined,
       changeCounter: 7
     };
     expect(isDbStatUnchanged(base, { ...base })).toBe(true);
 
-    const fields: Array<[keyof DbStat, number]> = [
+    const fields: Array<[keyof DbStat, number | string]> = [
       ["mtimeMs", 101],
       ["size", 4097],
       ["walMtimeMs", 201],
       ["walSize", 33],
-      ["walCheckpointSeq", 2],
-      ["walSalt1", 0xbbbbbbbb],
-      ["walSalt2", 3],
+      ["walHash", "bbb"],
       ["changeCounter", 8]
     ];
     for (const [field, value] of fields) {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2,8 +2,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ConversationDb } from "../src/agy/db/database.js";
-import { ReplayCache } from "../src/agy/db/replay.js";
+import { ConversationDb, type DbStat, statConversation } from "../src/agy/db/database.js";
+import { ReplayCache, isDbStatUnchanged } from "../src/agy/db/replay.js";
 import { conversationSnapshot, newConversationId } from "../src/agy/db/scan.js";
 import { StreamPoller } from "../src/agy/db/streaming.js";
 import { Translator } from "../src/agy/db/translator.js";
@@ -2796,6 +2796,78 @@ describe("ReplayCache", () => {
     const second = cache.get(dir, "conv-replay-same-size", { skipNarration: false });
     expect(second?.updates).toMatchObject([{ content: { text: "world" } }]);
     expect(second?.updates).not.toBe(first?.updates);
+  });
+
+  it("detects a same-size, same-mtime WAL generation change (RESTART checkpoint rewrite)", () => {
+    const db = createConversationDb(dir, "conv-wal-gen");
+    insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hi" }) });
+    db.close();
+
+    // Synthesize a WAL sidecar. In WAL mode a RESTART checkpoint can leave the
+    // WAL file at the same size/mtime while rewriting its frames; only the WAL
+    // header's checkpoint sequence + salts change. The main-file change counter
+    // does not advance until checkpoint, so the fingerprint must key on these.
+    const walPath = path.join(dir, "conv-wal-gen.db-wal");
+    const header = Buffer.alloc(32);
+    header.writeUInt32BE(0x377f0682, 0); // WAL magic (little-endian variant)
+    header.writeUInt32BE(1, 12); // checkpoint sequence
+    header.writeUInt32BE(0xaaaaaaaa, 16); // salt-1
+    header.writeUInt32BE(0x00000001, 20); // salt-2
+    fs.writeFileSync(walPath, header);
+    const pinnedTime = new Date(2020, 0, 1, 0, 0, 0);
+    fs.utimesSync(walPath, pinnedTime, pinnedTime);
+
+    const before = statConversation(dir, "conv-wal-gen");
+    expect(before?.walCheckpointSeq).toBe(1);
+    expect(before?.walSalt1).toBe(0xaaaaaaaa);
+    expect(before?.walSalt2).toBe(1);
+
+    // Rewrite the header in place (RESTART bumps sequence + salts), same length.
+    header.writeUInt32BE(2, 12);
+    header.writeUInt32BE(0xbbbbbbbb, 16);
+    header.writeUInt32BE(0x00000002, 20);
+    fs.writeFileSync(walPath, header);
+    fs.utimesSync(walPath, pinnedTime, pinnedTime);
+
+    const after = statConversation(dir, "conv-wal-gen");
+    // Metadata the old check relied on is identical...
+    expect(after?.walMtimeMs).toBe(before?.walMtimeMs);
+    expect(after?.walSize).toBe(before?.walSize);
+    expect(after?.changeCounter).toBe(before?.changeCounter);
+    // ...but the WAL generation moved, so the fingerprint reports a change.
+    expect(after?.walCheckpointSeq).toBe(2);
+    expect(after?.walSalt1).toBe(0xbbbbbbbb);
+    expect(isDbStatUnchanged(before as DbStat, after as DbStat)).toBe(false);
+  });
+
+  it("isDbStatUnchanged treats any single fingerprint field as significant", () => {
+    const base: DbStat = {
+      mtimeMs: 100,
+      size: 4096,
+      walMtimeMs: 200,
+      walSize: 32,
+      walCheckpointSeq: 1,
+      walSalt1: 0xaaaaaaaa,
+      walSalt2: 2,
+      journalMtimeMs: undefined,
+      journalSize: undefined,
+      changeCounter: 7
+    };
+    expect(isDbStatUnchanged(base, { ...base })).toBe(true);
+
+    const fields: Array<[keyof DbStat, number]> = [
+      ["mtimeMs", 101],
+      ["size", 4097],
+      ["walMtimeMs", 201],
+      ["walSize", 33],
+      ["walCheckpointSeq", 2],
+      ["walSalt1", 0xbbbbbbbb],
+      ["walSalt2", 3],
+      ["changeCounter", 8]
+    ];
+    for (const [field, value] of fields) {
+      expect(isDbStatUnchanged(base, { ...base, [field]: value })).toBe(false);
+    }
   });
 
   it("allows manual invalidation via invalidate() and clear()", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2768,6 +2768,41 @@ describe("ReplayCache", () => {
     ]);
   });
 
+  it("rebuilds cached replay after an in-place step update with identical payload byte size", () => {
+    const db = createConversationDb(dir, "conv-replay-same-size");
+    insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hello" }) });
+
+    const cache = new ReplayCache(8);
+    const first = cache.get(dir, "conv-replay-same-size", { skipNarration: false });
+    expect(first?.updates).toMatchObject([{ content: { text: "hello" } }]);
+
+    // Same string length ("hello" vs "world") keeps payload byte length unchanged
+    updateStepPayload(db, 1, encodeStepPayload({ agentText: "world" }));
+    db.close();
+
+    const second = cache.get(dir, "conv-replay-same-size", { skipNarration: false });
+    expect(second?.updates).toMatchObject([{ content: { text: "world" } }]);
+    expect(second?.updates).not.toBe(first?.updates);
+  });
+
+  it("allows manual invalidation via invalidate() and clear()", () => {
+    const db = createConversationDb(dir, "conv-replay-inv");
+    insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "v1" }) });
+
+    const cache = new ReplayCache(8);
+    const first = cache.get(dir, "conv-replay-inv", { skipNarration: false });
+    expect(first?.updates).toMatchObject([{ content: { text: "v1" } }]);
+
+    cache.invalidate("conv-replay-inv");
+    const second = cache.get(dir, "conv-replay-inv", { skipNarration: false });
+    expect(second?.updates).not.toBe(first?.updates);
+
+    cache.clear();
+    const third = cache.get(dir, "conv-replay-inv", { skipNarration: false });
+    expect(third?.updates).not.toBe(second?.updates);
+    db.close();
+  });
+
   it("rebuilds cached locations when a referenced file is deleted", () => {
     const file = path.join(dir, "cached-location.txt");
     fs.writeFileSync(file, "content");

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2768,17 +2768,30 @@ describe("ReplayCache", () => {
     ]);
   });
 
-  it("rebuilds cached replay after an in-place step update with identical payload byte size", () => {
+  it("rebuilds cached replay after an in-place step update the (mtime,size) check misses", () => {
+    const dbPath = path.join(dir, "conv-replay-same-size.db");
     const db = createConversationDb(dir, "conv-replay-same-size");
     insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hello" }) });
+
+    // Pin the main-file mtime to a fixed, ms-precision value so we can restore it
+    // exactly after the update and defeat the old (mtime, size) staleness check.
+    const pinnedTime = new Date(2020, 0, 1, 0, 0, 0);
+    fs.utimesSync(dbPath, pinnedTime, pinnedTime);
 
     const cache = new ReplayCache(8);
     const first = cache.get(dir, "conv-replay-same-size", { skipNarration: false });
     expect(first?.updates).toMatchObject([{ content: { text: "hello" } }]);
+    const sizeBefore = fs.statSync(dbPath).size;
 
-    // Same string length ("hello" vs "world") keeps payload byte length unchanged
+    // Same string length ("hello" vs "world") keeps the main-file byte size unchanged.
     updateStepPayload(db, 1, encodeStepPayload({ agentText: "world" }));
     db.close();
+
+    // Restore the exact mtime the cache recorded: with size also unchanged, only the
+    // SQLite header change counter differs, so this fails unless the widened
+    // fingerprint (change counter / WAL / journal) is doing the work.
+    fs.utimesSync(dbPath, pinnedTime, pinnedTime);
+    expect(fs.statSync(dbPath).size).toBe(sizeBefore);
 
     const second = cache.get(dir, "conv-replay-same-size", { skipNarration: false });
     expect(second?.updates).toMatchObject([{ content: { text: "world" } }]);

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2798,43 +2798,70 @@ describe("ReplayCache", () => {
     expect(second?.updates).not.toBe(first?.updates);
   });
 
-  it("detects a same-size, same-mtime WAL rewrite that keeps the WAL generation", () => {
-    const db = createConversationDb(dir, "conv-wal-rewrite");
+  it("detects committed WAL state changes via the wal-index when WAL metadata is unchanged", () => {
+    const db = createConversationDb(dir, "conv-wal-committed");
     insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hi" }) });
     db.close();
 
-    // Synthesize a WAL sidecar. When a spilled WAL transaction rolls back, its
-    // uncommitted frames stay allocated; a later smaller commit overwrites that
-    // tail without restarting the WAL, so the size, mtime (same tick), header
-    // salts, and checkpoint sequence all stay fixed while committed content
-    // changes. Only a content fingerprint catches this.
-    const walPath = path.join(dir, "conv-wal-rewrite.db-wal");
-    const wal = Buffer.alloc(64);
-    wal.writeUInt32BE(0x377f0682, 0); // WAL magic (little-endian variant)
-    wal.writeUInt32BE(1, 12); // checkpoint sequence
-    wal.writeUInt32BE(0xaaaaaaaa, 16); // salt-1
-    wal.writeUInt32BE(0x00000001, 20); // salt-2
-    wal.fill(0x11, 32); // frame bytes
-    fs.writeFileSync(walPath, wal);
+    // Synthesize WAL + wal-index sidecars. A commit publishes mxFrame and the
+    // cumulative frame checksum in the wal-index; that publication is the same
+    // event that makes new rows visible to SQLite readers, so keying the
+    // fingerprint on it catches commits even when the WAL file's size/mtime
+    // (same-tick write, reused spill frames) and the main-file change counter
+    // (pre-checkpoint) all stay fixed.
     const pinnedTime = new Date(2020, 0, 1, 0, 0, 0);
-    fs.utimesSync(walPath, pinnedTime, pinnedTime);
+    fs.writeFileSync(path.join(dir, "conv-wal-committed.db-wal"), Buffer.alloc(64));
+    fs.utimesSync(path.join(dir, "conv-wal-committed.db-wal"), pinnedTime, pinnedTime);
 
-    const before = statConversation(dir, "conv-wal-rewrite");
-    expect(before?.walHash).toBeDefined();
+    const shmPath = path.join(dir, "conv-wal-committed.db-shm");
+    const shm = Buffer.alloc(48);
+    shm.writeUInt32LE(3007000, 0); // wal-index iVersion
+    shm.writeUInt32LE(10, 16); // mxFrame
+    shm.writeUInt32LE(0x11111111, 24); // aFrameCksum[0]
+    shm.writeUInt32LE(0x22222222, 28); // aFrameCksum[1]
+    fs.writeFileSync(shmPath, shm);
+    fs.utimesSync(shmPath, pinnedTime, pinnedTime);
 
-    // Overwrite the frame tail in place: same length, same header generation.
-    wal.fill(0x22, 32);
-    fs.writeFileSync(walPath, wal);
-    fs.utimesSync(walPath, pinnedTime, pinnedTime);
+    const before = statConversation(dir, "conv-wal-committed");
+    expect(before?.walMxFrame).toBe(10);
+    expect(before?.walFrameCksum0).toBe(0x11111111);
+    expect(before?.walFrameCksum1).toBe(0x22222222);
 
-    const after = statConversation(dir, "conv-wal-rewrite");
-    // Every metadata field the fingerprint previously relied on is identical...
+    // Publish a new commit: mxFrame advances and the checksum chain moves,
+    // while every other tracked field stays identical.
+    shm.writeUInt32LE(12, 16);
+    shm.writeUInt32LE(0x33333333, 24);
+    shm.writeUInt32LE(0x44444444, 28);
+    fs.writeFileSync(shmPath, shm);
+    fs.utimesSync(shmPath, pinnedTime, pinnedTime);
+
+    const after = statConversation(dir, "conv-wal-committed");
+    expect(after?.mtimeMs).toBe(before?.mtimeMs);
     expect(after?.walMtimeMs).toBe(before?.walMtimeMs);
     expect(after?.walSize).toBe(before?.walSize);
     expect(after?.changeCounter).toBe(before?.changeCounter);
-    // ...but the content hash moved, so the fingerprint reports a change.
-    expect(after?.walHash).not.toBe(before?.walHash);
+    expect(after?.walMxFrame).toBe(12);
+    expect(after?.walFrameCksum0).toBe(0x33333333);
     expect(isDbStatUnchanged(before as DbStat, after as DbStat)).toBe(false);
+  });
+
+  it("parses big-endian wal-index headers", () => {
+    const db = createConversationDb(dir, "conv-wal-be");
+    insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hi" }) });
+    db.close();
+    fs.writeFileSync(path.join(dir, "conv-wal-be.db-wal"), Buffer.alloc(64));
+
+    const shm = Buffer.alloc(48);
+    shm.writeUInt32BE(3007000, 0);
+    shm.writeUInt32BE(7, 16);
+    shm.writeUInt32BE(0xaaaaaaaa, 24);
+    shm.writeUInt32BE(0xbbbbbbbb, 28);
+    fs.writeFileSync(path.join(dir, "conv-wal-be.db-shm"), shm);
+
+    const stat = statConversation(dir, "conv-wal-be");
+    expect(stat?.walMxFrame).toBe(7);
+    expect(stat?.walFrameCksum0).toBe(0xaaaaaaaa);
+    expect(stat?.walFrameCksum1).toBe(0xbbbbbbbb);
   });
 
   it("isDbStatUnchanged treats any single fingerprint field as significant", () => {
@@ -2843,19 +2870,23 @@ describe("ReplayCache", () => {
       size: 4096,
       walMtimeMs: 200,
       walSize: 32,
-      walHash: "aaa",
+      walMxFrame: 10,
+      walFrameCksum0: 0x11111111,
+      walFrameCksum1: 0x22222222,
       journalMtimeMs: undefined,
       journalSize: undefined,
       changeCounter: 7
     };
     expect(isDbStatUnchanged(base, { ...base })).toBe(true);
 
-    const fields: Array<[keyof DbStat, number | string]> = [
+    const fields: Array<[keyof DbStat, number]> = [
       ["mtimeMs", 101],
       ["size", 4097],
       ["walMtimeMs", 201],
       ["walSize", 33],
-      ["walHash", "bbb"],
+      ["walMxFrame", 11],
+      ["walFrameCksum0", 0x33333333],
+      ["walFrameCksum1", 0x44444444],
       ["changeCounter", 8]
     ];
     for (const [field, value] of fields) {


### PR DESCRIPTION
## Description

`ReplayCache` keyed staleness on the conversation DB file's `mtimeMs` and `size` only. In-place SQLite row updates (e.g. rewriting a step payload with an equal byte length) can leave the main db file's mtime and size unchanged, so the cache returned stale replay data.

This widens the `DbStat` fingerprint to also include:
- WAL file (`-wal`) mtime and size
- rollback journal file (`-journal`) mtime and size
- the SQLite header change counter (4 bytes at offset 24)

Any of these changing now invalidates the cached replay. Also adds `Lru.delete`/`Lru.clear` and `ReplayCache.invalidate`/`ReplayCache.clear` for manual eviction.

## Related Issues

Fixes #75

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed