### PR TITLE
Reflect all supported agy filesystem edits through ACP updates and fs operations

### DIFF
--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -172,6 +172,9 @@ export class AgyCliSession {
   #conversationId: string | null = null;
   #lastStepIdx = -1;
   #lastPromptUserStepIdxs: number[] = [];
+  // Monotonic per-session counter so reconciled edit tool-call IDs stay unique
+  // across turns (clients key tool-call lifecycles on toolCallId).
+  #reconcileTurnSeq = 0;
   readonly config: AgyCliConfig;
   readonly spawnProcess: SpawnFactory;
   readonly ptyFactory?: PtyFactory;
@@ -635,10 +638,11 @@ export class AgyCliSession {
     try {
       const roots = [this.config.cwd, ...this.config.additionalDirectories];
       const { reflected, unsupported } = await reconcileWorkingTree(baseline, roots, reflectedPaths);
+      const turnToken = String(this.#reconcileTurnSeq++);
       let index = 0;
       for (const edit of reflected) {
         if (this.#cancelled) return;
-        const update = buildReconcileEditUpdate(edit, index++, this.config.cwd);
+        const update = buildReconcileEditUpdate(edit, index++, this.config.cwd, turnToken);
         await this.raceTurnCallback(onUpdate(update), deadline);
         if (fsBridge) await this.raceTurnCallback(routeEditThroughClient(update, fsBridge), deadline);
       }

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -10,7 +10,7 @@ import { conversationSnapshot } from "./db/scan.js";
 import { defaultInstallBinDir, ensureAgyInstalled } from "./installer.js";
 import { StreamPoller } from "./db/streaming.js";
 import type { StepRow } from "./db/types.js";
-import { diffBlocks, revertEditToolCall } from "./edit/revert.js";
+import { diffBlocks, revertEditToolCall, type DiffBlock } from "./edit/revert.js";
 import {
   primeEditReadThroughClient,
   routeEditThroughClient,
@@ -23,6 +23,7 @@ import {
   reconcileWorkingTree,
   snapshotWorkingTree,
   toDisplayPath,
+  type ReportedBlock,
   type ReportedContent,
   type WorkingTreeSnapshot
 } from "./edit/reconcile.js";
@@ -76,6 +77,30 @@ function reportedContents(cwd: string, toolCall: SessionUpdate): ReportedContent
     else byPath.set(abs, [{ oldText, newText }]);
   }
   return [...byPath].map(([filePath, blocks]) => ({ path: filePath, blocks, wholeFile }));
+}
+
+/**
+ * What a completed revert restored, per absolute path. A rejected creation
+ * left nothing on disk and the client rejected it, so the path is forgotten
+ * unconditionally. Anything else is attributed by the *reverse* of the
+ * restored blocks: the client knows the edit was undone, but a restored block
+ * says nothing about the rest of the file, so an unrelated change that landed
+ * next to the edit before the reject still reaches reconciliation.
+ */
+function revertedContents(cwd: string, toolCall: SessionUpdate, restored: DiffBlock[]): ReportedContent[] {
+  const name = (toolCall as unknown as { name?: string }).name;
+  const wholeFile = name !== undefined && WHOLE_FILE_EDIT_TOOLS.has(name);
+  const byPath = new Map<string, { created: boolean; blocks: ReportedBlock[] }>();
+  for (const { path: target, oldText, newText } of restored) {
+    const abs = path.resolve(cwd, target);
+    const entry = byPath.get(abs) ?? { created: false, blocks: [] };
+    if (oldText === null) entry.created = true;
+    else entry.blocks.push({ oldText: newText, newText: oldText });
+    byPath.set(abs, entry);
+  }
+  return [...byPath].map(([filePath, { created, blocks }]) =>
+    created ? { path: filePath } : { path: filePath, wholeFile, blocks }
+  );
 }
 
 /** How many unsupported changes to name individually in the warning line. */
@@ -585,7 +610,7 @@ export class AgyCliSession {
           // change. Paths whose content this update no longer accounts for are
           // left for reconciliation to report.
           await observeReported(reportedContents(this.config.cwd, toolCall));
-          let restored: string[] = [];
+          let restored: DiffBlock[] = [];
           try {
             if (fsBridge) {
               const routed = gatedIds.has(id)
@@ -619,11 +644,13 @@ export class AgyCliSession {
           } finally {
             // A reject put the pre-edit text back on disk; that restoration is
             // the answer the client already has, so re-record it rather than
-            // reporting it again as an unstructured change. Only the paths the
-            // revert actually restored: a diverged block it declined to touch
-            // still holds content the client has not seen.
+            // reporting it again as an unstructured change. Only the blocks
+            // the revert actually restored, and only through the reverse
+            // attribution: a diverged block it declined to touch, or an
+            // unrelated change next to the edit, still holds content the
+            // client has not seen.
             if (restored.length > 0) {
-              await observeReported(restored.map((target) => ({ path: path.resolve(this.config.cwd, target) })));
+              await observeReported(revertedContents(this.config.cwd, toolCall, restored));
             }
           }
         }

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -18,8 +18,8 @@ import {
   type ClientFileSystem
 } from "./edit/bridge.js";
 import {
-  applyDiffBlocksToSnapshot,
   buildReconcileEditUpdate,
+  observeEditedPaths,
   reconcileWorkingTree,
   snapshotWorkingTree,
   toDisplayPath,
@@ -52,27 +52,13 @@ function permissionSignature(row: StepRow): string {
   return p ? `${p.kind}\u0000${p.value}\u0000${p.decision}` : "none";
 }
 
-/**
- * Advance the edit baseline from a completed structured-edit tool-call.
- * Groups multi-replace chunks by path so StartLine values stay relative to the
- * pre-edit file (see {@link applyDiffBlocksToSnapshot}).
- */
-function noteStructuredEditOnBaseline(
-  baseline: WorkingTreeSnapshot,
-  cwd: string,
-  toolCall: SessionUpdate
-): void {
-  const byPath = new Map<string, ReturnType<typeof diffBlocks>>();
-  for (const block of diffBlocks(toolCall)) {
-    const abs = path.resolve(cwd, block.path);
-    const list = byPath.get(abs);
-    if (list) list.push(block);
-    else byPath.set(abs, [block]);
-  }
-  for (const [abs, blocks] of byPath) {
-    applyDiffBlocksToSnapshot(baseline, abs, blocks);
-  }
+/** Absolute paths a tool-call's diff reported. Targets may be session-relative. */
+function editedPaths(cwd: string, toolCall: SessionUpdate): string[] {
+  return [...new Set(diffBlocks(toolCall).map((block) => path.resolve(cwd, block.path)))];
 }
+
+/** How many unsupported changes to name individually in the warning line. */
+const UNSUPPORTED_DETAIL_LIMIT = 10;
 
 export type SpawnedProcess = ChildProcessWithoutNullStreams;
 
@@ -359,23 +345,14 @@ export class AgyCliSession {
     // get reflected through ACP. Emitting the synthetic session/update needs no
     // client fs capability, so do this for every client (v1 and v2); the client
     // write-through is layered on later only when a bridge is available.
-    // When a recognized edit lands we advance the baseline for that path (see
-    // noteRecognizedEdit below) so a later shell change to the same file is
-    // still reconciled rather than suppressed for the rest of the turn.
     let editBaseline: WorkingTreeSnapshot | null = null;
     try {
       editBaseline = await snapshotWorkingTree([this.config.cwd, ...this.config.additionalDirectories]);
     } catch {
       editBaseline = null;
     }
-    // Advance baseline from the structured diff content (not disk): by the time
-    // we observe the tool-call, a later shell edit may already be on disk.
-    // Multi-replace chunks for one path are applied together so StartLine stays
-    // relative to the pre-edit text.
-    const noteRecognizedEdit = (toolCall: SessionUpdate): void => {
-      if (!editBaseline) return;
-      noteStructuredEditOnBaseline(editBaseline, this.config.cwd, toolCall);
-    };
+    const observeReportedEdit = (toolCall: SessionUpdate): Promise<void> =>
+      this.observeReportedEdit(editBaseline, toolCall);
     const signature = JSON.stringify([this.config.model, this.config.effort, this.config.mode]);
     if (this.#pty && this.#ptyConfig !== signature) await this.stopPty();
     if (this.#cancelled) { this.#cancelTurn = undefined; return { stopReason: "cancelled" }; }
@@ -579,10 +556,13 @@ export class AgyCliSession {
           // (accept-edits / skip-permissions), or it just passed through the
           // live gate above and agy applied it. Either way, if the client can
           // take the write itself, hand it off so its native diff/review UI
-          // (e.g. Zed's Review Changes panel) tracks it. On keep, advance the
-          // edit baseline from the structured diff so end-of-turn reconciliation
-          // only picks up *further* unstructured changes (and is not fooled by
-          // disk that already includes a later shell edit).
+          // (e.g. Zed's Review Changes panel) tracks it.
+          //
+          // Disk holds exactly the content this update reports, right now:
+          // record it before any write-through revert/replay so end-of-turn
+          // reconciliation cannot mistake the client's own write (or the
+          // intermediate revert) for an unreflected change.
+          await observeReportedEdit(toolCall);
           let rejected = false;
           try {
             if (fsBridge) {
@@ -616,9 +596,10 @@ export class AgyCliSession {
               rejected = true;
             }
           } finally {
-            // Reject leaves disk (and baseline) at the pre-edit state — do not
-            // advance. Diff-block paths may be session-relative.
-            if (!rejected) noteRecognizedEdit(toolCall);
+            // A reject put the pre-edit text back on disk; that restoration is
+            // the answer the client already has, so re-record it rather than
+            // reporting it again as an unstructured change.
+            if (rejected) await observeReportedEdit(toolCall);
           }
         }
         if (this.#cancelled) break;
@@ -665,14 +646,33 @@ export class AgyCliSession {
   }
 
   /**
-   * After a turn, diff the working tree against the (possibly advanced)
-   * baseline and reflect any change agy made that never surfaced as a
-   * recognized structured edit (shell edits, unrecognized payloads) through
-   * ACP: emit a synthetic edit update for every client, and additionally hand
-   * the write to the client when it advertises fs capabilities. Discovery
-   * failures are best-effort (logged); notification failures propagate so the
-   * caller does not go idle after a dropped update. Changes that can't be
-   * shown as a text diff (binary/oversized/deletions) are reported, not
+   * Record the on-disk content of the paths a reported edit covers, so
+   * end-of-turn reconciliation only emits changes the client has *not* been
+   * told about. Best effort: a snapshot we fail to refresh at worst re-reports
+   * a change the client already has, which is preferable to failing the turn.
+   */
+  private async observeReportedEdit(
+    baseline: WorkingTreeSnapshot | null,
+    toolCall: SessionUpdate
+  ): Promise<void> {
+    if (!baseline) return;
+    try {
+      await observeEditedPaths(baseline, editedPaths(this.config.cwd, toolCall));
+    } catch (error) {
+      console.error(`[agy-acp] WARN: could not record reported edit state: ${(error as Error).message}`);
+    }
+  }
+
+  /**
+   * After a turn, diff the working tree against what the client has been told
+   * (see {@link observeReportedEdit}) and reflect any change agy made that
+   * never surfaced as a recognized structured edit (shell edits, unrecognized
+   * payloads) through ACP: emit a synthetic edit update for every client, and
+   * additionally hand the write to the client when it advertises fs
+   * capabilities. Discovery failures are best-effort (logged); notification
+   * failures propagate so the caller does not go idle after a dropped update.
+   * Changes that can't be shown as a text diff (binary/oversized/deletions,
+   * files whose pre-turn content was never captured) are reported, not
    * dropped (#76).
    */
   private async reflectUnstructuredEdits(
@@ -680,11 +680,10 @@ export class AgyCliSession {
     fsBridge: ClientFileSystem | undefined,
     onUpdate: (update: SessionUpdate) => Promise<void>
   ): Promise<void> {
-    const roots = [this.config.cwd, ...this.config.additionalDirectories];
     let reflected: Awaited<ReturnType<typeof reconcileWorkingTree>>["reflected"];
     let unsupported: Awaited<ReturnType<typeof reconcileWorkingTree>>["unsupported"];
     try {
-      ({ reflected, unsupported } = await reconcileWorkingTree(baseline, roots));
+      ({ reflected, unsupported } = await reconcileWorkingTree(baseline));
     } catch (error) {
       // Filesystem scan is best-effort — a transient stat failure shouldn't
       // fail the whole turn after agy already finished.
@@ -718,11 +717,16 @@ export class AgyCliSession {
       }
     }
     if (unsupported.length > 0) {
-      const detail = unsupported
+      // One removed ignore rule can expose a whole directory; name a bounded
+      // sample instead of a line with thousands of paths on it.
+      const named = unsupported
+        .slice(0, UNSUPPORTED_DETAIL_LIMIT)
         .map((change) => `${toDisplayPath(change.path, this.config.cwd)} (${change.reason})`)
         .join(", ");
+      const rest = unsupported.length - Math.min(unsupported.length, UNSUPPORTED_DETAIL_LIMIT);
       console.error(
-        `[agy-acp] WARN: ${unsupported.length} filesystem change(s) not reflected through ACP: ${detail}`
+        `[agy-acp] WARN: ${unsupported.length} filesystem change(s) not reflected through ACP: ${named}` +
+          (rest > 0 ? `, and ${rest} more` : "")
       );
     }
   }
@@ -791,13 +795,13 @@ export class AgyCliSession {
       const pollOnce = async () => {
         for (const update of poller.poll()) {
           await onUpdate(update);
-          // Advance the baseline from the structured diff (not disk): a shell
-          // edit may already have landed before this poll observes the tool-call.
-          // Only completed edits — pending/failed lifecycle updates must not
-          // move the baseline to proposed content that never landed on disk.
+          // Record what disk holds for the reported paths, so end-of-turn
+          // reconciliation only reports what the client has *not* been told.
+          // Only completed edits: pending/failed lifecycle updates describe
+          // proposed content that may never land.
           const rawUpdate = update as unknown as { status?: string };
-          if (editBaseline && isEditToolCall(update) && rawUpdate.status === "completed") {
-            noteStructuredEditOnBaseline(editBaseline, this.config.cwd, update);
+          if (isEditToolCall(update) && rawUpdate.status === "completed") {
+            await this.observeReportedEdit(editBaseline, update);
           }
         }
       };

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -543,8 +543,10 @@ export class AgyCliSession {
           // take the write itself, hand it off so its native diff/review UI
           // (e.g. Zed's Review Changes panel) tracks it.
           // Recognized edit: record its paths so end-of-turn reconciliation
-          // doesn't re-emit them as unstructured changes.
-          for (const block of diffBlocks(toolCall)) reflectedPaths.add(path.resolve(block.path));
+          // doesn't re-emit them as unstructured changes. Diff-block paths may
+          // be session-relative, so resolve against the session cwd (not the
+          // adapter process cwd) to match the snapshot's absolute keys.
+          for (const block of diffBlocks(toolCall)) reflectedPaths.add(path.resolve(this.config.cwd, block.path));
           if (fsBridge) {
             const routed = gatedIds.has(id)
               // Pre-edit state was already primed above (race-free) — just

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -323,19 +323,27 @@ export class AgyCliSession {
     elicitationCap?: ClientElicitationCapability
   ): Promise<PromptOutcome> {
     this.#lastPromptUserStepIdxs = [];
-    if (this.config.interactivePermissions) {
-      if (!onPermission) throw new Error("interactive permissions require a permission callback");
-      return this.runInteractivePrompt(prompt, onUpdate, onPermission, fsBridge, elicitationCap);
+    if (this.config.interactivePermissions && !onPermission) {
+      throw new Error("interactive permissions require a permission callback");
     }
-    const command = this.commandForPrompt(prompt);
+    this.#cancelled = false;
+    this.#cancelWait = new Promise((resolve) => { this.#cancelTurn = resolve; });
     try {
-      return await this.runPromptCommand(command, prompt, onUpdate, fsBridge);
-    } catch (error) {
-      if (this.shouldInstallAfterError(error)) {
-        await this.installAgy();
-        return await this.runPromptCommand(this.commandForPrompt(prompt), prompt, onUpdate, fsBridge);
+      if (this.config.interactivePermissions) {
+        return await this.runInteractivePrompt(prompt, onUpdate, onPermission!, fsBridge, elicitationCap);
       }
-      throw error;
+      const command = this.commandForPrompt(prompt);
+      try {
+        return await this.runPromptCommand(command, prompt, onUpdate, fsBridge);
+      } catch (error) {
+        if (this.shouldInstallAfterError(error)) {
+          await this.installAgy();
+          return await this.runPromptCommand(this.commandForPrompt(prompt), prompt, onUpdate, fsBridge);
+        }
+        throw error;
+      }
+    } finally {
+      this.#cancelTurn = undefined;
     }
   }
 
@@ -346,8 +354,6 @@ export class AgyCliSession {
     fsBridge?: ClientFileSystem,
     elicitationCap?: ClientElicitationCapability
   ): Promise<PromptOutcome> {
-    this.#cancelled = false;
-    this.#cancelWait = new Promise((resolve) => { this.#cancelTurn = resolve; });
     // Snapshot the pre-edit working tree so edits agy makes outside recognized
     // structured-edit tool-calls (shell commands, unrecognized payloads) still
     // get reflected through ACP. Emitting the synthetic session/update needs no
@@ -621,7 +627,9 @@ export class AgyCliSession {
         if (exited && !this.#cancelled) throw new AgyCliError(`agy interactive PTY exited unexpectedly: ${this.#ptyOutput.trim() || "<no output>"}`, [this.config.agyPath], null, this.#ptyOutput);
       }
       if (editBaseline && !this.#cancelled) {
-        await this.reflectUnstructuredEdits(editBaseline, fsBridge, onUpdate, deadline);
+        // The final idle marker has already proved that agy completed. Do not
+        // reuse its inactivity deadline for client notification/write-through.
+        await this.reflectUnstructuredEdits(editBaseline, fsBridge, onUpdate);
       }
       return { stopReason: this.#cancelled ? "cancelled" : "end_turn" };
     } catch (error) {
@@ -634,7 +642,6 @@ export class AgyCliSession {
       this.#lastPromptUserStepIdxs = poller.userStepIdxs;
       poller.close();
       if (this.#cancelled && !failed) await this.stopPty();
-      this.#cancelTurn = undefined;
     }
   }
 
@@ -671,8 +678,7 @@ export class AgyCliSession {
   private async reflectUnstructuredEdits(
     baseline: WorkingTreeSnapshot,
     fsBridge: ClientFileSystem | undefined,
-    onUpdate: (update: SessionUpdate) => Promise<void>,
-    deadline?: number
+    onUpdate: (update: SessionUpdate) => Promise<void>
   ): Promise<void> {
     const roots = [this.config.cwd, ...this.config.additionalDirectories];
     let reflected: Awaited<ReturnType<typeof reconcileWorkingTree>>["reflected"];
@@ -695,13 +701,15 @@ export class AgyCliSession {
       // Propagate onUpdate / write-through failures: the ordinary update loop
       // does not swallow them, and going idle after a dropped edit update
       // would leave the client inconsistent with disk.
-      await this.raceTurnCallback(onUpdate(update), deadline);
+      const delivered = await this.raceTurnCallback(onUpdate(update));
+      if (delivered === "cancelled") return;
       if (fsBridge) {
         // routeEditThroughClient swallows RPC errors and returns false — treat
         // that as a hard failure here so we do not report end_turn after a
-        // promised client handoff that never completed.
-        const routed = await this.raceTurnCallback(routeEditThroughClient(update, fsBridge), deadline);
-        if (routed === "cancelled") return;
+        // promised client handoff that never completed. Once routing starts it
+        // must finish even if cancellation arrives, because it temporarily
+        // restores pre-edit text on disk while the client snapshots it.
+        const routed = await routeEditThroughClient(update, fsBridge);
         if (routed !== true) {
           throw new Error(
             `client filesystem write-through failed for reconciled edit ${toDisplayPath(edit.path, this.config.cwd)}`
@@ -726,7 +734,6 @@ export class AgyCliSession {
     fsBridge?: ClientFileSystem
   ): Promise<PromptOutcome> {
     const [program, ...args] = command;
-    this.#cancelled = false;
 
     // Snapshot existing conversation ids *before* spawning, so the file agy
     // creates for a fresh prompt is guaranteed to look "new" once it appears —
@@ -921,8 +928,12 @@ export class AgyCliSession {
     this.#cancelled = true;
     if (this.#cancelTurn) {
       this.#cancelTurn();
-      if (this.#pty) await this.stopPty();
-      return;
+      // Interactive turns have a PTY to stop. Print turns also have a cancel
+      // waiter now, but must continue below and signal their child process.
+      if (this.#pty) {
+        await this.stopPty();
+        return;
+      }
     }
     if (this.#pty) {
       await this.stopPty();

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -23,6 +23,7 @@ import {
   reconcileWorkingTree,
   snapshotWorkingTree,
   toDisplayPath,
+  type ReportedContent,
   type WorkingTreeSnapshot
 } from "./edit/reconcile.js";
 import {
@@ -52,9 +53,20 @@ function permissionSignature(row: StepRow): string {
   return p ? `${p.kind}\u0000${p.value}\u0000${p.decision}` : "none";
 }
 
-/** Absolute paths a tool-call's diff reported. Targets may be session-relative. */
-function editedPaths(cwd: string, toolCall: SessionUpdate): string[] {
-  return [...new Set(diffBlocks(toolCall).map((block) => path.resolve(cwd, block.path)))];
+/**
+ * What a tool-call's diff reported, per absolute path (targets may be
+ * session-relative). The reported texts let the reconciler tell disk that this
+ * update accounts for apart from disk a later change has already moved on.
+ */
+function reportedContents(cwd: string, toolCall: SessionUpdate): ReportedContent[] {
+  const byPath = new Map<string, string[]>();
+  for (const block of diffBlocks(toolCall)) {
+    const abs = path.resolve(cwd, block.path);
+    const texts = byPath.get(abs);
+    if (texts) texts.push(block.newText);
+    else byPath.set(abs, [block.newText]);
+  }
+  return [...byPath].map(([filePath, reportedTexts]) => ({ path: filePath, reportedTexts }));
 }
 
 /** How many unsupported changes to name individually in the warning line. */
@@ -351,8 +363,8 @@ export class AgyCliSession {
     } catch {
       editBaseline = null;
     }
-    const observeReportedEdit = (toolCall: SessionUpdate): Promise<void> =>
-      this.observeReportedEdit(editBaseline, toolCall);
+    const observeReported = (reported: ReportedContent[]): Promise<void> =>
+      this.observeReported(editBaseline, reported);
     const signature = JSON.stringify([this.config.model, this.config.effort, this.config.mode]);
     if (this.#pty && this.#ptyConfig !== signature) await this.stopPty();
     if (this.#cancelled) { this.#cancelTurn = undefined; return { stopReason: "cancelled" }; }
@@ -558,12 +570,13 @@ export class AgyCliSession {
           // take the write itself, hand it off so its native diff/review UI
           // (e.g. Zed's Review Changes panel) tracks it.
           //
-          // Disk holds exactly the content this update reports, right now:
-          // record it before any write-through revert/replay so end-of-turn
-          // reconciliation cannot mistake the client's own write (or the
-          // intermediate revert) for an unreflected change.
-          await observeReportedEdit(toolCall);
-          let rejected = false;
+          // Record what disk holds for the reported paths before any
+          // write-through revert/replay, so reconciliation cannot mistake the
+          // client's own write (or the intermediate revert) for an unreflected
+          // change. Paths whose content this update no longer accounts for are
+          // left for reconciliation to report.
+          await observeReported(reportedContents(this.config.cwd, toolCall));
+          let restored: string[] = [];
           try {
             if (fsBridge) {
               const routed = gatedIds.has(id)
@@ -592,14 +605,17 @@ export class AgyCliSession {
             deadline = Date.now() + timeoutMs;
             if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
             if (normalizePermissionChoice(choice) === "agy-reject-once") {
-              revertEditToolCall(toolCall);
-              rejected = true;
+              restored = revertEditToolCall(toolCall);
             }
           } finally {
             // A reject put the pre-edit text back on disk; that restoration is
             // the answer the client already has, so re-record it rather than
-            // reporting it again as an unstructured change.
-            if (rejected) await observeReportedEdit(toolCall);
+            // reporting it again as an unstructured change. Only the paths the
+            // revert actually restored: a diverged block it declined to touch
+            // still holds content the client has not seen.
+            if (restored.length > 0) {
+              await observeReported(restored.map((target) => ({ path: path.resolve(this.config.cwd, target) })));
+            }
           }
         }
         if (this.#cancelled) break;
@@ -650,14 +666,15 @@ export class AgyCliSession {
    * end-of-turn reconciliation only emits changes the client has *not* been
    * told about. Best effort: a snapshot we fail to refresh at worst re-reports
    * a change the client already has, which is preferable to failing the turn.
+   * (See {@link ReportedContent} for how divergence is handled.)
    */
-  private async observeReportedEdit(
+  private async observeReported(
     baseline: WorkingTreeSnapshot | null,
-    toolCall: SessionUpdate
+    reported: ReportedContent[]
   ): Promise<void> {
     if (!baseline) return;
     try {
-      await observeEditedPaths(baseline, editedPaths(this.config.cwd, toolCall));
+      await observeEditedPaths(baseline, reported);
     } catch (error) {
       console.error(`[agy-acp] WARN: could not record reported edit state: ${(error as Error).message}`);
     }
@@ -801,7 +818,7 @@ export class AgyCliSession {
           // proposed content that may never land.
           const rawUpdate = update as unknown as { status?: string };
           if (isEditToolCall(update) && rawUpdate.status === "completed") {
-            await this.observeReportedEdit(editBaseline, update);
+            await this.observeReported(editBaseline, reportedContents(this.config.cwd, update));
           }
         }
       };

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -17,9 +17,9 @@ import {
   type ClientFileSystem
 } from "./edit/bridge.js";
 import {
+  applyDiffBlockToSnapshot,
   buildReconcileEditUpdate,
   reconcileWorkingTree,
-  refreshSnapshotPath,
   snapshotWorkingTree,
   toDisplayPath,
   type WorkingTreeSnapshot
@@ -342,10 +342,17 @@ export class AgyCliSession {
     } catch {
       editBaseline = null;
     }
-    const noteRecognizedEdit = async (toolCall: SessionUpdate): Promise<void> => {
+    // Advance baseline from the structured diff content (not disk): by the time
+    // we observe the tool-call, a later shell edit may already be on disk.
+    const noteRecognizedEdit = (toolCall: SessionUpdate): void => {
       if (!editBaseline) return;
       for (const block of diffBlocks(toolCall)) {
-        await refreshSnapshotPath(editBaseline, path.resolve(this.config.cwd, block.path));
+        applyDiffBlockToSnapshot(
+          editBaseline,
+          path.resolve(this.config.cwd, block.path),
+          block.oldText,
+          block.newText
+        );
       }
     };
     const signature = JSON.stringify([this.config.model, this.config.effort, this.config.mode]);
@@ -551,9 +558,11 @@ export class AgyCliSession {
           // (accept-edits / skip-permissions), or it just passed through the
           // live gate above and agy applied it. Either way, if the client can
           // take the write itself, hand it off so its native diff/review UI
-          // (e.g. Zed's Review Changes panel) tracks it. After disk settles,
-          // advance the edit baseline for this path so end-of-turn
-          // reconciliation only picks up *further* unstructured changes.
+          // (e.g. Zed's Review Changes panel) tracks it. On keep, advance the
+          // edit baseline from the structured diff so end-of-turn reconciliation
+          // only picks up *further* unstructured changes (and is not fooled by
+          // disk that already includes a later shell edit).
+          let rejected = false;
           try {
             if (fsBridge) {
               const routed = gatedIds.has(id)
@@ -581,11 +590,14 @@ export class AgyCliSession {
             );
             deadline = Date.now() + timeoutMs;
             if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
-            if (normalizePermissionChoice(choice) === "agy-reject-once") revertEditToolCall(toolCall);
+            if (normalizePermissionChoice(choice) === "agy-reject-once") {
+              revertEditToolCall(toolCall);
+              rejected = true;
+            }
           } finally {
-            // Diff-block paths may be session-relative — resolve against the
-            // session cwd so the baseline key matches the snapshot.
-            await noteRecognizedEdit(toolCall);
+            // Reject leaves disk (and baseline) at the pre-edit state — do not
+            // advance. Diff-block paths may be session-relative.
+            if (!rejected) noteRecognizedEdit(toolCall);
           }
         }
         if (this.#cancelled) break;
@@ -744,11 +756,16 @@ export class AgyCliSession {
       const pollOnce = async () => {
         for (const update of poller.poll()) {
           await onUpdate(update);
-          // Advance the baseline past recognized edits so end-of-turn
-          // reconciliation only emits further unstructured changes.
+          // Advance the baseline from the structured diff (not disk): a shell
+          // edit may already have landed before this poll observes the tool-call.
           if (editBaseline && isEditToolCall(update)) {
             for (const block of diffBlocks(update)) {
-              await refreshSnapshotPath(editBaseline, path.resolve(this.config.cwd, block.path));
+              applyDiffBlockToSnapshot(
+                editBaseline,
+                path.resolve(this.config.cwd, block.path),
+                block.oldText,
+                block.newText
+              );
             }
           }
         }

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -19,6 +19,7 @@ import {
 import {
   buildReconcileEditUpdate,
   reconcileWorkingTree,
+  refreshSnapshotPath,
   snapshotWorkingTree,
   toDisplayPath,
   type WorkingTreeSnapshot
@@ -308,11 +309,11 @@ export class AgyCliSession {
     }
     const command = this.commandForPrompt(prompt);
     try {
-      return await this.runPromptCommand(command, prompt, onUpdate);
+      return await this.runPromptCommand(command, prompt, onUpdate, fsBridge);
     } catch (error) {
       if (this.shouldInstallAfterError(error)) {
         await this.installAgy();
-        return await this.runPromptCommand(this.commandForPrompt(prompt), prompt, onUpdate);
+        return await this.runPromptCommand(this.commandForPrompt(prompt), prompt, onUpdate, fsBridge);
       }
       throw error;
     }
@@ -327,20 +328,26 @@ export class AgyCliSession {
   ): Promise<PromptOutcome> {
     this.#cancelled = false;
     this.#cancelWait = new Promise((resolve) => { this.#cancelTurn = resolve; });
-    // Paths reflected through a recognized edit this turn; excluded from the
-    // end-of-turn working-tree reconciliation (see #76) so we don't double-emit.
-    const reflectedPaths = new Set<string>();
     // Snapshot the pre-edit working tree so edits agy makes outside recognized
     // structured-edit tool-calls (shell commands, unrecognized payloads) still
     // get reflected through ACP. Emitting the synthetic session/update needs no
     // client fs capability, so do this for every client (v1 and v2); the client
     // write-through is layered on later only when a bridge is available.
+    // When a recognized edit lands we advance the baseline for that path (see
+    // noteRecognizedEdit below) so a later shell change to the same file is
+    // still reconciled rather than suppressed for the rest of the turn.
     let editBaseline: WorkingTreeSnapshot | null = null;
     try {
       editBaseline = await snapshotWorkingTree([this.config.cwd, ...this.config.additionalDirectories]);
     } catch {
       editBaseline = null;
     }
+    const noteRecognizedEdit = async (toolCall: SessionUpdate): Promise<void> => {
+      if (!editBaseline) return;
+      for (const block of diffBlocks(toolCall)) {
+        await refreshSnapshotPath(editBaseline, path.resolve(this.config.cwd, block.path));
+      }
+    };
     const signature = JSON.stringify([this.config.model, this.config.effort, this.config.mode]);
     if (this.#pty && this.#ptyConfig !== signature) await this.stopPty();
     if (this.#cancelled) { this.#cancelTurn = undefined; return { stopReason: "cancelled" }; }
@@ -544,39 +551,42 @@ export class AgyCliSession {
           // (accept-edits / skip-permissions), or it just passed through the
           // live gate above and agy applied it. Either way, if the client can
           // take the write itself, hand it off so its native diff/review UI
-          // (e.g. Zed's Review Changes panel) tracks it.
-          // Recognized edit: record its paths so end-of-turn reconciliation
-          // doesn't re-emit them as unstructured changes. Diff-block paths may
-          // be session-relative, so resolve against the session cwd (not the
-          // adapter process cwd) to match the snapshot's absolute keys.
-          for (const block of diffBlocks(toolCall)) reflectedPaths.add(path.resolve(this.config.cwd, block.path));
-          if (fsBridge) {
-            const routed = gatedIds.has(id)
-              // Pre-edit state was already primed above (race-free) — just
-              // hand over the final content, no local revert needed.
-              ? await this.raceTurnCallback(writeEditThroughClient(toolCall, fsBridge), deadline)
-              // No prior gate — this is the only chance we get, so fall back
-              // to revert-then-replay (races the client's file watcher if
-              // the file happens to be open there, but it's the best we can
-              // do after the fact).
-              : await this.raceTurnCallback(routeEditThroughClient(toolCall, fsBridge), deadline);
-            if (routed === true) continue;
-          }
-          if (gatedIds.has(id)) {
-            // Already approved through the live gate above and the client
-            // has no write-through — nothing more to do here.
-            continue;
-          }
+          // (e.g. Zed's Review Changes panel) tracks it. After disk settles,
+          // advance the edit baseline for this path so end-of-turn
+          // reconciliation only picks up *further* unstructured changes.
+          try {
+            if (fsBridge) {
+              const routed = gatedIds.has(id)
+                // Pre-edit state was already primed above (race-free) — just
+                // hand over the final content, no local revert needed.
+                ? await this.raceTurnCallback(writeEditThroughClient(toolCall, fsBridge), deadline)
+                // No prior gate — this is the only chance we get, so fall back
+                // to revert-then-replay (races the client's file watcher if
+                // the file happens to be open there, but it's the best we can
+                // do after the fact).
+                : await this.raceTurnCallback(routeEditThroughClient(toolCall, fsBridge), deadline);
+              if (routed === true) continue;
+            }
+            if (gatedIds.has(id)) {
+              // Already approved through the live gate above and the client
+              // has no write-through — nothing more to do here.
+              continue;
+            }
 
-          // Genuinely ungated (no live agy gate ever asked) and no client
-          // write-through available — offer local review: keep is a no-op,
-          // reject restores prior text.
-          const choice = await this.raceTurnCallback(
-            onPermission(toolCall, { toolName: interaction.toolName })
-          );
-          deadline = Date.now() + timeoutMs;
-          if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
-          if (normalizePermissionChoice(choice) === "agy-reject-once") revertEditToolCall(toolCall);
+            // Genuinely ungated (no live agy gate ever asked) and no client
+            // write-through available — offer local review: keep is a no-op,
+            // reject restores prior text.
+            const choice = await this.raceTurnCallback(
+              onPermission(toolCall, { toolName: interaction.toolName })
+            );
+            deadline = Date.now() + timeoutMs;
+            if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
+            if (normalizePermissionChoice(choice) === "agy-reject-once") revertEditToolCall(toolCall);
+          } finally {
+            // Diff-block paths may be session-relative — resolve against the
+            // session cwd so the baseline key matches the snapshot.
+            await noteRecognizedEdit(toolCall);
+          }
         }
         if (this.#cancelled) break;
         if (candidateRevision === poller.revision && this.#ptyIdleMarkerCount >= requiredIdleMarkerCount) break;
@@ -584,7 +594,7 @@ export class AgyCliSession {
         if (exited && !this.#cancelled) throw new AgyCliError(`agy interactive PTY exited unexpectedly: ${this.#ptyOutput.trim() || "<no output>"}`, [this.config.agyPath], null, this.#ptyOutput);
       }
       if (editBaseline && !this.#cancelled) {
-        await this.reflectUnstructuredEdits(editBaseline, reflectedPaths, fsBridge, onUpdate, deadline);
+        await this.reflectUnstructuredEdits(editBaseline, fsBridge, onUpdate, deadline);
       }
       return { stopReason: this.#cancelled ? "cancelled" : "end_turn" };
     } catch (error) {
@@ -621,48 +631,59 @@ export class AgyCliSession {
   }
 
   /**
-   * After a turn, diff the working tree against the pre-edit snapshot and
-   * reflect any change agy made that never surfaced as a recognized structured
-   * edit (shell edits, unrecognized payloads) through ACP: emit a synthetic
-   * edit update for every client, and additionally hand the write to the client
-   * when it advertises fs capabilities. Changes that can't be shown as a text
-   * diff (binary/oversized/deletions) are reported, not dropped (#76).
+   * After a turn, diff the working tree against the (possibly advanced)
+   * baseline and reflect any change agy made that never surfaced as a
+   * recognized structured edit (shell edits, unrecognized payloads) through
+   * ACP: emit a synthetic edit update for every client, and additionally hand
+   * the write to the client when it advertises fs capabilities. Discovery
+   * failures are best-effort (logged); notification failures propagate so the
+   * caller does not go idle after a dropped update. Changes that can't be
+   * shown as a text diff (binary/oversized/deletions) are reported, not
+   * dropped (#76).
    */
   private async reflectUnstructuredEdits(
     baseline: WorkingTreeSnapshot,
-    reflectedPaths: Set<string>,
     fsBridge: ClientFileSystem | undefined,
     onUpdate: (update: SessionUpdate) => Promise<void>,
-    deadline: number
+    deadline?: number
   ): Promise<void> {
+    const roots = [this.config.cwd, ...this.config.additionalDirectories];
+    let reflected: Awaited<ReturnType<typeof reconcileWorkingTree>>["reflected"];
+    let unsupported: Awaited<ReturnType<typeof reconcileWorkingTree>>["unsupported"];
     try {
-      const roots = [this.config.cwd, ...this.config.additionalDirectories];
-      const { reflected, unsupported } = await reconcileWorkingTree(baseline, roots, reflectedPaths);
-      const turnToken = String(this.#reconcileTurnSeq++);
-      let index = 0;
-      for (const edit of reflected) {
-        if (this.#cancelled) return;
-        const update = buildReconcileEditUpdate(edit, index++, this.config.cwd, turnToken);
-        await this.raceTurnCallback(onUpdate(update), deadline);
-        if (fsBridge) await this.raceTurnCallback(routeEditThroughClient(update, fsBridge), deadline);
-      }
-      if (unsupported.length > 0) {
-        const detail = unsupported
-          .map((change) => `${toDisplayPath(change.path, this.config.cwd)} (${change.reason})`)
-          .join(", ");
-        console.error(
-          `[agy-acp] WARN: ${unsupported.length} filesystem change(s) not reflected through ACP: ${detail}`
-        );
-      }
+      ({ reflected, unsupported } = await reconcileWorkingTree(baseline, roots));
     } catch (error) {
+      // Filesystem scan is best-effort — a transient stat failure shouldn't
+      // fail the whole turn after agy already finished.
       console.error(`[agy-acp] WARN: working-tree reconciliation failed: ${(error as Error).message}`);
+      return;
+    }
+    const turnToken = String(this.#reconcileTurnSeq++);
+    let index = 0;
+    for (const edit of reflected) {
+      if (this.#cancelled) return;
+      const update = buildReconcileEditUpdate(edit, index++, this.config.cwd, turnToken);
+      // Propagate onUpdate / write-through failures: the ordinary update loop
+      // does not swallow them, and going idle after a dropped edit update
+      // would leave the client inconsistent with disk.
+      await this.raceTurnCallback(onUpdate(update), deadline);
+      if (fsBridge) await this.raceTurnCallback(routeEditThroughClient(update, fsBridge), deadline);
+    }
+    if (unsupported.length > 0) {
+      const detail = unsupported
+        .map((change) => `${toDisplayPath(change.path, this.config.cwd)} (${change.reason})`)
+        .join(", ");
+      console.error(
+        `[agy-acp] WARN: ${unsupported.length} filesystem change(s) not reflected through ACP: ${detail}`
+      );
     }
   }
 
   private async runPromptCommand(
     command: string[],
     prompt: string,
-    onUpdate: (update: SessionUpdate) => Promise<void>
+    onUpdate: (update: SessionUpdate) => Promise<void>,
+    fsBridge?: ClientFileSystem
   ): Promise<PromptOutcome> {
     const [program, ...args] = command;
     this.#cancelled = false;
@@ -672,6 +693,17 @@ export class AgyCliSession {
     // spawning after the snapshot would risk racing agy's own DB creation.
     const snapshot = this.#conversationId === null ? conversationSnapshot(this.config.conversationsDir) : null;
 
+    // Same working-tree reconciliation as the interactive path: print-mode
+    // turns (`--dangerously-skip-permissions`, `--no-interactive-permissions`,
+    // etc.) still need shell / unrecognized edits reflected through ACP.
+    let editBaseline: WorkingTreeSnapshot | null = null;
+    try {
+      editBaseline = await snapshotWorkingTree([this.config.cwd, ...this.config.additionalDirectories]);
+    } catch {
+      editBaseline = null;
+    }
+    if (this.#cancelled) return { stopReason: "cancelled" };
+
     let child: SpawnedProcess;
     try {
       child = this.spawnProcess(program, args, this.spawnOptions());
@@ -679,6 +711,12 @@ export class AgyCliSession {
       throw this.errorForSpawnFailure(command, error as NodeJS.ErrnoException);
     }
     this.#process = child;
+    // Cancel may have landed in the gap between snapshot and spawn assignment.
+    if (this.#cancelled) {
+      if (process.platform === "win32") child.kill();
+      else child.kill("SIGINT");
+      return { stopReason: "cancelled" };
+    }
     const exitPromise = waitForExit(child);
     const errorPromise = once(child, "error") as Promise<[NodeJS.ErrnoException]>;
     const stderrChunks: Buffer[] = [];
@@ -706,6 +744,13 @@ export class AgyCliSession {
       const pollOnce = async () => {
         for (const update of poller.poll()) {
           await onUpdate(update);
+          // Advance the baseline past recognized edits so end-of-turn
+          // reconciliation only emits further unstructured changes.
+          if (editBaseline && isEditToolCall(update)) {
+            for (const block of diffBlocks(update)) {
+              await refreshSnapshotPath(editBaseline, path.resolve(this.config.cwd, block.path));
+            }
+          }
         }
       };
 
@@ -743,6 +788,10 @@ export class AgyCliSession {
           exitCode,
           stderr
         );
+      }
+
+      if (editBaseline && !this.#cancelled) {
+        await this.reflectUnstructuredEdits(editBaseline, fsBridge, onUpdate);
       }
 
       return { stopReason: this.#cancelled ? "cancelled" : "end_turn" };
@@ -825,14 +874,16 @@ export class AgyCliSession {
   }
 
   async cancel(): Promise<void> {
+    // Always mark cancelled first so a print-mode turn still in its pre-spawn
+    // working-tree snapshot (or any other gap before #process is set) observes
+    // the cancel and returns cancelled instead of racing ahead.
+    this.#cancelled = true;
     if (this.#cancelTurn) {
-      this.#cancelled = true;
       this.#cancelTurn();
       if (this.#pty) await this.stopPty();
       return;
     }
     if (this.#pty) {
-      this.#cancelled = true;
       await this.stopPty();
       return;
     }
@@ -840,7 +891,6 @@ export class AgyCliSession {
     if (!child || child.exitCode !== null) {
       return;
     }
-    this.#cancelled = true;
     const exitPromise = once(child, "exit");
     // SIGINT (rather than SIGTERM) gives agy a chance to flush its last
     // conversation-database write before exiting. Windows has no real SIGINT,

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -61,14 +61,19 @@ function permissionSignature(row: StepRow): string {
  */
 const WHOLE_FILE_EDIT_TOOLS = new Set(["write_to_file"]);
 
+/** True when the tool-call's diff blocks carry whole file bodies, not snippets. */
+function wholeFileEdit(toolCall: SessionUpdate): boolean {
+  const name = (toolCall as unknown as { name?: string }).name;
+  return name !== undefined && WHOLE_FILE_EDIT_TOOLS.has(name);
+}
+
 /**
  * What a tool-call's diff reported, per absolute path (targets may be
  * session-relative). The blocks let the reconciler tell the change this update
  * accounts for apart from one that reached the file before it was polled.
  */
 function reportedContents(cwd: string, toolCall: SessionUpdate): ReportedContent[] {
-  const name = (toolCall as unknown as { name?: string }).name;
-  const wholeFile = name !== undefined && WHOLE_FILE_EDIT_TOOLS.has(name);
+  const wholeFile = wholeFileEdit(toolCall);
   const byPath = new Map<string, Array<{ oldText: string | null; newText: string }>>();
   for (const { path: target, oldText, newText } of diffBlocks(toolCall)) {
     const abs = path.resolve(cwd, target);
@@ -88,8 +93,7 @@ function reportedContents(cwd: string, toolCall: SessionUpdate): ReportedContent
  * next to the edit before the reject still reaches reconciliation.
  */
 function revertedContents(cwd: string, toolCall: SessionUpdate, restored: DiffBlock[]): ReportedContent[] {
-  const name = (toolCall as unknown as { name?: string }).name;
-  const wholeFile = name !== undefined && WHOLE_FILE_EDIT_TOOLS.has(name);
+  const wholeFile = wholeFileEdit(toolCall);
   const byPath = new Map<string, { created: boolean; blocks: ReportedBlock[] }>();
   for (const { path: target, oldText, newText } of restored) {
     const abs = path.resolve(cwd, target);

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -351,7 +351,8 @@ export class AgyCliSession {
           editBaseline,
           path.resolve(this.config.cwd, block.path),
           block.oldText,
-          block.newText
+          block.newText,
+          block.line
         );
       }
     };
@@ -679,7 +680,18 @@ export class AgyCliSession {
       // does not swallow them, and going idle after a dropped edit update
       // would leave the client inconsistent with disk.
       await this.raceTurnCallback(onUpdate(update), deadline);
-      if (fsBridge) await this.raceTurnCallback(routeEditThroughClient(update, fsBridge), deadline);
+      if (fsBridge) {
+        // routeEditThroughClient swallows RPC errors and returns false — treat
+        // that as a hard failure here so we do not report end_turn after a
+        // promised client handoff that never completed.
+        const routed = await this.raceTurnCallback(routeEditThroughClient(update, fsBridge), deadline);
+        if (routed === "cancelled") return;
+        if (routed !== true) {
+          throw new Error(
+            `client filesystem write-through failed for reconciled edit ${toDisplayPath(edit.path, this.config.cwd)}`
+          );
+        }
+      }
     }
     if (unsupported.length > 0) {
       const detail = unsupported
@@ -758,13 +770,17 @@ export class AgyCliSession {
           await onUpdate(update);
           // Advance the baseline from the structured diff (not disk): a shell
           // edit may already have landed before this poll observes the tool-call.
-          if (editBaseline && isEditToolCall(update)) {
+          // Only completed edits — pending/failed lifecycle updates must not
+          // move the baseline to proposed content that never landed on disk.
+          const rawUpdate = update as unknown as { status?: string };
+          if (editBaseline && isEditToolCall(update) && rawUpdate.status === "completed") {
             for (const block of diffBlocks(update)) {
               applyDiffBlockToSnapshot(
                 editBaseline,
                 path.resolve(this.config.cwd, block.path),
                 block.oldText,
-                block.newText
+                block.newText,
+                block.line
               );
             }
           }

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -327,16 +327,16 @@ export class AgyCliSession {
     // Paths reflected through a recognized edit this turn; excluded from the
     // end-of-turn working-tree reconciliation (see #76) so we don't double-emit.
     const reflectedPaths = new Set<string>();
-    // Snapshot the pre-edit working tree while the client can consume writes,
-    // so edits agy makes outside recognized structured-edit tool-calls (shell
-    // commands, unrecognized payloads) still get reflected through ACP.
+    // Snapshot the pre-edit working tree so edits agy makes outside recognized
+    // structured-edit tool-calls (shell commands, unrecognized payloads) still
+    // get reflected through ACP. Emitting the synthetic session/update needs no
+    // client fs capability, so do this for every client (v1 and v2); the client
+    // write-through is layered on later only when a bridge is available.
     let editBaseline: WorkingTreeSnapshot | null = null;
-    if (fsBridge) {
-      try {
-        editBaseline = await snapshotWorkingTree([this.config.cwd, ...this.config.additionalDirectories]);
-      } catch {
-        editBaseline = null;
-      }
+    try {
+      editBaseline = await snapshotWorkingTree([this.config.cwd, ...this.config.additionalDirectories]);
+    } catch {
+      editBaseline = null;
     }
     const signature = JSON.stringify([this.config.model, this.config.effort, this.config.mode]);
     if (this.#pty && this.#ptyConfig !== signature) await this.stopPty();
@@ -578,7 +578,7 @@ export class AgyCliSession {
         const exited = await Promise.race([activePtyExit.then(() => true), sleep(POLL_INTERVAL_MS).then(() => false)]);
         if (exited && !this.#cancelled) throw new AgyCliError(`agy interactive PTY exited unexpectedly: ${this.#ptyOutput.trim() || "<no output>"}`, [this.config.agyPath], null, this.#ptyOutput);
       }
-      if (fsBridge && editBaseline && !this.#cancelled) {
+      if (editBaseline && !this.#cancelled) {
         await this.reflectUnstructuredEdits(editBaseline, reflectedPaths, fsBridge, onUpdate, deadline);
       }
       return { stopReason: this.#cancelled ? "cancelled" : "end_turn" };
@@ -619,13 +619,14 @@ export class AgyCliSession {
    * After a turn, diff the working tree against the pre-edit snapshot and
    * reflect any change agy made that never surfaced as a recognized structured
    * edit (shell edits, unrecognized payloads) through ACP: emit a synthetic
-   * edit update and hand the write to the client. Changes that can't be shown
-   * as a text diff (binary/oversized/deletions) are reported, not dropped (#76).
+   * edit update for every client, and additionally hand the write to the client
+   * when it advertises fs capabilities. Changes that can't be shown as a text
+   * diff (binary/oversized/deletions) are reported, not dropped (#76).
    */
   private async reflectUnstructuredEdits(
     baseline: WorkingTreeSnapshot,
     reflectedPaths: Set<string>,
-    fsBridge: ClientFileSystem,
+    fsBridge: ClientFileSystem | undefined,
     onUpdate: (update: SessionUpdate) => Promise<void>,
     deadline: number
   ): Promise<void> {
@@ -637,7 +638,7 @@ export class AgyCliSession {
         if (this.#cancelled) return;
         const update = buildReconcileEditUpdate(edit, index++, this.config.cwd);
         await this.raceTurnCallback(onUpdate(update), deadline);
-        await this.raceTurnCallback(routeEditThroughClient(update, fsBridge), deadline);
+        if (fsBridge) await this.raceTurnCallback(routeEditThroughClient(update, fsBridge), deadline);
       }
       if (unsupported.length > 0) {
         const detail = unsupported

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -9,13 +9,20 @@ import { conversationSnapshot } from "./db/scan.js";
 import { defaultInstallBinDir, ensureAgyInstalled } from "./installer.js";
 import { StreamPoller } from "./db/streaming.js";
 import type { StepRow } from "./db/types.js";
-import { revertEditToolCall } from "./edit/revert.js";
+import { diffBlocks, revertEditToolCall } from "./edit/revert.js";
 import {
   primeEditReadThroughClient,
   routeEditThroughClient,
   writeEditThroughClient,
   type ClientFileSystem
 } from "./edit/bridge.js";
+import {
+  buildReconcileEditUpdate,
+  reconcileWorkingTree,
+  snapshotWorkingTree,
+  toDisplayPath,
+  type WorkingTreeSnapshot
+} from "./edit/reconcile.js";
 import {
   canBridgeInteraction,
   interactionKeys,
@@ -317,6 +324,20 @@ export class AgyCliSession {
   ): Promise<PromptOutcome> {
     this.#cancelled = false;
     this.#cancelWait = new Promise((resolve) => { this.#cancelTurn = resolve; });
+    // Paths reflected through a recognized edit this turn; excluded from the
+    // end-of-turn working-tree reconciliation (see #76) so we don't double-emit.
+    const reflectedPaths = new Set<string>();
+    // Snapshot the pre-edit working tree while the client can consume writes,
+    // so edits agy makes outside recognized structured-edit tool-calls (shell
+    // commands, unrecognized payloads) still get reflected through ACP.
+    let editBaseline: WorkingTreeSnapshot | null = null;
+    if (fsBridge) {
+      try {
+        editBaseline = await snapshotWorkingTree([this.config.cwd, ...this.config.additionalDirectories]);
+      } catch {
+        editBaseline = null;
+      }
+    }
     const signature = JSON.stringify([this.config.model, this.config.effort, this.config.mode]);
     if (this.#pty && this.#ptyConfig !== signature) await this.stopPty();
     if (this.#cancelled) { this.#cancelTurn = undefined; return { stopReason: "cancelled" }; }
@@ -521,6 +542,9 @@ export class AgyCliSession {
           // live gate above and agy applied it. Either way, if the client can
           // take the write itself, hand it off so its native diff/review UI
           // (e.g. Zed's Review Changes panel) tracks it.
+          // Recognized edit: record its paths so end-of-turn reconciliation
+          // doesn't re-emit them as unstructured changes.
+          for (const block of diffBlocks(toolCall)) reflectedPaths.add(path.resolve(block.path));
           if (fsBridge) {
             const routed = gatedIds.has(id)
               // Pre-edit state was already primed above (race-free) — just
@@ -554,6 +578,9 @@ export class AgyCliSession {
         const exited = await Promise.race([activePtyExit.then(() => true), sleep(POLL_INTERVAL_MS).then(() => false)]);
         if (exited && !this.#cancelled) throw new AgyCliError(`agy interactive PTY exited unexpectedly: ${this.#ptyOutput.trim() || "<no output>"}`, [this.config.agyPath], null, this.#ptyOutput);
       }
+      if (fsBridge && editBaseline && !this.#cancelled) {
+        await this.reflectUnstructuredEdits(editBaseline, reflectedPaths, fsBridge, onUpdate, deadline);
+      }
       return { stopReason: this.#cancelled ? "cancelled" : "end_turn" };
     } catch (error) {
       failed = true;
@@ -585,6 +612,43 @@ export class AgyCliSession {
       return await Promise.race([guarded, this.#cancelWait.then(() => "cancelled" as const), timedOut]);
     } finally {
       if (timer) clearTimeout(timer);
+    }
+  }
+
+  /**
+   * After a turn, diff the working tree against the pre-edit snapshot and
+   * reflect any change agy made that never surfaced as a recognized structured
+   * edit (shell edits, unrecognized payloads) through ACP: emit a synthetic
+   * edit update and hand the write to the client. Changes that can't be shown
+   * as a text diff (binary/oversized/deletions) are reported, not dropped (#76).
+   */
+  private async reflectUnstructuredEdits(
+    baseline: WorkingTreeSnapshot,
+    reflectedPaths: Set<string>,
+    fsBridge: ClientFileSystem,
+    onUpdate: (update: SessionUpdate) => Promise<void>,
+    deadline: number
+  ): Promise<void> {
+    try {
+      const roots = [this.config.cwd, ...this.config.additionalDirectories];
+      const { reflected, unsupported } = await reconcileWorkingTree(baseline, roots, reflectedPaths);
+      let index = 0;
+      for (const edit of reflected) {
+        if (this.#cancelled) return;
+        const update = buildReconcileEditUpdate(edit, index++, this.config.cwd);
+        await this.raceTurnCallback(onUpdate(update), deadline);
+        await this.raceTurnCallback(routeEditThroughClient(update, fsBridge), deadline);
+      }
+      if (unsupported.length > 0) {
+        const detail = unsupported
+          .map((change) => `${toDisplayPath(change.path, this.config.cwd)} (${change.reason})`)
+          .join(", ");
+        console.error(
+          `[agy-acp] WARN: ${unsupported.length} filesystem change(s) not reflected through ACP: ${detail}`
+        );
+      }
+    } catch (error) {
+      console.error(`[agy-acp] WARN: working-tree reconciliation failed: ${(error as Error).message}`);
     }
   }
 

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -54,19 +54,28 @@ function permissionSignature(row: StepRow): string {
 }
 
 /**
+ * agy tools whose diff blocks carry the whole file body rather than a snippet,
+ * so disk is accounted for exactly when it equals the reported content. An
+ * unrecognized name is treated as a targeted replacement, which fails closed.
+ */
+const WHOLE_FILE_EDIT_TOOLS = new Set(["write_to_file"]);
+
+/**
  * What a tool-call's diff reported, per absolute path (targets may be
- * session-relative). The reported texts let the reconciler tell disk that this
- * update accounts for apart from disk a later change has already moved on.
+ * session-relative). The blocks let the reconciler tell the change this update
+ * accounts for apart from one that reached the file before it was polled.
  */
 function reportedContents(cwd: string, toolCall: SessionUpdate): ReportedContent[] {
-  const byPath = new Map<string, string[]>();
-  for (const block of diffBlocks(toolCall)) {
-    const abs = path.resolve(cwd, block.path);
-    const texts = byPath.get(abs);
-    if (texts) texts.push(block.newText);
-    else byPath.set(abs, [block.newText]);
+  const name = (toolCall as unknown as { name?: string }).name;
+  const wholeFile = name !== undefined && WHOLE_FILE_EDIT_TOOLS.has(name);
+  const byPath = new Map<string, Array<{ oldText: string | null; newText: string }>>();
+  for (const { path: target, oldText, newText } of diffBlocks(toolCall)) {
+    const abs = path.resolve(cwd, target);
+    const blocks = byPath.get(abs);
+    if (blocks) blocks.push({ oldText, newText });
+    else byPath.set(abs, [{ oldText, newText }]);
   }
-  return [...byPath].map(([filePath, reportedTexts]) => ({ path: filePath, reportedTexts }));
+  return [...byPath].map(([filePath, blocks]) => ({ path: filePath, blocks, wholeFile }));
 }
 
 /** How many unsupported changes to name individually in the warning line. */

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -1,4 +1,5 @@
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import { randomUUID } from "node:crypto";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { once } from "node:events";
 import { chmodSync, existsSync, statSync } from "node:fs";
@@ -17,7 +18,7 @@ import {
   type ClientFileSystem
 } from "./edit/bridge.js";
 import {
-  applyDiffBlockToSnapshot,
+  applyDiffBlocksToSnapshot,
   buildReconcileEditUpdate,
   reconcileWorkingTree,
   snapshotWorkingTree,
@@ -49,6 +50,28 @@ const PERMISSION_REDRAW_TIMEOUT_MS = 500;
 function permissionSignature(row: StepRow): string {
   const p = row.permission;
   return p ? `${p.kind}\u0000${p.value}\u0000${p.decision}` : "none";
+}
+
+/**
+ * Advance the edit baseline from a completed structured-edit tool-call.
+ * Groups multi-replace chunks by path so StartLine values stay relative to the
+ * pre-edit file (see {@link applyDiffBlocksToSnapshot}).
+ */
+function noteStructuredEditOnBaseline(
+  baseline: WorkingTreeSnapshot,
+  cwd: string,
+  toolCall: SessionUpdate
+): void {
+  const byPath = new Map<string, ReturnType<typeof diffBlocks>>();
+  for (const block of diffBlocks(toolCall)) {
+    const abs = path.resolve(cwd, block.path);
+    const list = byPath.get(abs);
+    if (list) list.push(block);
+    else byPath.set(abs, [block]);
+  }
+  for (const [abs, blocks] of byPath) {
+    applyDiffBlocksToSnapshot(baseline, abs, blocks);
+  }
 }
 
 export type SpawnedProcess = ChildProcessWithoutNullStreams;
@@ -173,9 +196,6 @@ export class AgyCliSession {
   #conversationId: string | null = null;
   #lastStepIdx = -1;
   #lastPromptUserStepIdxs: number[] = [];
-  // Monotonic per-session counter so reconciled edit tool-call IDs stay unique
-  // across turns (clients key tool-call lifecycles on toolCallId).
-  #reconcileTurnSeq = 0;
   readonly config: AgyCliConfig;
   readonly spawnProcess: SpawnFactory;
   readonly ptyFactory?: PtyFactory;
@@ -344,17 +364,11 @@ export class AgyCliSession {
     }
     // Advance baseline from the structured diff content (not disk): by the time
     // we observe the tool-call, a later shell edit may already be on disk.
+    // Multi-replace chunks for one path are applied together so StartLine stays
+    // relative to the pre-edit text.
     const noteRecognizedEdit = (toolCall: SessionUpdate): void => {
       if (!editBaseline) return;
-      for (const block of diffBlocks(toolCall)) {
-        applyDiffBlockToSnapshot(
-          editBaseline,
-          path.resolve(this.config.cwd, block.path),
-          block.oldText,
-          block.newText,
-          block.line
-        );
-      }
+      noteStructuredEditOnBaseline(editBaseline, this.config.cwd, toolCall);
     };
     const signature = JSON.stringify([this.config.model, this.config.effort, this.config.mode]);
     if (this.#pty && this.#ptyConfig !== signature) await this.stopPty();
@@ -671,7 +685,9 @@ export class AgyCliSession {
       console.error(`[agy-acp] WARN: working-tree reconciliation failed: ${(error as Error).message}`);
       return;
     }
-    const turnToken = String(this.#reconcileTurnSeq++);
+    // UUID (not a session-local counter): session/load and session/resume rebuild
+    // AgyCliSession via startSession, which would reset a counter and reuse IDs.
+    const turnToken = randomUUID();
     let index = 0;
     for (const edit of reflected) {
       if (this.#cancelled) return;
@@ -774,15 +790,7 @@ export class AgyCliSession {
           // move the baseline to proposed content that never landed on disk.
           const rawUpdate = update as unknown as { status?: string };
           if (editBaseline && isEditToolCall(update) && rawUpdate.status === "completed") {
-            for (const block of diffBlocks(update)) {
-              applyDiffBlockToSnapshot(
-                editBaseline,
-                path.resolve(this.config.cwd, block.path),
-                block.oldText,
-                block.newText,
-                block.line
-              );
-            }
+            noteStructuredEditOnBaseline(editBaseline, this.config.cwd, update);
           }
         }
       };

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -159,6 +159,10 @@ export class StreamPoller {
       latest !== undefined &&
       latest.stepType !== 14 &&
       (latest.status === 3 || latest.status === 6 || latest.status === 7);
+    // readAfter(baseStepIdx) is a complete prompt-scoped snapshot on every DB
+    // change. Rebuild derived file history from those rows so completed writes
+    // from a prior poll cannot become the oldText of an earlier historical row.
+    this.translator.resetFileContentsForFullReplay();
     const updates = this.translator.translate(rows);
     const rowsByToolCallId = new Map(rows.map((row) => [toolCallId(row), row]));
     const blockedIds = new Set(rows.filter((row) => row.status === 9).map(toolCallId));

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -696,8 +696,10 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
       const cacheKey = path.resolve(resolvedTarget);
       const prior = fileContents?.get(cacheKey) ?? null;
       content.push({ type: "diff", path: targetFile, oldText: prior, newText: fullContent });
-      // Plan-file incomplete writes must not poison the cache used by replace derivation.
-      if (!isPlanFile(targetFile) || status === "completed") {
+      // Pending/failed writes describe proposed content, not a new baseline.
+      // Preserve the prior body until completion so the completed lifecycle
+      // update still carries a meaningful oldText instead of newText→newText.
+      if (status === "completed") {
         fileContents?.set(cacheKey, fullContent);
       }
       if (isReadableLocation(resolvedTarget, ctx)) locations.push({ path: resolvedTarget });

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -715,10 +715,18 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
       const newText = asStr(pick(chunk, "ReplacementContent", "replacementContent"));
       if (newText === null || !targetFile) continue;
       const oldText = asStr(pick(chunk, "TargetContent", "targetContent"));
-      content.push({ type: "diff", path: targetFile, oldText, newText });
+      // Carry StartLine on the diff block so baseline advancement can target the
+      // same occurrence when TargetContent appears more than once.
+      const line = asNum(pick(chunk, "StartLine", "startLine"));
+      content.push({
+        type: "diff",
+        path: targetFile,
+        oldText,
+        newText,
+        ...(line !== null ? { line } : {})
+      });
 
       if (isReadableLocation(resolvedTarget, ctx)) {
-        const line = asNum(pick(chunk, "StartLine", "startLine"));
         locations.push(line !== null ? { path: resolvedTarget, line } : { path: resolvedTarget });
       }
     }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -717,18 +717,10 @@ export function editUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate
       const newText = asStr(pick(chunk, "ReplacementContent", "replacementContent"));
       if (newText === null || !targetFile) continue;
       const oldText = asStr(pick(chunk, "TargetContent", "targetContent"));
-      // Carry StartLine on the diff block so baseline advancement can target the
-      // same occurrence when TargetContent appears more than once.
-      const line = asNum(pick(chunk, "StartLine", "startLine"));
-      content.push({
-        type: "diff",
-        path: targetFile,
-        oldText,
-        newText,
-        ...(line !== null ? { line } : {})
-      });
+      content.push({ type: "diff", path: targetFile, oldText, newText });
 
       if (isReadableLocation(resolvedTarget, ctx)) {
+        const line = asNum(pick(chunk, "StartLine", "startLine"));
         locations.push(line !== null ? { path: resolvedTarget, line } : { path: resolvedTarget });
       }
     }

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -126,6 +126,16 @@ export class Translator {
     return this._hadUpdates;
   }
 
+  /**
+   * Reset row-derived file state before replaying a complete prompt-scoped
+   * snapshot. StreamPoller rereads all rows after its fixed base idx whenever
+   * SQLite changes; rebuilding this cache makes oldText derivation independent
+   * of the previous poll's terminal state.
+   */
+  resetFileContentsForFullReplay(): void {
+    this.fileContents.clear();
+  }
+
   /** Translate a batch of rows into ordered ACP updates, advancing state. */
   translate(rows: StepRow[]): SessionUpdate[] {
     const out: SessionUpdate[] = [];

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -5,18 +5,38 @@
 // cover recognized edits; without this, Zed/Git can show files agy modified
 // while ACP emits no corresponding diff update or fs/write-through (see #76).
 //
-// Strategy: snapshot the working tree at turn start, advance the baseline when
-// a recognized edit lands, diff the remainder at turn end, and for every
-// changed file synthesize an ACP `tool_call` edit update the caller can emit +
-// hand to the client's fs write-through. Changes we can't represent as a text
-// diff (binary/oversized/deletions) are reported to the caller so it can
-// surface the limitation instead of silently dropping them.
+// The snapshot models one thing only: *the content the client has already been
+// told each file holds*. Two invariants keep that model honest and keep this
+// module out of the business of reimplementing agy's edit semantics or Git's
+// ignore semantics:
+//
+//  1. Content only ever enters the snapshot by reading disk — never by
+//     replaying a structured diff onto a remembered body. When a recognized
+//     edit is reported to the client, the caller calls
+//     {@link observeEditedPaths} for its paths and the on-disk bytes at that
+//     moment become the new "client knows this" state. A snippet matcher can
+//     never reliably reproduce what agy actually wrote (the file may already
+//     carry a later shell edit, the snippet may repeat, a chunk may not
+//     apply), and a wrong guess produces a duplicate or destructive synthetic
+//     edit. The tradeoff is that an unrecognized change made to the *same*
+//     path *earlier in the same turn* is folded into the structured edit
+//     instead of being emitted separately; the client's final view still
+//     matches disk, which is what #76 asks for.
+//  2. Files are keyed by physical identity (`fs.realpath`), and every path
+//     comparison happens between strings produced by the *same* root spelling.
+//     Aliased/overlapping workspace roots therefore collapse to one entry
+//     instead of producing two ACP edits for one physical change, and no
+//     lexical `startsWith` ever has to compare a symlinked spelling against a
+//     canonical one.
+//
+// Changes we can't represent as a text diff (binary/oversized/deleted, or a
+// file whose pre-turn content was never captured) are reported to the caller
+// so it can surface the limitation instead of silently dropping them.
 
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { createReadStream, promises as fs, realpathSync } from "node:fs";
-import * as os from "node:os";
+import { createReadStream, promises as fs } from "node:fs";
 import * as path from "node:path";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 
@@ -24,28 +44,43 @@ const execFileAsync = promisify(execFile);
 
 /** Files larger than this are treated as out-of-scope (reported, not diffed). */
 export const MAX_TEXT_BYTES = 1024 * 1024;
-/** Directories never worth scanning for agy edits. */
+/** Directories never worth scanning for agy edits (non-git roots only). */
 const SKIP_DIRS = new Set([".git", "node_modules"]);
+const LS_FILES_MAX_BUFFER = 64 * 1024 * 1024;
 
 const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
-export interface FileSnapshot {
+export interface FileRecord {
+  /** Absolute path in the first configured root spelling — what we emit. */
+  path: string;
+  /** Physical identity (`fs.realpath`); the snapshot's map key. */
+  canonicalPath: string;
   sha1: string;
   size: number;
   /** utf-8 contents, or null when binary or oversized (out of scope for a diff). */
   text: string | null;
-  /** False when added by structured-diff advancement rather than root listing. */
-  candidate?: boolean;
-  /** Original listed fingerprint, retained when structured diffs advance sha1. */
-  initialSha1?: string;
-  /** Original listed text, retained to evaluate pre-turn ignore rules. */
-  initialText?: string | null;
-  /** Physical file identity used to match structured paths across aliases. */
-  canonicalPath?: string;
 }
 
-/** Absolute file path -> snapshot. */
-export type WorkingTreeSnapshot = Map<string, FileSnapshot>;
+/** A configured workspace root, in both the configured and physical spelling. */
+export interface WorkspaceRoot {
+  display: string;
+  canonical: string;
+}
+
+export interface WorkingTreeSnapshot {
+  /** Deduplicated by physical identity, in configured order (cwd first). */
+  roots: WorkspaceRoot[];
+  /** canonical path -> content the client has been told the file holds. */
+  files: Map<string, FileRecord>;
+  /**
+   * Absolute paths (files or directories) the listing deliberately skipped:
+   * gitignored entries, symlinks, and the non-git walker's skip list. Recorded
+   * in the same root spelling as {@link files}, so a path that only becomes
+   * visible later (agy edited an ignore rule) is recognizable as pre-existing
+   * rather than invented as a creation whose pre-turn content we never had.
+   */
+  excluded: string[];
+}
 
 export interface ReflectedEdit {
   path: string;
@@ -54,7 +89,7 @@ export interface ReflectedEdit {
   newText: string;
 }
 
-export type UnsupportedReason = "binary" | "oversized" | "deleted" | "ignore-rules-changed";
+export type UnsupportedReason = "binary" | "oversized" | "deleted" | "previously-excluded";
 
 export interface UnsupportedChange {
   path: string;
@@ -66,27 +101,7 @@ export interface ReconcileResult {
   unsupported: UnsupportedChange[];
 }
 
-async function dedupeRoots(roots: string[]): Promise<string[]> {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const root of roots) {
-    const resolved = path.resolve(root);
-    let canonical = resolved;
-    try {
-      canonical = await fs.realpath(resolved);
-    } catch {
-      // Preserve the unresolved root so the existing git/walk fallback can
-      // decide whether it is readable.
-    }
-    if (seen.has(canonical)) continue;
-    seen.add(canonical);
-    // Keep the first configured spelling (normally cwd) for emitted paths.
-    out.push(resolved);
-  }
-  return out;
-}
-
-/** True when `buf` is valid UTF-8 (and not empty of encoding errors). */
+/** True when `buf` decodes as UTF-8 without replacement. */
 export function isValidUtf8(buf: Buffer): boolean {
   try {
     utf8Decoder.decode(buf);
@@ -97,99 +112,158 @@ export function isValidUtf8(buf: Buffer): boolean {
 }
 
 /**
+ * Resolve configured roots to `{ display, canonical }`, dropping roots that
+ * alias a root already listed. The first configured spelling (normally the
+ * session cwd) is what emitted paths use.
+ */
+async function resolveRoots(rootPaths: string[]): Promise<WorkspaceRoot[]> {
+  const seen = new Set<string>();
+  const roots: WorkspaceRoot[] = [];
+  for (const rootPath of rootPaths) {
+    const display = path.resolve(rootPath);
+    let canonical = display;
+    try {
+      canonical = await fs.realpath(display);
+    } catch {
+      // Keep the unresolved spelling; listing decides whether it is readable.
+    }
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+    roots.push({ display, canonical });
+  }
+  return roots;
+}
+
+interface Listing {
+  files: string[];
+  excluded: string[];
+}
+
+function splitNulList(stdout: string): string[] {
+  return stdout.split("\0").filter((entry) => entry.length > 0);
+}
+
+/**
  * List candidate files under a root. Prefers git (tracked + untracked but not
  * gitignored, so build output and node_modules stay out); falls back to a
  * bounded recursive walk for non-git roots. Checked-out submodules appear as
- * gitlink directories in the parent listing — expand them by listing inside.
- * Symlinks are never followed (a tracked symlink to a directory is not a
- * gitlink; following it can loop or walk outside the configured roots).
+ * gitlink directories in the parent listing — expand them by listing inside,
+ * which also keeps the parent's ignore rules and index from governing the
+ * nested repository. Symlinks are never followed (a tracked symlink to a
+ * directory is not a gitlink; following it can loop or leave the roots).
  */
-async function listFiles(root: string): Promise<string[]> {
+async function listRoot(root: string): Promise<Listing> {
+  let entries: string[];
   try {
     const { stdout } = await execFileAsync(
       "git",
       ["-C", root, "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
-      { maxBuffer: 64 * 1024 * 1024 }
+      { maxBuffer: LS_FILES_MAX_BUFFER }
     );
-    const out: string[] = [];
-    for (const rel of stdout.split("\0")) {
-      if (rel.length === 0) continue;
-      const abs = path.resolve(root, rel);
+    entries = splitNulList(stdout);
+  } catch {
+    return await walkRoot(root);
+  }
+
+  const listing: Listing = { files: [], excluded: [] };
+  try {
+    // `--directory` collapses a wholly ignored directory into one entry, so
+    // this stays cheap even next to a populated node_modules.
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", root, "ls-files", "-z", "--others", "--ignored", "--exclude-standard", "--directory"],
+      { maxBuffer: LS_FILES_MAX_BUFFER }
+    );
+    for (const rel of splitNulList(stdout)) listing.excluded.push(path.resolve(root, rel));
+  } catch {
+    // Advisory: without it a newly visible ignored file looks like a creation.
+  }
+
+  for (const rel of entries) {
+    const abs = path.resolve(root, rel);
+    let stats: import("node:fs").Stats;
+    try {
       // lstat: do not follow symlinks. Gitlinks (mode 160000) show up as a
       // single path; when checked out that path is a real directory.
-      let st: import("node:fs").Stats | null = null;
-      try {
-        st = await fs.lstat(abs);
-      } catch {
-        // vanished between ls-files and lstat — skip
-        continue;
-      }
-      if (st.isSymbolicLink()) continue;
-      if (st.isDirectory()) {
-        out.push(...(await listFiles(abs)));
-      } else if (st.isFile()) {
-        out.push(abs);
-      }
+      stats = await fs.lstat(abs);
+    } catch {
+      continue; // vanished between ls-files and lstat
     }
-    return out;
-  } catch {
-    return await walk(root);
+    if (stats.isSymbolicLink()) {
+      listing.excluded.push(abs);
+    } else if (stats.isDirectory()) {
+      const nested = await listRoot(abs);
+      listing.files.push(...nested.files);
+      listing.excluded.push(...nested.excluded);
+    } else if (stats.isFile()) {
+      listing.files.push(abs);
+    }
   }
+  return listing;
 }
 
-async function walk(dir: string): Promise<string[]> {
-  const out: string[] = [];
+async function walkRoot(dir: string): Promise<Listing> {
+  const listing: Listing = { files: [], excluded: [] };
   let entries: import("node:fs").Dirent[];
   try {
     entries = await fs.readdir(dir, { withFileTypes: true });
   } catch {
-    return out;
+    return listing;
   }
   for (const entry of entries) {
-    if (entry.isSymbolicLink()) continue;
     const abs = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (SKIP_DIRS.has(entry.name)) continue;
-      out.push(...(await walk(abs)));
+    if (entry.isSymbolicLink()) {
+      listing.excluded.push(abs);
+    } else if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) {
+        listing.excluded.push(abs);
+        continue;
+      }
+      const nested = await walkRoot(abs);
+      listing.files.push(...nested.files);
+      listing.excluded.push(...nested.excluded);
     } else if (entry.isFile()) {
-      out.push(abs);
+      listing.files.push(abs);
     }
   }
-  return out;
+  return listing;
 }
 
-async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
-  let st: import("node:fs").Stats;
+/**
+ * Read one path into a {@link FileRecord}, or null when it is not a readable
+ * regular file. `expectedCanonicalPath` refuses a path whose physical identity
+ * moved since it was recorded (any component replaced by a symlink): the file
+ * we tracked is gone, and whatever the spelling now points at must not be read
+ * into an ACP update or a write-through.
+ */
+async function readFileRecord(abs: string, expectedCanonicalPath?: string): Promise<FileRecord | null> {
+  let stats: import("node:fs").Stats;
   try {
-    // Do not follow a regular-file path that was replaced with a symlink after
-    // the baseline listing, especially during direct candidate resnapshot.
-    st = await fs.lstat(abs);
+    stats = await fs.lstat(abs);
   } catch {
     return null;
   }
-  if (!st.isFile()) return null;
+  if (!stats.isFile()) return null;
   let canonicalPath: string;
   try {
     canonicalPath = await fs.realpath(abs);
   } catch {
     return null;
   }
+  if (expectedCanonicalPath !== undefined && canonicalPath !== expectedCanonicalPath) return null;
 
   // Never buffer multi-megabyte blobs into memory. Hash them as a stream so a
-  // same-size replacement with a preserved/coarse mtime is still reported.
-  if (st.size > MAX_TEXT_BYTES) {
+  // same-size replacement with a preserved/coarse mtime is still detected.
+  if (stats.size > MAX_TEXT_BYTES) {
     try {
       const hash = createHash("sha1");
       for await (const chunk of createReadStream(abs)) hash.update(chunk);
-      const sha1 = `oversized:${st.size}:${hash.digest("hex")}`;
       return {
-        sha1,
-        size: st.size,
-        text: null,
-        candidate: true,
-        initialSha1: sha1,
-        initialText: null,
-        canonicalPath
+        path: abs,
+        canonicalPath,
+        sha1: `oversized:${stats.size}:${hash.digest("hex")}`,
+        size: stats.size,
+        text: null
       };
     } catch {
       return null;
@@ -200,469 +274,168 @@ async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
   try {
     buf = await fs.readFile(abs);
   } catch {
-    return null; // unreadable / vanished / not a regular file
+    return null;
   }
-  const sha1 = createHash("sha1").update(buf).digest("hex");
   // NUL byte *or* invalid UTF-8 => binary. Invalid UTF-8 must not be handed to
   // the client's text write-through (which would rewrite U+FFFD replacements).
   const isBinary = buf.includes(0) || !isValidUtf8(buf);
-  const text = !isBinary ? buf.toString("utf8") : null;
-  return { sha1, size: buf.length, text, candidate: true, initialSha1: sha1, initialText: text, canonicalPath };
-}
-
-function snapshotFromText(
-  text: string,
-  candidate: boolean,
-  initialSha1?: string,
-  initialText?: string | null,
-  canonicalPath?: string
-): FileSnapshot {
-  const buf = Buffer.from(text, "utf8");
-  if (buf.length > MAX_TEXT_BYTES) {
-    const sha1 = `oversized:${buf.length}:${createHash("sha1").update(buf).digest("hex")}`;
-    return { sha1, size: buf.length, text: null, candidate, initialSha1, initialText, canonicalPath };
-  }
-  const sha1 = createHash("sha1").update(buf).digest("hex");
   return {
-    sha1,
+    path: abs,
+    canonicalPath,
+    sha1: createHash("sha1").update(buf).digest("hex"),
     size: buf.length,
-    text,
-    candidate,
-    initialSha1,
-    initialText,
-    canonicalPath
+    text: isBinary ? null : buf.toString("utf8")
   };
 }
 
-/** Match a structured path to the spelling retained by the working-tree scan. */
-function snapshotKeyForPath(snapshot: WorkingTreeSnapshot, filePath: string): string {
-  const abs = path.resolve(filePath);
-  if (snapshot.has(abs)) return abs;
-  let canonical: string;
-  try {
-    canonical = realpathSync(abs);
-  } catch {
-    return abs;
-  }
-  for (const [key, file] of snapshot) {
-    if (file.canonicalPath === canonical) return key;
-  }
-  return abs;
-}
-
-/**
- * Byte offset of the start of 1-based line `line` in `text`, or null if the
- * file has fewer lines.
- */
-function offsetOfLine(text: string, line: number): number | null {
-  if (line < 1) return null;
-  if (line === 1) return 0;
-  let offset = 0;
-  for (let current = 1; current < line; current++) {
-    const nl = text.indexOf("\n", offset);
-    if (nl === -1) return null;
-    offset = nl + 1;
-  }
-  return offset;
-}
-
-/**
- * Replace one occurrence of `oldText` with `newText`. When `line` is set
- * (1-based), search starts at that line so a later repeated snippet is chosen
- * over the first match — matching agy `StartLine` on replace chunks.
- */
-export function replaceOccurrence(
-  text: string,
-  oldText: string,
-  newText: string,
-  line?: number
-): string | null {
-  const from = line !== undefined ? offsetOfLine(text, line) : 0;
-  if (from === null) return null;
-  const idx = text.indexOf(oldText, from);
-  if (idx === -1) return null;
-  return text.slice(0, idx) + newText + text.slice(idx + oldText.length);
-}
-
-export interface DiffBlockSpec {
-  oldText: string | null;
-  newText: string;
-  /** 1-based start line in the *pre-edit* file (agy StartLine). */
-  line?: number;
-}
-
-/**
- * Advance a snapshot entry to the post-edit content described by a structured
- * diff block, without reading disk. Disk may already include later shell edits
- * by the time the structured tool-call is polled; rereading would advance past
- * those too and suppress the synthetic update for them.
- *
- * `oldText`/`newText` may be whole-file bodies (`write_to_file`) or replacement
- * snippets (`replace_file_content`). Optional `line` (1-based) selects which
- * occurrence of a repeated snippet was replaced.
- */
-export function applyDiffBlockToSnapshot(
-  snapshot: WorkingTreeSnapshot,
-  filePath: string,
-  oldText: string | null,
-  newText: string,
-  line?: number
-): void {
-  applyDiffBlocksToSnapshot(snapshot, filePath, [{ oldText, newText, line }]);
-}
-
-/**
- * Apply one or more structured diff blocks for a single path. Multi-replace
- * chunks carry `StartLine` against the *original* file; applying them left-to-
- * right on a mutating buffer can invalidate later line numbers when an earlier
- * chunk changes the line count. Instead, locate every match on the original
- * text and apply from end to start so indices stay valid.
- */
-export function applyDiffBlocksToSnapshot(
-  snapshot: WorkingTreeSnapshot,
-  filePath: string,
-  blocks: DiffBlockSpec[]
-): void {
-  if (blocks.length === 0) return;
-
-  const abs = snapshotKeyForPath(snapshot, filePath);
-  const before = snapshot.get(abs);
-
-  // Full-file writes (oldText null) and missing/binary baselines cannot use
-  // multi-match positioning — fall back to sequential single-block rules.
-  if (blocks.some((b) => b.oldText === null) || before?.text == null) {
-    for (const block of blocks) {
-      applySingleDiffBlock(snapshot, abs, snapshot.get(abs), block);
+/** Canonicalize a path that may no longer exist, without following a symlink
+ *  that replaced any missing component. */
+async function canonicalizeMissing(abs: string): Promise<string> {
+  const suffix: string[] = [];
+  let ancestor = path.resolve(abs);
+  while (true) {
+    try {
+      return path.join(await fs.realpath(ancestor), ...suffix.reverse());
+    } catch {
+      const parent = path.dirname(ancestor);
+      if (parent === ancestor) return path.resolve(abs);
+      suffix.push(path.basename(ancestor));
+      ancestor = parent;
     }
-    return;
   }
-
-  const original = before.text;
-  type Op = { idx: number; oldLen: number; newText: string };
-  const ops: Op[] = [];
-
-  for (const block of blocks) {
-    const oldText = block.oldText!;
-    if (original === oldText) {
-      ops.push({ idx: 0, oldLen: original.length, newText: block.newText });
-      continue;
-    }
-    const from = block.line !== undefined ? offsetOfLine(original, block.line) : 0;
-    if (from === null) continue;
-    const idx = original.indexOf(oldText, from);
-    if (idx === -1) continue;
-    ops.push({ idx, oldLen: oldText.length, newText: block.newText });
-  }
-
-  if (ops.length === 0) {
-    // Nothing matched — same best-effort as a single failed apply.
-    const last = blocks[blocks.length - 1]!;
-    if (original === last.newText || original.includes(last.newText)) return;
-    return;
-  }
-
-  // End-to-start so earlier replacements do not shift later indices.
-  ops.sort((a, b) => b.idx - a.idx || b.oldLen - a.oldLen);
-  let result = original;
-  for (const op of ops) {
-    result = result.slice(0, op.idx) + op.newText + result.slice(op.idx + op.oldLen);
-  }
-  snapshot.set(
-    abs,
-    snapshotFromText(
-      result,
-      before.candidate !== false,
-      before.initialSha1 ?? before.sha1,
-      before.initialText ?? before.text,
-      before.canonicalPath
-    )
-  );
 }
 
-function applySingleDiffBlock(
-  snapshot: WorkingTreeSnapshot,
-  abs: string,
-  before: FileSnapshot | undefined,
-  block: DiffBlockSpec
-): void {
-  const { oldText, newText, line } = block;
-  let post: string;
-
-  if (oldText === null) {
-    post = newText;
-  } else if (before?.text != null) {
-    if (before.text === oldText) {
-      post = newText;
-    } else {
-      const applied = replaceOccurrence(before.text, oldText, newText, line);
-      if (applied !== null) {
-        post = applied;
-      } else if (before.text === newText || before.text.includes(newText)) {
-        return;
-      } else {
-        return;
-      }
-    }
-  } else {
-    post = newText;
+function rootFor(canonicalPath: string, roots: WorkspaceRoot[]): WorkspaceRoot | undefined {
+  for (const root of roots) {
+    const relative = path.relative(root.canonical, canonicalPath);
+    if (relative === "") return root;
+    if (path.isAbsolute(relative)) continue;
+    if (relative === ".." || relative.startsWith(`..${path.sep}`)) continue;
+    return root;
   }
-
-  snapshot.set(
-    abs,
-    snapshotFromText(
-      post,
-      before?.candidate ?? false,
-      before ? (before.initialSha1 ?? before.sha1) : undefined,
-      before ? (before.initialText ?? before.text) : undefined,
-      before?.canonicalPath ?? (() => {
-        try { return realpathSync(abs); } catch { return undefined; }
-      })()
-    )
-  );
+  return undefined;
 }
 
-/** Snapshot the working tree across one or more roots. */
-export async function snapshotWorkingTree(roots: string[]): Promise<WorkingTreeSnapshot> {
-  const snapshot: WorkingTreeSnapshot = new Map();
-  const seenFiles = new Set<string>();
-  for (const root of await dedupeRoots(roots)) {
-    for (const abs of await listFiles(root)) {
-      if (snapshot.has(abs)) continue;
-      const file = await snapshotFile(abs);
-      if (!file || (file.canonicalPath && seenFiles.has(file.canonicalPath))) continue;
-      if (file.canonicalPath) seenFiles.add(file.canonicalPath);
-      // Keep the first configured spelling while deduplicating overlapping
-      // roots that list the same physical file through different paths.
-      snapshot.set(abs, file);
+/** Absolute path in the configured spelling of whichever root contains it. */
+function displayPathFor(canonicalPath: string, roots: WorkspaceRoot[]): string | undefined {
+  const root = rootFor(canonicalPath, roots);
+  if (!root) return undefined;
+  const relative = path.relative(root.canonical, canonicalPath);
+  return relative === "" ? root.display : path.join(root.display, relative);
+}
+
+function isUnder(target: string, prefixes: readonly string[]): boolean {
+  for (const prefix of prefixes) {
+    if (target === prefix || target.startsWith(prefix + path.sep)) return true;
+  }
+  return false;
+}
+
+/** Snapshot the working tree across one or more configured roots. */
+export async function snapshotWorkingTree(rootPaths: string[]): Promise<WorkingTreeSnapshot> {
+  const roots = await resolveRoots(rootPaths);
+  const snapshot: WorkingTreeSnapshot = { roots, files: new Map(), excluded: [] };
+  for (const root of roots) {
+    const listing = await listRoot(root.display);
+    snapshot.excluded.push(...listing.excluded);
+    for (const abs of listing.files) {
+      const record = await readFileRecord(abs);
+      // Overlapping roots list one physical file under several spellings; keep
+      // the first configured one so emitted paths stay stable.
+      if (!record || snapshot.files.has(record.canonicalPath)) continue;
+      snapshot.files.set(record.canonicalPath, record);
     }
   }
   return snapshot;
 }
 
-async function pathIsWithinRoots(
-  filePath: string,
-  roots: string[],
-  recordedCanonicalPath?: string
-): Promise<boolean> {
-  // The file and newly-created parent directories may have been deleted. Walk
-  // up to the deepest surviving ancestor, canonicalize it, then restore the
-  // missing suffix without following any replacement symlink.
-  let canonicalFile = recordedCanonicalPath;
-  if (!canonicalFile) {
-    const suffix: string[] = [];
-    let ancestor = path.resolve(filePath);
-    while (true) {
-      try {
-        canonicalFile = path.join(await fs.realpath(ancestor), ...suffix.reverse());
-        break;
-      } catch {
-        const parent = path.dirname(ancestor);
-        if (parent === ancestor) return false;
-        suffix.push(path.basename(ancestor));
-        ancestor = parent;
-      }
-    }
-  }
-  for (const root of await dedupeRoots(roots)) {
-    let canonicalRoot: string;
-    try {
-      canonicalRoot = await fs.realpath(root);
-    } catch {
+/**
+ * Record the current on-disk content of paths whose change has *already* been
+ * reported to the client (a recognized structured edit, or a synthetic one this
+ * module produced), so end-of-turn reconciliation only emits what is still
+ * unreflected. Call it while disk holds the reported content — before any
+ * write-through revert/replay dance, and again after a rejected edit is
+ * reverted. Paths outside the configured roots are ignored, which keeps the
+ * snapshot to files this workspace is responsible for.
+ */
+export async function observeEditedPaths(snapshot: WorkingTreeSnapshot, paths: string[]): Promise<void> {
+  for (const filePath of paths) {
+    const abs = path.resolve(filePath);
+    const record = await readFileRecord(abs);
+    const canonicalPath = record?.canonicalPath ?? (await canonicalizeMissing(abs));
+    if (!rootFor(canonicalPath, snapshot.roots)) continue;
+    if (!record) {
+      // The reported edit removed the file (a reverted creation, a delete).
+      // Forgetting it keeps a later recreation reportable as a creation.
+      snapshot.files.delete(canonicalPath);
       continue;
     }
-    const relative = path.relative(canonicalRoot, canonicalFile);
-    if (relative === "" || (!path.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path.sep}`))) {
-      return true;
-    }
+    const retained = snapshot.files.get(canonicalPath)?.path
+      ?? displayPathFor(canonicalPath, snapshot.roots)
+      ?? abs;
+    snapshot.files.set(canonicalPath, { ...record, path: retained });
   }
-  return false;
 }
 
 /**
- * Use Git's own matcher to determine which newly listed paths were ignored by
- * the pre-turn .gitignore contents. Reconstructing only ignore files in a
- * temporary repository avoids mutating the real worktree and avoids a partial
- * reimplementation of gitignore pattern/negation semantics.
+ * Diff the working tree against what the client has been told (see
+ * {@link observeEditedPaths}). Added/modified text files become `reflected`
+ * edits; anything we cannot represent as a text diff becomes `unsupported`.
  */
-async function ignoredByBaselineRules(
-  baseline: WorkingTreeSnapshot,
-  candidates: string[]
-): Promise<Set<string>> {
-  const ignored = new Set<string>();
-  const byRepository = new Map<string, Array<{ abs: string; canonical: string }>>();
-  for (const abs of candidates) {
-    try {
-      const canonical = path.join(await fs.realpath(path.dirname(abs)), path.basename(abs));
-      const { stdout } = await execFileAsync(
-        "git",
-        ["-C", path.dirname(abs), "rev-parse", "--show-toplevel"]
-      );
-      const repository = path.resolve(stdout.trim());
-      const existing = byRepository.get(repository);
-      const candidate = { abs, canonical };
-      if (existing) existing.push(candidate);
-      else byRepository.set(repository, [candidate]);
-    } catch {
-      // Non-git roots use the recursive walker, where .gitignore never changes
-      // candidate visibility.
+export async function reconcileWorkingTree(snapshot: WorkingTreeSnapshot): Promise<ReconcileResult> {
+  const current = new Map<string, FileRecord>();
+  for (const root of snapshot.roots) {
+    for (const abs of (await listRoot(root.display)).files) {
+      const record = await readFileRecord(abs);
+      if (!record || current.has(record.canonicalPath)) continue;
+      current.set(record.canonicalPath, record);
     }
   }
 
-  for (const [repository, repositoryCandidates] of byRepository) {
-    const temp = await fs.mkdtemp(path.join(os.tmpdir(), "agy-acp-ignore-"));
-    try {
-      await execFileAsync("git", ["-C", temp, "init", "-q"]);
-      for (const [ignoreFile, snapshot] of baseline) {
-        let canonicalIgnoreFile: string;
-        try {
-          canonicalIgnoreFile = path.join(
-            await fs.realpath(path.dirname(ignoreFile)),
-            path.basename(ignoreFile)
-          );
-        } catch {
-          continue;
-        }
-        if (
-          path.basename(ignoreFile) !== ".gitignore" ||
-          (canonicalIgnoreFile !== path.join(repository, ".gitignore") &&
-            !canonicalIgnoreFile.startsWith(repository + path.sep))
-        ) continue;
-        const text = snapshot.initialText ?? snapshot.text;
-        if (text == null) continue;
-        const relative = path.relative(repository, canonicalIgnoreFile);
-        const target = path.join(temp, relative);
-        await fs.mkdir(path.dirname(target), { recursive: true });
-        await fs.writeFile(target, text, "utf8");
-      }
-
-      for (const { abs, canonical } of repositoryCandidates) {
-        const relative = path.relative(repository, canonical);
-        try {
-          await execFileAsync("git", ["-C", temp, "check-ignore", "-q", "--no-index", "--", relative]);
-          ignored.add(abs);
-        } catch {
-          // Exit 1 means the path was visible under the baseline rules. Other
-          // matcher failures conservatively leave it eligible for reflection.
-        }
-      }
-    } finally {
-      await fs.rm(temp, { recursive: true, force: true });
-    }
-  }
-  return ignored;
-}
-
-/**
- * Diff the current working tree against a baseline snapshot. Callers that have
- * already reflected a recognized edit should {@link applyDiffBlockToSnapshot}
- * the baseline for that path first so only *further* changes are emitted.
- * Added/modified text files become `reflected` edits; binary/oversized/deleted
- * changes (and binary→text replacements we can't represent) become `unsupported`.
- */
-export async function reconcileWorkingTree(
-  baseline: WorkingTreeSnapshot,
-  roots: string[]
-): Promise<ReconcileResult> {
-  const current = await snapshotWorkingTree(roots);
   const reflected: ReflectedEdit[] = [];
   const unsupported: UnsupportedChange[] = [];
-  const structuredCandidates = new Set<string>();
-  const baselineByCanonical = new Map<string, FileSnapshot>();
-  const currentByCanonical = new Map<string, string>();
-  for (const file of baseline.values()) {
-    if (file.canonicalPath) baselineByCanonical.set(file.canonicalPath, file);
-  }
-  for (const [abs, file] of current) {
-    if (file.canonicalPath) currentByCanonical.set(file.canonicalPath, abs);
-  }
-  const currentKeyFor = (abs: string, before: FileSnapshot): string | undefined =>
-    current.has(abs) ? abs : before.canonicalPath ? currentByCanonical.get(before.canonicalPath) : undefined;
-  const baselineFor = (abs: string, now: FileSnapshot): FileSnapshot | undefined =>
-    baseline.get(abs) ?? (now.canonicalPath ? baselineByCanonical.get(now.canonicalPath) : undefined);
-
-  // A newly added ignore rule can remove a still-existing baseline candidate
-  // from `git ls-files --others --exclude-standard`. Snapshot those paths
-  // directly so an eligibility change is not misreported as a deletion.
-  for (const [abs, before] of baseline) {
-    if (currentKeyFor(abs, before)) continue;
-    // Structured baseline advancement can add an absolute path outside the
-    // configured roots. Only pull structured-only entries into reconciliation
-    // when their physical location belongs to this workspace.
-    if (before.candidate === false) {
-      if (!(await pathIsWithinRoots(abs, roots, before.canonicalPath))) continue;
-      structuredCandidates.add(abs);
-      // Do not read through an intermediate symlink that now redirects the
-      // same spelling outside the workspace. The recorded in-root file is a
-      // deletion; any replacement target is unrelated and must remain unread.
-      if (!(await pathIsWithinRoots(abs, roots))) continue;
-    }
-    const now = await snapshotFile(abs);
-    if (now) {
-      current.set(abs, now);
-      if (now.canonicalPath) currentByCanonical.set(now.canonicalPath, abs);
-    }
-  }
-
-  // Conversely, removing an ignore rule can expose a pre-existing file that
-  // was absent from the baseline. We cannot reconstruct its pre-turn content,
-  // so report it rather than inventing a creation and routing a destructive
-  // empty→content write-through. Nested .gitignore changes affect descendants.
-  const changedIgnoreRules = new Set<string>();
-  const paths = new Set([...baseline.keys(), ...current.keys()]);
-  for (const abs of paths) {
-    if (path.basename(abs) !== ".gitignore") continue;
-    const before = baseline.get(abs);
-    const now = current.get(abs);
-    const alignedBefore = before ?? (now ? baselineFor(abs, now) : undefined);
-    const alignedNow = now ?? (before ? current.get(currentKeyFor(abs, before) ?? "") : undefined);
-    if ((alignedBefore?.initialSha1 ?? alignedBefore?.sha1) !== alignedNow?.sha1) {
-      changedIgnoreRules.add(abs);
-    }
-  }
-  const couldBeAffectedByIgnoreChange = (abs: string): boolean => {
-    if (path.basename(abs) === ".gitignore") return false;
-    for (const ignoreFile of changedIgnoreRules) {
-      const dir = path.dirname(ignoreFile);
-      if (abs.startsWith(dir + path.sep)) return true;
-    }
-    return false;
+  const unrepresentable = (record: FileRecord): UnsupportedReason =>
+    record.size > MAX_TEXT_BYTES ? "oversized" : "binary";
+  const pushChange = (before: FileRecord, after: FileRecord): void => {
+    // No representable oldText (or newText): treating a binary/oversized file
+    // as a text create would mislead the client and corrupt write-through.
+    if (before.text === null) unsupported.push({ path: before.path, reason: unrepresentable(before) });
+    else if (after.text === null) unsupported.push({ path: before.path, reason: unrepresentable(after) });
+    else reflected.push({ path: before.path, oldText: before.text, newText: after.text });
   };
-  const newlyListedAfterIgnoreChange = [...current.keys()].filter(
-    (abs) => !baselineFor(abs, current.get(abs)!) && couldBeAffectedByIgnoreChange(abs)
-  );
-  const ignoredBeforeTurn = await ignoredByBaselineRules(baseline, newlyListedAfterIgnoreChange);
 
-  for (const [abs, now] of current) {
-    const before = baselineFor(abs, now);
-    if (before && before.sha1 === now.sha1) continue; // unchanged
-    if (!before && ignoredBeforeTurn.has(abs)) {
-      unsupported.push({ path: abs, reason: "ignore-rules-changed" });
+  for (const [canonicalPath, after] of current) {
+    const before = snapshot.files.get(canonicalPath);
+    if (before) {
+      if (before.sha1 !== after.sha1) pushChange(before, after);
       continue;
     }
-    if (now.text === null) {
-      unsupported.push({ path: abs, reason: now.size > MAX_TEXT_BYTES ? "oversized" : "binary" });
-      continue;
+    // Absent from the pre-turn snapshot: a genuine creation, unless the
+    // pre-turn listing deliberately skipped it (gitignored, symlinked, skip
+    // list) and an edit to those rules has now exposed it. Both spellings come
+    // from listings over the same root, so this comparison never crosses
+    // aliases.
+    if (isUnder(after.path, snapshot.excluded)) {
+      unsupported.push({ path: after.path, reason: "previously-excluded" });
+    } else if (after.text === null) {
+      unsupported.push({ path: after.path, reason: unrepresentable(after) });
+    } else {
+      reflected.push({ path: after.path, oldText: null, newText: after.text });
     }
-    // File existed before but was binary/oversized: we have no representable
-    // oldText, and treating it as a create would mislead the client + corrupt
-    // write-through. Report rather than invent a creation.
-    if (before && before.text === null) {
-      unsupported.push({
-        path: abs,
-        reason: before.size > MAX_TEXT_BYTES ? "oversized" : "binary"
-      });
-      continue;
-    }
-    reflected.push({ path: abs, oldText: before?.text ?? null, newText: now.text });
   }
 
-  for (const [abs, before] of baseline) {
-    if (currentKeyFor(abs, before)) continue;
-    // Structured edits can introduce entries absent from the initial listing.
-    // Report a later deletion when that physical path belongs to a configured
-    // root, while continuing to ignore structured edits outside the workspace.
-    if (before.candidate === false && !structuredCandidates.has(abs)) continue;
-    unsupported.push({ path: abs, reason: "deleted" });
+  for (const [canonicalPath, before] of snapshot.files) {
+    if (current.has(canonicalPath)) continue;
+    // Missing from the listing is not the same as missing from disk: a new
+    // ignore rule hides a file that is still there, and observed structured
+    // edits can target paths the listing never covered. Read the recorded
+    // path directly, refusing any spelling whose physical identity moved.
+    const after = await readFileRecord(before.path, canonicalPath);
+    if (!after) {
+      unsupported.push({ path: before.path, reason: "deleted" });
+    } else if (before.sha1 !== after.sha1) {
+      pushChange(before, { ...after, path: before.path });
+    }
   }
 
   return { reflected, unsupported };

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -188,19 +188,55 @@ function snapshotFromText(text: string): FileSnapshot {
 }
 
 /**
+ * Byte offset of the start of 1-based line `line` in `text`, or null if the
+ * file has fewer lines.
+ */
+function offsetOfLine(text: string, line: number): number | null {
+  if (line < 1) return null;
+  if (line === 1) return 0;
+  let offset = 0;
+  for (let current = 1; current < line; current++) {
+    const nl = text.indexOf("\n", offset);
+    if (nl === -1) return null;
+    offset = nl + 1;
+  }
+  return offset;
+}
+
+/**
+ * Replace one occurrence of `oldText` with `newText`. When `line` is set
+ * (1-based), search starts at that line so a later repeated snippet is chosen
+ * over the first match — matching agy `StartLine` on replace chunks.
+ */
+export function replaceOccurrence(
+  text: string,
+  oldText: string,
+  newText: string,
+  line?: number
+): string | null {
+  const from = line !== undefined ? offsetOfLine(text, line) : 0;
+  if (from === null) return null;
+  const idx = text.indexOf(oldText, from);
+  if (idx === -1) return null;
+  return text.slice(0, idx) + newText + text.slice(idx + oldText.length);
+}
+
+/**
  * Advance a snapshot entry to the post-edit content described by a structured
  * diff block, without reading disk. Disk may already include later shell edits
  * by the time the structured tool-call is polled; rereading would advance past
  * those too and suppress the synthetic update for them.
  *
  * `oldText`/`newText` may be whole-file bodies (`write_to_file`) or replacement
- * snippets (`replace_file_content`) — same rules as {@link revertEditToolCall}.
+ * snippets (`replace_file_content`). Optional `line` (1-based) selects which
+ * occurrence of a repeated snippet was replaced.
  */
 export function applyDiffBlockToSnapshot(
   snapshot: WorkingTreeSnapshot,
   filePath: string,
   oldText: string | null,
-  newText: string
+  newText: string,
+  line?: number
 ): void {
   const abs = path.resolve(filePath);
   const before = snapshot.get(abs);
@@ -212,15 +248,18 @@ export function applyDiffBlockToSnapshot(
   } else if (before?.text != null) {
     if (before.text === oldText) {
       post = newText;
-    } else if (before.text.includes(oldText)) {
-      post = before.text.replace(oldText, newText);
-    } else if (before.text === newText || before.text.includes(newText)) {
-      // Baseline already reflects this edit.
-      return;
     } else {
-      // Snippet does not apply to baseline text — cannot reconstruct post-edit
-      // content without guessing; leave the entry unchanged.
-      return;
+      const applied = replaceOccurrence(before.text, oldText, newText, line);
+      if (applied !== null) {
+        post = applied;
+      } else if (before.text === newText || before.text.includes(newText)) {
+        // Baseline already reflects this edit.
+        return;
+      } else {
+        // Snippet does not apply to baseline text — cannot reconstruct post-edit
+        // content without guessing; leave the entry unchanged.
+        return;
+      }
     }
   } else {
     // Missing or binary baseline: best representable post state is newText

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -1,0 +1,203 @@
+// Reflect *arbitrary* filesystem edits agy made during a turn — including ones
+// that never surface as a recognized structured edit tool-call (e.g. edits made
+// through `run_command` or an edit payload the translator doesn't decode). The
+// edit/diff translator (db/tool-call-updates.ts) + bridge (edit/bridge.ts) only
+// cover recognized edits; without this, Zed/Git can show files agy modified
+// while ACP emits no corresponding diff update or fs/write-through (see #76).
+//
+// Strategy: snapshot the working tree at turn start, diff it at turn end, and
+// for every changed file NOT already reflected by a recognized edit, synthesize
+// an ACP `tool_call` edit update the caller can emit + hand to the client's fs
+// write-through. Changes we can't represent as a text diff (binary/oversized/
+// deletions) are reported to the caller so it can surface the limitation
+// instead of silently dropping them.
+
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+
+const execFileAsync = promisify(execFile);
+
+/** Files larger than this are treated as out-of-scope (reported, not diffed). */
+export const MAX_TEXT_BYTES = 1024 * 1024;
+/** Directories never worth scanning for agy edits. */
+const SKIP_DIRS = new Set([".git", "node_modules"]);
+
+export interface FileSnapshot {
+  sha1: string;
+  size: number;
+  /** utf-8 contents, or null when binary or oversized (out of scope for a diff). */
+  text: string | null;
+}
+
+/** Absolute file path -> snapshot. */
+export type WorkingTreeSnapshot = Map<string, FileSnapshot>;
+
+export interface ReflectedEdit {
+  path: string;
+  /** Pre-edit content; null when the file is newly created this turn. */
+  oldText: string | null;
+  newText: string;
+}
+
+export type UnsupportedReason = "binary" | "oversized" | "deleted";
+
+export interface UnsupportedChange {
+  path: string;
+  reason: UnsupportedReason;
+}
+
+export interface ReconcileResult {
+  reflected: ReflectedEdit[];
+  unsupported: UnsupportedChange[];
+}
+
+function dedupeRoots(roots: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const root of roots) {
+    const resolved = path.resolve(root);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    out.push(resolved);
+  }
+  return out;
+}
+
+/**
+ * List candidate files under a root. Prefers git (tracked + untracked but not
+ * gitignored, so build output and node_modules stay out); falls back to a
+ * bounded recursive walk for non-git roots.
+ */
+async function listFiles(root: string): Promise<string[]> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", root, "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+      { maxBuffer: 64 * 1024 * 1024 }
+    );
+    return stdout
+      .split("\0")
+      .filter((rel) => rel.length > 0)
+      .map((rel) => path.resolve(root, rel));
+  } catch {
+    return await walk(root);
+  }
+}
+
+async function walk(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      out.push(...(await walk(abs)));
+    } else if (entry.isFile()) {
+      out.push(abs);
+    }
+  }
+  return out;
+}
+
+async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
+  let buf: Buffer;
+  try {
+    buf = await fs.readFile(abs);
+  } catch {
+    return null; // unreadable / vanished / not a regular file
+  }
+  const sha1 = createHash("sha1").update(buf).digest("hex");
+  const isBinary = buf.includes(0);
+  const text = !isBinary && buf.length <= MAX_TEXT_BYTES ? buf.toString("utf8") : null;
+  return { sha1, size: buf.length, text };
+}
+
+/** Snapshot the working tree across one or more roots. */
+export async function snapshotWorkingTree(roots: string[]): Promise<WorkingTreeSnapshot> {
+  const snapshot: WorkingTreeSnapshot = new Map();
+  for (const root of dedupeRoots(roots)) {
+    for (const abs of await listFiles(root)) {
+      if (snapshot.has(abs)) continue;
+      const file = await snapshotFile(abs);
+      if (file) snapshot.set(abs, file);
+    }
+  }
+  return snapshot;
+}
+
+/**
+ * Diff the current working tree against a baseline snapshot, skipping any path
+ * already reflected through a recognized edit. Added/modified text files become
+ * `reflected` edits; binary/oversized/deleted changes become `unsupported`.
+ */
+export async function reconcileWorkingTree(
+  baseline: WorkingTreeSnapshot,
+  roots: string[],
+  reflectedPaths: Iterable<string>
+): Promise<ReconcileResult> {
+  const skip = new Set<string>();
+  for (const p of reflectedPaths) skip.add(path.resolve(p));
+
+  const current = await snapshotWorkingTree(roots);
+  const reflected: ReflectedEdit[] = [];
+  const unsupported: UnsupportedChange[] = [];
+
+  for (const [abs, now] of current) {
+    if (skip.has(abs)) continue;
+    const before = baseline.get(abs);
+    if (before && before.sha1 === now.sha1) continue; // unchanged
+    if (now.text === null) {
+      unsupported.push({ path: abs, reason: now.size > MAX_TEXT_BYTES ? "oversized" : "binary" });
+      continue;
+    }
+    // before?.text is null for a brand-new file, or for a file that was binary/
+    // oversized before and is now text — both are represented as a create.
+    reflected.push({ path: abs, oldText: before?.text ?? null, newText: now.text });
+  }
+
+  for (const [abs] of baseline) {
+    if (skip.has(abs)) continue;
+    if (!current.has(abs)) unsupported.push({ path: abs, reason: "deleted" });
+  }
+
+  return { reflected, unsupported };
+}
+
+/** Absolute path -> project-relative for display; unchanged if outside cwd. */
+export function toDisplayPath(filePath: string, cwd?: string): string {
+  if (!cwd) return filePath;
+  const resolvedCwd = path.resolve(cwd);
+  const resolvedFile = path.resolve(filePath);
+  if (resolvedFile === resolvedCwd || resolvedFile.startsWith(resolvedCwd + path.sep)) {
+    return path.relative(resolvedCwd, resolvedFile);
+  }
+  return filePath;
+}
+
+/**
+ * Build a synthetic completed-edit `tool_call` update for a reconciled change.
+ * Shaped so {@link diffBlocks} (edit/revert.ts) reads it back and the client
+ * fs write-through routes it exactly like a recognized edit.
+ */
+export function buildReconcileEditUpdate(edit: ReflectedEdit, index: number, cwd?: string): SessionUpdate {
+  const shown = toDisplayPath(edit.path, cwd);
+  return {
+    sessionUpdate: "tool_call",
+    toolCallId: `agy-fs-reconcile-${index}`,
+    name: edit.oldText === null ? "write_to_file" : "edit",
+    title: `Edit ${shown}`,
+    kind: "edit",
+    status: "completed",
+    content: [{ type: "diff", path: edit.path, oldText: edit.oldText, newText: edit.newText }]
+  } as unknown as SessionUpdate;
+}

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -84,6 +84,8 @@ export function isValidUtf8(buf: Buffer): boolean {
  * gitignored, so build output and node_modules stay out); falls back to a
  * bounded recursive walk for non-git roots. Checked-out submodules appear as
  * gitlink directories in the parent listing — expand them by listing inside.
+ * Symlinks are never followed (a tracked symlink to a directory is not a
+ * gitlink; following it can loop or walk outside the configured roots).
  */
 async function listFiles(root: string): Promise<string[]> {
   try {
@@ -96,15 +98,16 @@ async function listFiles(root: string): Promise<string[]> {
     for (const rel of stdout.split("\0")) {
       if (rel.length === 0) continue;
       const abs = path.resolve(root, rel);
-      // Gitlinks (mode 160000) show up as a single path; when checked out that
-      // path is a directory. Recurse so edits inside the submodule are visible.
+      // lstat: do not follow symlinks. Gitlinks (mode 160000) show up as a
+      // single path; when checked out that path is a real directory.
       let st: import("node:fs").Stats | null = null;
       try {
-        st = await fs.stat(abs);
+        st = await fs.lstat(abs);
       } catch {
-        // vanished between ls-files and stat — skip
+        // vanished between ls-files and lstat — skip
         continue;
       }
+      if (st.isSymbolicLink()) continue;
       if (st.isDirectory()) {
         out.push(...(await listFiles(abs)));
       } else if (st.isFile()) {
@@ -171,19 +174,61 @@ async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
   return { sha1, size: buf.length, text };
 }
 
+function snapshotFromText(text: string): FileSnapshot {
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length > MAX_TEXT_BYTES) {
+    // mtime unknown — size alone is enough; we never text-diff these.
+    return { sha1: `oversized:${buf.length}:0`, size: buf.length, text: null };
+  }
+  return {
+    sha1: createHash("sha1").update(buf).digest("hex"),
+    size: buf.length,
+    text
+  };
+}
+
 /**
- * Update (or remove) one path in an existing snapshot. Used after a recognized
- * structured edit lands so a later shell/unrecognized change to the same file
- * still reconciles against the post-edit content rather than being suppressed.
+ * Advance a snapshot entry to the post-edit content described by a structured
+ * diff block, without reading disk. Disk may already include later shell edits
+ * by the time the structured tool-call is polled; rereading would advance past
+ * those too and suppress the synthetic update for them.
+ *
+ * `oldText`/`newText` may be whole-file bodies (`write_to_file`) or replacement
+ * snippets (`replace_file_content`) — same rules as {@link revertEditToolCall}.
  */
-export async function refreshSnapshotPath(
+export function applyDiffBlockToSnapshot(
   snapshot: WorkingTreeSnapshot,
-  filePath: string
-): Promise<void> {
+  filePath: string,
+  oldText: string | null,
+  newText: string
+): void {
   const abs = path.resolve(filePath);
-  const file = await snapshotFile(abs);
-  if (file) snapshot.set(abs, file);
-  else snapshot.delete(abs);
+  const before = snapshot.get(abs);
+  let post: string;
+
+  if (oldText === null) {
+    // Create / full write with no prior text in the diff.
+    post = newText;
+  } else if (before?.text != null) {
+    if (before.text === oldText) {
+      post = newText;
+    } else if (before.text.includes(oldText)) {
+      post = before.text.replace(oldText, newText);
+    } else if (before.text === newText || before.text.includes(newText)) {
+      // Baseline already reflects this edit.
+      return;
+    } else {
+      // Snippet does not apply to baseline text — cannot reconstruct post-edit
+      // content without guessing; leave the entry unchanged.
+      return;
+    }
+  } else {
+    // Missing or binary baseline: best representable post state is newText
+    // (full-file writes; partial snippets are incomplete but all we have).
+    post = newText;
+  }
+
+  snapshot.set(abs, snapshotFromText(post));
 }
 
 /** Snapshot the working tree across one or more roots. */
@@ -201,8 +246,8 @@ export async function snapshotWorkingTree(roots: string[]): Promise<WorkingTreeS
 
 /**
  * Diff the current working tree against a baseline snapshot. Callers that have
- * already reflected a recognized edit should {@link refreshSnapshotPath} the
- * baseline for that path first so only *further* changes are emitted.
+ * already reflected a recognized edit should {@link applyDiffBlockToSnapshot}
+ * the baseline for that path first so only *further* changes are emitted.
  * Added/modified text files become `reflected` edits; binary/oversized/deleted
  * changes (and binary→text replacements we can't represent) become `unsupported`.
  */

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -331,22 +331,35 @@ function isUnder(target: string, prefixes: readonly string[]): boolean {
   return false;
 }
 
+/** List and read every file the given roots currently expose. */
+async function collectFiles(roots: WorkspaceRoot[]): Promise<{ files: Map<string, FileRecord>; excluded: string[] }> {
+  const files = new Map<string, FileRecord>();
+  const excluded: string[] = [];
+  for (const root of roots) {
+    const listing = await listRoot(root.display);
+    excluded.push(...listing.excluded);
+    for (const abs of listing.files) {
+      const record = await readFileRecord(abs);
+      if (!record) continue;
+      // A root spelling replaced or retargeted mid-turn (a directory swapped
+      // for a symlink) lists files whose physical location is outside every
+      // root captured at turn start. Those must never reach an ACP update or a
+      // write-through, however the listing reached them.
+      if (!rootFor(record.canonicalPath, roots)) continue;
+      // Overlapping roots list one physical file under several spellings; keep
+      // the first configured one so emitted paths stay stable.
+      if (files.has(record.canonicalPath)) continue;
+      files.set(record.canonicalPath, record);
+    }
+  }
+  return { files, excluded };
+}
+
 /** Snapshot the working tree across one or more configured roots. */
 export async function snapshotWorkingTree(rootPaths: string[]): Promise<WorkingTreeSnapshot> {
   const roots = await resolveRoots(rootPaths);
-  const snapshot: WorkingTreeSnapshot = { roots, files: new Map(), excluded: [] };
-  for (const root of roots) {
-    const listing = await listRoot(root.display);
-    snapshot.excluded.push(...listing.excluded);
-    for (const abs of listing.files) {
-      const record = await readFileRecord(abs);
-      // Overlapping roots list one physical file under several spellings; keep
-      // the first configured one so emitted paths stay stable.
-      if (!record || snapshot.files.has(record.canonicalPath)) continue;
-      snapshot.files.set(record.canonicalPath, record);
-    }
-  }
-  return snapshot;
+  const { files, excluded } = await collectFiles(roots);
+  return { roots, files, excluded };
 }
 
 /**
@@ -383,14 +396,7 @@ export async function observeEditedPaths(snapshot: WorkingTreeSnapshot, paths: s
  * edits; anything we cannot represent as a text diff becomes `unsupported`.
  */
 export async function reconcileWorkingTree(snapshot: WorkingTreeSnapshot): Promise<ReconcileResult> {
-  const current = new Map<string, FileRecord>();
-  for (const root of snapshot.roots) {
-    for (const abs of (await listRoot(root.display)).files) {
-      const record = await readFileRecord(abs);
-      if (!record || current.has(record.canonicalPath)) continue;
-      current.set(record.canonicalPath, record);
-    }
-  }
+  const { files: current } = await collectFiles(snapshot.roots);
 
   const reflected: ReflectedEdit[] = [];
   const unsupported: UnsupportedChange[] = [];

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -15,7 +15,7 @@
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { createReadStream, promises as fs } from "node:fs";
+import { createReadStream, promises as fs, realpathSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
@@ -40,6 +40,8 @@ export interface FileSnapshot {
   initialSha1?: string;
   /** Original listed text, retained to evaluate pre-turn ignore rules. */
   initialText?: string | null;
+  /** Physical file identity used to match structured paths across aliases. */
+  canonicalPath?: string;
 }
 
 /** Absolute file path -> snapshot. */
@@ -166,6 +168,12 @@ async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
     return null;
   }
   if (!st.isFile()) return null;
+  let canonicalPath: string;
+  try {
+    canonicalPath = await fs.realpath(abs);
+  } catch {
+    return null;
+  }
 
   // Never buffer multi-megabyte blobs into memory. Hash them as a stream so a
   // same-size replacement with a preserved/coarse mtime is still reported.
@@ -174,7 +182,15 @@ async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
       const hash = createHash("sha1");
       for await (const chunk of createReadStream(abs)) hash.update(chunk);
       const sha1 = `oversized:${st.size}:${hash.digest("hex")}`;
-      return { sha1, size: st.size, text: null, candidate: true, initialSha1: sha1, initialText: null };
+      return {
+        sha1,
+        size: st.size,
+        text: null,
+        candidate: true,
+        initialSha1: sha1,
+        initialText: null,
+        canonicalPath
+      };
     } catch {
       return null;
     }
@@ -191,19 +207,20 @@ async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
   // the client's text write-through (which would rewrite U+FFFD replacements).
   const isBinary = buf.includes(0) || !isValidUtf8(buf);
   const text = !isBinary ? buf.toString("utf8") : null;
-  return { sha1, size: buf.length, text, candidate: true, initialSha1: sha1, initialText: text };
+  return { sha1, size: buf.length, text, candidate: true, initialSha1: sha1, initialText: text, canonicalPath };
 }
 
 function snapshotFromText(
   text: string,
   candidate: boolean,
   initialSha1?: string,
-  initialText?: string | null
+  initialText?: string | null,
+  canonicalPath?: string
 ): FileSnapshot {
   const buf = Buffer.from(text, "utf8");
   if (buf.length > MAX_TEXT_BYTES) {
     const sha1 = `oversized:${buf.length}:${createHash("sha1").update(buf).digest("hex")}`;
-    return { sha1, size: buf.length, text: null, candidate, initialSha1, initialText };
+    return { sha1, size: buf.length, text: null, candidate, initialSha1, initialText, canonicalPath };
   }
   const sha1 = createHash("sha1").update(buf).digest("hex");
   return {
@@ -212,8 +229,25 @@ function snapshotFromText(
     text,
     candidate,
     initialSha1,
-    initialText
+    initialText,
+    canonicalPath
   };
+}
+
+/** Match a structured path to the spelling retained by the working-tree scan. */
+function snapshotKeyForPath(snapshot: WorkingTreeSnapshot, filePath: string): string {
+  const abs = path.resolve(filePath);
+  if (snapshot.has(abs)) return abs;
+  let canonical: string;
+  try {
+    canonical = realpathSync(abs);
+  } catch {
+    return abs;
+  }
+  for (const [key, file] of snapshot) {
+    if (file.canonicalPath === canonical) return key;
+  }
+  return abs;
 }
 
 /**
@@ -291,7 +325,7 @@ export function applyDiffBlocksToSnapshot(
 ): void {
   if (blocks.length === 0) return;
 
-  const abs = path.resolve(filePath);
+  const abs = snapshotKeyForPath(snapshot, filePath);
   const before = snapshot.get(abs);
 
   // Full-file writes (oldText null) and missing/binary baselines cannot use
@@ -339,7 +373,8 @@ export function applyDiffBlocksToSnapshot(
       result,
       before.candidate !== false,
       before.initialSha1 ?? before.sha1,
-      before.initialText ?? before.text
+      before.initialText ?? before.text,
+      before.canonicalPath
     )
   );
 }
@@ -378,7 +413,10 @@ function applySingleDiffBlock(
       post,
       before?.candidate ?? false,
       before ? (before.initialSha1 ?? before.sha1) : undefined,
-      before ? (before.initialText ?? before.text) : undefined
+      before ? (before.initialText ?? before.text) : undefined,
+      before?.canonicalPath ?? (() => {
+        try { return realpathSync(abs); } catch { return undefined; }
+      })()
     )
   );
 }
@@ -546,7 +584,8 @@ export async function reconcileWorkingTree(
     reflected.push({ path: abs, oldText: before?.text ?? null, newText: now.text });
   }
 
-  for (const [abs] of baseline) {
+  for (const [abs, before] of baseline) {
+    if (before.candidate === false) continue;
     if (!current.has(abs)) unsupported.push({ path: abs, reason: "deleted" });
   }
 

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -152,6 +152,32 @@ function splitNulList(stdout: string): string[] {
  * nested repository. Symlinks are never followed (a tracked symlink to a
  * directory is not a gitlink; following it can loop or leave the roots).
  */
+
+/**
+ * True when `dir` is the root of a checked-out repository of its own. A plain
+ * directory — including a deinitialized submodule, whose gitlink remains as an
+ * empty directory — makes git walk up and answer for an ancestor repository,
+ * in which case listing inside it would rediscover the parent (and the
+ * gitlink entry "./" would recurse into the same directory forever).
+ */
+async function isCheckedOutRepository(dir: string): Promise<boolean> {
+  let top: string;
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", dir, "rev-parse", "--show-toplevel"], { maxBuffer: LS_FILES_MAX_BUFFER });
+    top = stdout.trim();
+  } catch {
+    return false;
+  }
+  if (!top) return false;
+  try {
+    // rev-parse may print a different spelling of the same directory (e.g.
+    // /tmp vs /private/tmp), so compare physical identities.
+    return (await fs.realpath(top)) === (await fs.realpath(dir));
+  } catch {
+    return top === dir;
+  }
+}
+
 async function listRoot(root: string): Promise<Listing> {
   let entries: string[];
   try {
@@ -192,9 +218,15 @@ async function listRoot(root: string): Promise<Listing> {
     if (stats.isSymbolicLink()) {
       listing.excluded.push(abs);
     } else if (stats.isDirectory()) {
-      const nested = await listRoot(abs);
-      listing.files.push(...nested.files);
-      listing.excluded.push(...nested.excluded);
+      // Only an actual checked-out nested repository is listed inside. The
+      // self-reference guard rejects a gitlink that git reports for its own
+      // directory ("./" from a deinitialized submodule) even before the
+      // repository check runs.
+      if (abs !== root && (await isCheckedOutRepository(abs))) {
+        const nested = await listRoot(abs);
+        listing.files.push(...nested.files);
+        listing.excluded.push(...nested.excluded);
+      }
     } else if (stats.isFile()) {
       listing.files.push(abs);
     }

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -424,14 +424,58 @@ function applySingleDiffBlock(
 /** Snapshot the working tree across one or more roots. */
 export async function snapshotWorkingTree(roots: string[]): Promise<WorkingTreeSnapshot> {
   const snapshot: WorkingTreeSnapshot = new Map();
+  const seenFiles = new Set<string>();
   for (const root of await dedupeRoots(roots)) {
     for (const abs of await listFiles(root)) {
       if (snapshot.has(abs)) continue;
       const file = await snapshotFile(abs);
-      if (file) snapshot.set(abs, file);
+      if (!file || (file.canonicalPath && seenFiles.has(file.canonicalPath))) continue;
+      if (file.canonicalPath) seenFiles.add(file.canonicalPath);
+      // Keep the first configured spelling while deduplicating overlapping
+      // roots that list the same physical file through different paths.
+      snapshot.set(abs, file);
     }
   }
   return snapshot;
+}
+
+async function pathIsWithinRoots(
+  filePath: string,
+  roots: string[],
+  recordedCanonicalPath?: string
+): Promise<boolean> {
+  // The file and newly-created parent directories may have been deleted. Walk
+  // up to the deepest surviving ancestor, canonicalize it, then restore the
+  // missing suffix without following any replacement symlink.
+  let canonicalFile = recordedCanonicalPath;
+  if (!canonicalFile) {
+    const suffix: string[] = [];
+    let ancestor = path.resolve(filePath);
+    while (true) {
+      try {
+        canonicalFile = path.join(await fs.realpath(ancestor), ...suffix.reverse());
+        break;
+      } catch {
+        const parent = path.dirname(ancestor);
+        if (parent === ancestor) return false;
+        suffix.push(path.basename(ancestor));
+        ancestor = parent;
+      }
+    }
+  }
+  for (const root of await dedupeRoots(roots)) {
+    let canonicalRoot: string;
+    try {
+      canonicalRoot = await fs.realpath(root);
+    } catch {
+      continue;
+    }
+    const relative = path.relative(canonicalRoot, canonicalFile);
+    if (relative === "" || (!path.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path.sep}`))) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -522,18 +566,41 @@ export async function reconcileWorkingTree(
   const current = await snapshotWorkingTree(roots);
   const reflected: ReflectedEdit[] = [];
   const unsupported: UnsupportedChange[] = [];
+  const structuredCandidates = new Set<string>();
+  const baselineByCanonical = new Map<string, FileSnapshot>();
+  const currentByCanonical = new Map<string, string>();
+  for (const file of baseline.values()) {
+    if (file.canonicalPath) baselineByCanonical.set(file.canonicalPath, file);
+  }
+  for (const [abs, file] of current) {
+    if (file.canonicalPath) currentByCanonical.set(file.canonicalPath, abs);
+  }
+  const currentKeyFor = (abs: string, before: FileSnapshot): string | undefined =>
+    current.has(abs) ? abs : before.canonicalPath ? currentByCanonical.get(before.canonicalPath) : undefined;
+  const baselineFor = (abs: string, now: FileSnapshot): FileSnapshot | undefined =>
+    baseline.get(abs) ?? (now.canonicalPath ? baselineByCanonical.get(now.canonicalPath) : undefined);
 
   // A newly added ignore rule can remove a still-existing baseline candidate
   // from `git ls-files --others --exclude-standard`. Snapshot those paths
   // directly so an eligibility change is not misreported as a deletion.
   for (const [abs, before] of baseline) {
-    if (current.has(abs)) continue;
+    if (currentKeyFor(abs, before)) continue;
     // Structured baseline advancement can add an absolute path outside the
-    // configured roots. It was never a listing candidate, so do not pull it
-    // into reconciliation and duplicate the already-routed structured edit.
-    if (before.candidate === false) continue;
+    // configured roots. Only pull structured-only entries into reconciliation
+    // when their physical location belongs to this workspace.
+    if (before.candidate === false) {
+      if (!(await pathIsWithinRoots(abs, roots, before.canonicalPath))) continue;
+      structuredCandidates.add(abs);
+      // Do not read through an intermediate symlink that now redirects the
+      // same spelling outside the workspace. The recorded in-root file is a
+      // deletion; any replacement target is unrelated and must remain unread.
+      if (!(await pathIsWithinRoots(abs, roots))) continue;
+    }
     const now = await snapshotFile(abs);
-    if (now) current.set(abs, now);
+    if (now) {
+      current.set(abs, now);
+      if (now.canonicalPath) currentByCanonical.set(now.canonicalPath, abs);
+    }
   }
 
   // Conversely, removing an ignore rule can expose a pre-existing file that
@@ -545,7 +612,12 @@ export async function reconcileWorkingTree(
   for (const abs of paths) {
     if (path.basename(abs) !== ".gitignore") continue;
     const before = baseline.get(abs);
-    if ((before?.initialSha1 ?? before?.sha1) !== current.get(abs)?.sha1) changedIgnoreRules.add(abs);
+    const now = current.get(abs);
+    const alignedBefore = before ?? (now ? baselineFor(abs, now) : undefined);
+    const alignedNow = now ?? (before ? current.get(currentKeyFor(abs, before) ?? "") : undefined);
+    if ((alignedBefore?.initialSha1 ?? alignedBefore?.sha1) !== alignedNow?.sha1) {
+      changedIgnoreRules.add(abs);
+    }
   }
   const couldBeAffectedByIgnoreChange = (abs: string): boolean => {
     if (path.basename(abs) === ".gitignore") return false;
@@ -556,12 +628,12 @@ export async function reconcileWorkingTree(
     return false;
   };
   const newlyListedAfterIgnoreChange = [...current.keys()].filter(
-    (abs) => !baseline.has(abs) && couldBeAffectedByIgnoreChange(abs)
+    (abs) => !baselineFor(abs, current.get(abs)!) && couldBeAffectedByIgnoreChange(abs)
   );
   const ignoredBeforeTurn = await ignoredByBaselineRules(baseline, newlyListedAfterIgnoreChange);
 
   for (const [abs, now] of current) {
-    const before = baseline.get(abs);
+    const before = baselineFor(abs, now);
     if (before && before.sha1 === now.sha1) continue; // unchanged
     if (!before && ignoredBeforeTurn.has(abs)) {
       unsupported.push({ path: abs, reason: "ignore-rules-changed" });
@@ -585,8 +657,12 @@ export async function reconcileWorkingTree(
   }
 
   for (const [abs, before] of baseline) {
-    if (before.candidate === false) continue;
-    if (!current.has(abs)) unsupported.push({ path: abs, reason: "deleted" });
+    if (currentKeyFor(abs, before)) continue;
+    // Structured edits can introduce entries absent from the initial listing.
+    // Report a later deletion when that physical path belongs to a configured
+    // root, while continuing to ignore structured edits outside the workspace.
+    if (before.candidate === false && !structuredCandidates.has(abs)) continue;
+    unsupported.push({ path: abs, reason: "deleted" });
   }
 
   return { reflected, unsupported };

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -5,12 +5,12 @@
 // cover recognized edits; without this, Zed/Git can show files agy modified
 // while ACP emits no corresponding diff update or fs/write-through (see #76).
 //
-// Strategy: snapshot the working tree at turn start, diff it at turn end, and
-// for every changed file NOT already reflected by a recognized edit, synthesize
-// an ACP `tool_call` edit update the caller can emit + hand to the client's fs
-// write-through. Changes we can't represent as a text diff (binary/oversized/
-// deletions) are reported to the caller so it can surface the limitation
-// instead of silently dropping them.
+// Strategy: snapshot the working tree at turn start, advance the baseline when
+// a recognized edit lands, diff the remainder at turn end, and for every
+// changed file synthesize an ACP `tool_call` edit update the caller can emit +
+// hand to the client's fs write-through. Changes we can't represent as a text
+// diff (binary/oversized/deletions) are reported to the caller so it can
+// surface the limitation instead of silently dropping them.
 
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
@@ -25,6 +25,8 @@ const execFileAsync = promisify(execFile);
 export const MAX_TEXT_BYTES = 1024 * 1024;
 /** Directories never worth scanning for agy edits. */
 const SKIP_DIRS = new Set([".git", "node_modules"]);
+
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
 export interface FileSnapshot {
   sha1: string;
@@ -67,10 +69,21 @@ function dedupeRoots(roots: string[]): string[] {
   return out;
 }
 
+/** True when `buf` is valid UTF-8 (and not empty of encoding errors). */
+export function isValidUtf8(buf: Buffer): boolean {
+  try {
+    utf8Decoder.decode(buf);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * List candidate files under a root. Prefers git (tracked + untracked but not
  * gitignored, so build output and node_modules stay out); falls back to a
- * bounded recursive walk for non-git roots.
+ * bounded recursive walk for non-git roots. Checked-out submodules appear as
+ * gitlink directories in the parent listing — expand them by listing inside.
  */
 async function listFiles(root: string): Promise<string[]> {
   try {
@@ -79,10 +92,26 @@ async function listFiles(root: string): Promise<string[]> {
       ["-C", root, "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
       { maxBuffer: 64 * 1024 * 1024 }
     );
-    return stdout
-      .split("\0")
-      .filter((rel) => rel.length > 0)
-      .map((rel) => path.resolve(root, rel));
+    const out: string[] = [];
+    for (const rel of stdout.split("\0")) {
+      if (rel.length === 0) continue;
+      const abs = path.resolve(root, rel);
+      // Gitlinks (mode 160000) show up as a single path; when checked out that
+      // path is a directory. Recurse so edits inside the submodule are visible.
+      let st: import("node:fs").Stats | null = null;
+      try {
+        st = await fs.stat(abs);
+      } catch {
+        // vanished between ls-files and stat — skip
+        continue;
+      }
+      if (st.isDirectory()) {
+        out.push(...(await listFiles(abs)));
+      } else if (st.isFile()) {
+        out.push(abs);
+      }
+    }
+    return out;
   } catch {
     return await walk(root);
   }
@@ -110,6 +139,24 @@ async function walk(dir: string): Promise<string[]> {
 }
 
 async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
+  let st: import("node:fs").Stats;
+  try {
+    st = await fs.stat(abs);
+  } catch {
+    return null;
+  }
+  if (!st.isFile()) return null;
+
+  // Never buffer multi-megabyte blobs into memory. Size+mtime is enough to
+  // notice a change so we can report it as unsupported; we never text-diff them.
+  if (st.size > MAX_TEXT_BYTES) {
+    return {
+      sha1: `oversized:${st.size}:${st.mtimeMs}`,
+      size: st.size,
+      text: null
+    };
+  }
+
   let buf: Buffer;
   try {
     buf = await fs.readFile(abs);
@@ -117,9 +164,26 @@ async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
     return null; // unreadable / vanished / not a regular file
   }
   const sha1 = createHash("sha1").update(buf).digest("hex");
-  const isBinary = buf.includes(0);
-  const text = !isBinary && buf.length <= MAX_TEXT_BYTES ? buf.toString("utf8") : null;
+  // NUL byte *or* invalid UTF-8 => binary. Invalid UTF-8 must not be handed to
+  // the client's text write-through (which would rewrite U+FFFD replacements).
+  const isBinary = buf.includes(0) || !isValidUtf8(buf);
+  const text = !isBinary ? buf.toString("utf8") : null;
   return { sha1, size: buf.length, text };
+}
+
+/**
+ * Update (or remove) one path in an existing snapshot. Used after a recognized
+ * structured edit lands so a later shell/unrecognized change to the same file
+ * still reconciles against the post-edit content rather than being suppressed.
+ */
+export async function refreshSnapshotPath(
+  snapshot: WorkingTreeSnapshot,
+  filePath: string
+): Promise<void> {
+  const abs = path.resolve(filePath);
+  const file = await snapshotFile(abs);
+  if (file) snapshot.set(abs, file);
+  else snapshot.delete(abs);
 }
 
 /** Snapshot the working tree across one or more roots. */
@@ -136,37 +200,41 @@ export async function snapshotWorkingTree(roots: string[]): Promise<WorkingTreeS
 }
 
 /**
- * Diff the current working tree against a baseline snapshot, skipping any path
- * already reflected through a recognized edit. Added/modified text files become
- * `reflected` edits; binary/oversized/deleted changes become `unsupported`.
+ * Diff the current working tree against a baseline snapshot. Callers that have
+ * already reflected a recognized edit should {@link refreshSnapshotPath} the
+ * baseline for that path first so only *further* changes are emitted.
+ * Added/modified text files become `reflected` edits; binary/oversized/deleted
+ * changes (and binary→text replacements we can't represent) become `unsupported`.
  */
 export async function reconcileWorkingTree(
   baseline: WorkingTreeSnapshot,
-  roots: string[],
-  reflectedPaths: Iterable<string>
+  roots: string[]
 ): Promise<ReconcileResult> {
-  const skip = new Set<string>();
-  for (const p of reflectedPaths) skip.add(path.resolve(p));
-
   const current = await snapshotWorkingTree(roots);
   const reflected: ReflectedEdit[] = [];
   const unsupported: UnsupportedChange[] = [];
 
   for (const [abs, now] of current) {
-    if (skip.has(abs)) continue;
     const before = baseline.get(abs);
     if (before && before.sha1 === now.sha1) continue; // unchanged
     if (now.text === null) {
       unsupported.push({ path: abs, reason: now.size > MAX_TEXT_BYTES ? "oversized" : "binary" });
       continue;
     }
-    // before?.text is null for a brand-new file, or for a file that was binary/
-    // oversized before and is now text — both are represented as a create.
+    // File existed before but was binary/oversized: we have no representable
+    // oldText, and treating it as a create would mislead the client + corrupt
+    // write-through. Report rather than invent a creation.
+    if (before && before.text === null) {
+      unsupported.push({
+        path: abs,
+        reason: before.size > MAX_TEXT_BYTES ? "oversized" : "binary"
+      });
+      continue;
+    }
     reflected.push({ path: abs, oldText: before?.text ?? null, newText: now.text });
   }
 
   for (const [abs] of baseline) {
-    if (skip.has(abs)) continue;
     if (!current.has(abs)) unsupported.push({ path: abs, reason: "deleted" });
   }
 

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -144,16 +144,6 @@ function splitNulList(stdout: string): string[] {
 }
 
 /**
- * List candidate files under a root. Prefers git (tracked + untracked but not
- * gitignored, so build output and node_modules stay out); falls back to a
- * bounded recursive walk for non-git roots. Checked-out submodules appear as
- * gitlink directories in the parent listing — expand them by listing inside,
- * which also keeps the parent's ignore rules and index from governing the
- * nested repository. Symlinks are never followed (a tracked symlink to a
- * directory is not a gitlink; following it can loop or leave the roots).
- */
-
-/**
  * True when `dir` is the root of a checked-out repository of its own. A plain
  * directory — including a deinitialized submodule, whose gitlink remains as an
  * empty directory — makes git walk up and answer for an ancestor repository,
@@ -178,6 +168,15 @@ async function isCheckedOutRepository(dir: string): Promise<boolean> {
   }
 }
 
+/**
+ * List candidate files under a root. Prefers git (tracked + untracked but not
+ * gitignored, so build output and node_modules stay out); falls back to a
+ * bounded recursive walk for non-git roots. Checked-out submodules appear as
+ * gitlink directories in the parent listing — expand them by listing inside,
+ * which also keeps the parent's ignore rules and index from governing the
+ * nested repository. Symlinks are never followed (a tracked symlink to a
+ * directory is not a gitlink; following it can loop or leave the roots).
+ */
 async function listRoot(root: string): Promise<Listing> {
   let entries: string[];
   try {
@@ -363,6 +362,10 @@ function isUnder(target: string, prefixes: readonly string[]): boolean {
   return false;
 }
 
+/** How many files collectFiles reads at once; large repos would otherwise
+ *  pay a serial stat+read+hash per file twice a turn. */
+const READ_CONCURRENCY = 16;
+
 /** List and read every file the given roots currently expose. */
 async function collectFiles(roots: WorkspaceRoot[]): Promise<{ files: Map<string, FileRecord>; excluded: string[] }> {
   const files = new Map<string, FileRecord>();
@@ -370,8 +373,18 @@ async function collectFiles(roots: WorkspaceRoot[]): Promise<{ files: Map<string
   for (const root of roots) {
     const listing = await listRoot(root.display);
     excluded.push(...listing.excluded);
-    for (const abs of listing.files) {
-      const record = await readFileRecord(abs);
+    // Read with bounded concurrency, then apply in listing order: root order
+    // and the first-spelling-wins dedup below stay deterministic.
+    const records: Array<FileRecord | null> = new Array(listing.files.length).fill(null);
+    let next = 0;
+    const worker = async (): Promise<void> => {
+      while (next < records.length) {
+        const index = next++;
+        records[index] = await readFileRecord(listing.files[index]);
+      }
+    };
+    await Promise.all(Array.from({ length: Math.min(READ_CONCURRENCY, records.length) }, worker));
+    for (const record of records) {
       if (!record) continue;
       // A root spelling replaced or retargeted mid-turn (a directory swapped
       // for a symlink) lists files whose physical location is outside every
@@ -449,6 +462,16 @@ function reportedAccountsForDisk(
 }
 
 /**
+ * Digest of a reported whole-file body, in the same shape
+ * {@link readFileRecord} uses for files too large to buffer, so an oversized
+ * text file can be attributed to a whole-file write without buffering it.
+ */
+function oversizedTextDigest(text: string): string {
+  const buf = Buffer.from(text, "utf8");
+  return `oversized:${buf.length}:${createHash("sha1").update(buf).digest("hex")}`;
+}
+
+/**
  * Record the current on-disk content of paths whose change has *already* been
  * reported to the client (a recognized structured edit, or a synthetic one this
  * module produced), so end-of-turn reconciliation only emits what is still
@@ -475,8 +498,17 @@ export async function observeEditedPaths(
       continue;
     }
     if (blocks !== undefined) {
-      if (record.text === null) continue;
-      if (!reportedAccountsForDisk(existing?.text, blocks, wholeFile === true, record.text)) continue;
+      if (record.text === null) {
+        // Binary content cannot round-trip through a text diff block, but an
+        // oversized *text* file can still be attributed to a whole-file write:
+        // hash the reported body and compare it with the streamed disk hash.
+        // (A binary file's plain digest never matches the prefixed form.)
+        const attributed =
+          wholeFile === true && blocks.some((block) => oversizedTextDigest(block.newText) === record.sha1);
+        if (!attributed) continue;
+      } else if (!reportedAccountsForDisk(existing?.text, blocks, wholeFile === true, record.text)) {
+        continue;
+      }
     }
     const retained = existing?.path ?? displayPathFor(canonicalPath, snapshot.roots) ?? abs;
     snapshot.files.set(canonicalPath, { ...record, path: retained });

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -15,7 +15,7 @@
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { promises as fs } from "node:fs";
+import { createReadStream, promises as fs } from "node:fs";
 import * as path from "node:path";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 
@@ -33,6 +33,10 @@ export interface FileSnapshot {
   size: number;
   /** utf-8 contents, or null when binary or oversized (out of scope for a diff). */
   text: string | null;
+  /** False when added by structured-diff advancement rather than root listing. */
+  candidate?: boolean;
+  /** Original listed fingerprint, retained when structured diffs advance sha1. */
+  initialSha1?: string;
 }
 
 /** Absolute file path -> snapshot. */
@@ -45,7 +49,7 @@ export interface ReflectedEdit {
   newText: string;
 }
 
-export type UnsupportedReason = "binary" | "oversized" | "deleted";
+export type UnsupportedReason = "binary" | "oversized" | "deleted" | "ignore-rules-changed";
 
 export interface UnsupportedChange {
   path: string;
@@ -150,14 +154,17 @@ async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
   }
   if (!st.isFile()) return null;
 
-  // Never buffer multi-megabyte blobs into memory. Size+mtime is enough to
-  // notice a change so we can report it as unsupported; we never text-diff them.
+  // Never buffer multi-megabyte blobs into memory. Hash them as a stream so a
+  // same-size replacement with a preserved/coarse mtime is still reported.
   if (st.size > MAX_TEXT_BYTES) {
-    return {
-      sha1: `oversized:${st.size}:${st.mtimeMs}`,
-      size: st.size,
-      text: null
-    };
+    try {
+      const hash = createHash("sha1");
+      for await (const chunk of createReadStream(abs)) hash.update(chunk);
+      const sha1 = `oversized:${st.size}:${hash.digest("hex")}`;
+      return { sha1, size: st.size, text: null, candidate: true, initialSha1: sha1 };
+    } catch {
+      return null;
+    }
   }
 
   let buf: Buffer;
@@ -171,19 +178,22 @@ async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
   // the client's text write-through (which would rewrite U+FFFD replacements).
   const isBinary = buf.includes(0) || !isValidUtf8(buf);
   const text = !isBinary ? buf.toString("utf8") : null;
-  return { sha1, size: buf.length, text };
+  return { sha1, size: buf.length, text, candidate: true, initialSha1: sha1 };
 }
 
-function snapshotFromText(text: string): FileSnapshot {
+function snapshotFromText(text: string, candidate: boolean, initialSha1?: string): FileSnapshot {
   const buf = Buffer.from(text, "utf8");
   if (buf.length > MAX_TEXT_BYTES) {
-    // mtime unknown — size alone is enough; we never text-diff these.
-    return { sha1: `oversized:${buf.length}:0`, size: buf.length, text: null };
+    const sha1 = `oversized:${buf.length}:${createHash("sha1").update(buf).digest("hex")}`;
+    return { sha1, size: buf.length, text: null, candidate, initialSha1 };
   }
+  const sha1 = createHash("sha1").update(buf).digest("hex");
   return {
-    sha1: createHash("sha1").update(buf).digest("hex"),
+    sha1,
     size: buf.length,
-    text
+    text,
+    candidate,
+    initialSha1
   };
 }
 
@@ -304,7 +314,7 @@ export function applyDiffBlocksToSnapshot(
   for (const op of ops) {
     result = result.slice(0, op.idx) + op.newText + result.slice(op.idx + op.oldLen);
   }
-  snapshot.set(abs, snapshotFromText(result));
+  snapshot.set(abs, snapshotFromText(result, before.candidate !== false, before.initialSha1 ?? before.sha1));
 }
 
 function applySingleDiffBlock(
@@ -335,7 +345,10 @@ function applySingleDiffBlock(
     post = newText;
   }
 
-  snapshot.set(abs, snapshotFromText(post));
+  snapshot.set(
+    abs,
+    snapshotFromText(post, before?.candidate ?? false, before ? (before.initialSha1 ?? before.sha1) : undefined)
+  );
 }
 
 /** Snapshot the working tree across one or more roots. */
@@ -366,9 +379,46 @@ export async function reconcileWorkingTree(
   const reflected: ReflectedEdit[] = [];
   const unsupported: UnsupportedChange[] = [];
 
+  // A newly added ignore rule can remove a still-existing baseline candidate
+  // from `git ls-files --others --exclude-standard`. Snapshot those paths
+  // directly so an eligibility change is not misreported as a deletion.
+  for (const [abs, before] of baseline) {
+    if (current.has(abs)) continue;
+    // Structured baseline advancement can add an absolute path outside the
+    // configured roots. It was never a listing candidate, so do not pull it
+    // into reconciliation and duplicate the already-routed structured edit.
+    if (before.candidate === false) continue;
+    const now = await snapshotFile(abs);
+    if (now) current.set(abs, now);
+  }
+
+  // Conversely, removing an ignore rule can expose a pre-existing file that
+  // was absent from the baseline. We cannot reconstruct its pre-turn content,
+  // so report it rather than inventing a creation and routing a destructive
+  // empty→content write-through. Nested .gitignore changes affect descendants.
+  const changedIgnoreRules = new Set<string>();
+  const paths = new Set([...baseline.keys(), ...current.keys()]);
+  for (const abs of paths) {
+    if (path.basename(abs) !== ".gitignore") continue;
+    const before = baseline.get(abs);
+    if ((before?.initialSha1 ?? before?.sha1) !== current.get(abs)?.sha1) changedIgnoreRules.add(abs);
+  }
+  const becameVisibleAfterIgnoreChange = (abs: string): boolean => {
+    if (path.basename(abs) === ".gitignore") return false;
+    for (const ignoreFile of changedIgnoreRules) {
+      const dir = path.dirname(ignoreFile);
+      if (abs.startsWith(dir + path.sep)) return true;
+    }
+    return false;
+  };
+
   for (const [abs, now] of current) {
     const before = baseline.get(abs);
     if (before && before.sha1 === now.sha1) continue; // unchanged
+    if (!before && becameVisibleAfterIgnoreChange(abs)) {
+      unsupported.push({ path: abs, reason: "ignore-rules-changed" });
+      continue;
+    }
     if (now.text === null) {
       unsupported.push({ path: abs, reason: now.size > MAX_TEXT_BYTES ? "oversized" : "binary" });
       continue;

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -64,13 +64,21 @@ export interface ReconcileResult {
   unsupported: UnsupportedChange[];
 }
 
-function dedupeRoots(roots: string[]): string[] {
+async function dedupeRoots(roots: string[]): Promise<string[]> {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const root of roots) {
     const resolved = path.resolve(root);
-    if (seen.has(resolved)) continue;
-    seen.add(resolved);
+    let canonical = resolved;
+    try {
+      canonical = await fs.realpath(resolved);
+    } catch {
+      // Preserve the unresolved root so the existing git/walk fallback can
+      // decide whether it is readable.
+    }
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+    // Keep the first configured spelling (normally cwd) for emitted paths.
     out.push(resolved);
   }
   return out;
@@ -378,7 +386,7 @@ function applySingleDiffBlock(
 /** Snapshot the working tree across one or more roots. */
 export async function snapshotWorkingTree(roots: string[]): Promise<WorkingTreeSnapshot> {
   const snapshot: WorkingTreeSnapshot = new Map();
-  for (const root of dedupeRoots(roots)) {
+  for (const root of await dedupeRoots(roots)) {
     for (const abs of await listFiles(root)) {
       if (snapshot.has(abs)) continue;
       const file = await snapshotFile(abs);

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -221,6 +221,13 @@ export function replaceOccurrence(
   return text.slice(0, idx) + newText + text.slice(idx + oldText.length);
 }
 
+export interface DiffBlockSpec {
+  oldText: string | null;
+  newText: string;
+  /** 1-based start line in the *pre-edit* file (agy StartLine). */
+  line?: number;
+}
+
 /**
  * Advance a snapshot entry to the post-edit content described by a structured
  * diff block, without reading disk. Disk may already include later shell edits
@@ -238,12 +245,78 @@ export function applyDiffBlockToSnapshot(
   newText: string,
   line?: number
 ): void {
+  applyDiffBlocksToSnapshot(snapshot, filePath, [{ oldText, newText, line }]);
+}
+
+/**
+ * Apply one or more structured diff blocks for a single path. Multi-replace
+ * chunks carry `StartLine` against the *original* file; applying them left-to-
+ * right on a mutating buffer can invalidate later line numbers when an earlier
+ * chunk changes the line count. Instead, locate every match on the original
+ * text and apply from end to start so indices stay valid.
+ */
+export function applyDiffBlocksToSnapshot(
+  snapshot: WorkingTreeSnapshot,
+  filePath: string,
+  blocks: DiffBlockSpec[]
+): void {
+  if (blocks.length === 0) return;
+
   const abs = path.resolve(filePath);
   const before = snapshot.get(abs);
+
+  // Full-file writes (oldText null) and missing/binary baselines cannot use
+  // multi-match positioning — fall back to sequential single-block rules.
+  if (blocks.some((b) => b.oldText === null) || before?.text == null) {
+    for (const block of blocks) {
+      applySingleDiffBlock(snapshot, abs, snapshot.get(abs), block);
+    }
+    return;
+  }
+
+  const original = before.text;
+  type Op = { idx: number; oldLen: number; newText: string };
+  const ops: Op[] = [];
+
+  for (const block of blocks) {
+    const oldText = block.oldText!;
+    if (original === oldText) {
+      ops.push({ idx: 0, oldLen: original.length, newText: block.newText });
+      continue;
+    }
+    const from = block.line !== undefined ? offsetOfLine(original, block.line) : 0;
+    if (from === null) continue;
+    const idx = original.indexOf(oldText, from);
+    if (idx === -1) continue;
+    ops.push({ idx, oldLen: oldText.length, newText: block.newText });
+  }
+
+  if (ops.length === 0) {
+    // Nothing matched — same best-effort as a single failed apply.
+    const last = blocks[blocks.length - 1]!;
+    if (original === last.newText || original.includes(last.newText)) return;
+    return;
+  }
+
+  // End-to-start so earlier replacements do not shift later indices.
+  ops.sort((a, b) => b.idx - a.idx || b.oldLen - a.oldLen);
+  let result = original;
+  for (const op of ops) {
+    result = result.slice(0, op.idx) + op.newText + result.slice(op.idx + op.oldLen);
+  }
+  snapshot.set(abs, snapshotFromText(result));
+}
+
+function applySingleDiffBlock(
+  snapshot: WorkingTreeSnapshot,
+  abs: string,
+  before: FileSnapshot | undefined,
+  block: DiffBlockSpec
+): void {
+  const { oldText, newText, line } = block;
   let post: string;
 
   if (oldText === null) {
-    // Create / full write with no prior text in the diff.
     post = newText;
   } else if (before?.text != null) {
     if (before.text === oldText) {
@@ -253,17 +326,12 @@ export function applyDiffBlockToSnapshot(
       if (applied !== null) {
         post = applied;
       } else if (before.text === newText || before.text.includes(newText)) {
-        // Baseline already reflects this edit.
         return;
       } else {
-        // Snippet does not apply to baseline text — cannot reconstruct post-edit
-        // content without guessing; leave the entry unchanged.
         return;
       }
     }
   } else {
-    // Missing or binary baseline: best representable post state is newText
-    // (full-file writes; partial snippets are incomplete but all we have).
     post = newText;
   }
 

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -16,6 +16,7 @@ import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { createReadStream, promises as fs } from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 
@@ -37,6 +38,8 @@ export interface FileSnapshot {
   candidate?: boolean;
   /** Original listed fingerprint, retained when structured diffs advance sha1. */
   initialSha1?: string;
+  /** Original listed text, retained to evaluate pre-turn ignore rules. */
+  initialText?: string | null;
 }
 
 /** Absolute file path -> snapshot. */
@@ -148,7 +151,9 @@ async function walk(dir: string): Promise<string[]> {
 async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
   let st: import("node:fs").Stats;
   try {
-    st = await fs.stat(abs);
+    // Do not follow a regular-file path that was replaced with a symlink after
+    // the baseline listing, especially during direct candidate resnapshot.
+    st = await fs.lstat(abs);
   } catch {
     return null;
   }
@@ -161,7 +166,7 @@ async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
       const hash = createHash("sha1");
       for await (const chunk of createReadStream(abs)) hash.update(chunk);
       const sha1 = `oversized:${st.size}:${hash.digest("hex")}`;
-      return { sha1, size: st.size, text: null, candidate: true, initialSha1: sha1 };
+      return { sha1, size: st.size, text: null, candidate: true, initialSha1: sha1, initialText: null };
     } catch {
       return null;
     }
@@ -178,14 +183,19 @@ async function snapshotFile(abs: string): Promise<FileSnapshot | null> {
   // the client's text write-through (which would rewrite U+FFFD replacements).
   const isBinary = buf.includes(0) || !isValidUtf8(buf);
   const text = !isBinary ? buf.toString("utf8") : null;
-  return { sha1, size: buf.length, text, candidate: true, initialSha1: sha1 };
+  return { sha1, size: buf.length, text, candidate: true, initialSha1: sha1, initialText: text };
 }
 
-function snapshotFromText(text: string, candidate: boolean, initialSha1?: string): FileSnapshot {
+function snapshotFromText(
+  text: string,
+  candidate: boolean,
+  initialSha1?: string,
+  initialText?: string | null
+): FileSnapshot {
   const buf = Buffer.from(text, "utf8");
   if (buf.length > MAX_TEXT_BYTES) {
     const sha1 = `oversized:${buf.length}:${createHash("sha1").update(buf).digest("hex")}`;
-    return { sha1, size: buf.length, text: null, candidate, initialSha1 };
+    return { sha1, size: buf.length, text: null, candidate, initialSha1, initialText };
   }
   const sha1 = createHash("sha1").update(buf).digest("hex");
   return {
@@ -193,7 +203,8 @@ function snapshotFromText(text: string, candidate: boolean, initialSha1?: string
     size: buf.length,
     text,
     candidate,
-    initialSha1
+    initialSha1,
+    initialText
   };
 }
 
@@ -314,7 +325,15 @@ export function applyDiffBlocksToSnapshot(
   for (const op of ops) {
     result = result.slice(0, op.idx) + op.newText + result.slice(op.idx + op.oldLen);
   }
-  snapshot.set(abs, snapshotFromText(result, before.candidate !== false, before.initialSha1 ?? before.sha1));
+  snapshot.set(
+    abs,
+    snapshotFromText(
+      result,
+      before.candidate !== false,
+      before.initialSha1 ?? before.sha1,
+      before.initialText ?? before.text
+    )
+  );
 }
 
 function applySingleDiffBlock(
@@ -347,7 +366,12 @@ function applySingleDiffBlock(
 
   snapshot.set(
     abs,
-    snapshotFromText(post, before?.candidate ?? false, before ? (before.initialSha1 ?? before.sha1) : undefined)
+    snapshotFromText(
+      post,
+      before?.candidate ?? false,
+      before ? (before.initialSha1 ?? before.sha1) : undefined,
+      before ? (before.initialText ?? before.text) : undefined
+    )
   );
 }
 
@@ -362,6 +386,59 @@ export async function snapshotWorkingTree(roots: string[]): Promise<WorkingTreeS
     }
   }
   return snapshot;
+}
+
+/**
+ * Use Git's own matcher to determine which newly listed paths were ignored by
+ * the pre-turn .gitignore contents. Reconstructing only ignore files in a
+ * temporary repository avoids mutating the real worktree and avoids a partial
+ * reimplementation of gitignore pattern/negation semantics.
+ */
+async function ignoredByBaselineRules(
+  baseline: WorkingTreeSnapshot,
+  roots: string[],
+  candidates: string[]
+): Promise<Set<string>> {
+  const ignored = new Set<string>();
+  for (const root of dedupeRoots(roots)) {
+    const underRoot = candidates.filter((abs) => abs.startsWith(root + path.sep));
+    if (underRoot.length === 0) continue;
+    try {
+      await execFileAsync("git", ["-C", root, "rev-parse", "--is-inside-work-tree"]);
+    } catch {
+      // Non-git roots use the recursive walker, where .gitignore never changes
+      // candidate visibility.
+      continue;
+    }
+
+    const temp = await fs.mkdtemp(path.join(os.tmpdir(), "agy-acp-ignore-"));
+    try {
+      await execFileAsync("git", ["-C", temp, "init", "-q"]);
+      for (const [ignoreFile, snapshot] of baseline) {
+        if (path.basename(ignoreFile) !== ".gitignore" || !ignoreFile.startsWith(root + path.sep)) continue;
+        const text = snapshot.initialText ?? snapshot.text;
+        if (text == null) continue;
+        const relative = path.relative(root, ignoreFile);
+        const target = path.join(temp, relative);
+        await fs.mkdir(path.dirname(target), { recursive: true });
+        await fs.writeFile(target, text, "utf8");
+      }
+
+      for (const abs of underRoot) {
+        const relative = path.relative(root, abs);
+        try {
+          await execFileAsync("git", ["-C", temp, "check-ignore", "-q", "--no-index", "--", relative]);
+          ignored.add(abs);
+        } catch {
+          // Exit 1 means the path was visible under the baseline rules. Other
+          // matcher failures conservatively leave it eligible for reflection.
+        }
+      }
+    } finally {
+      await fs.rm(temp, { recursive: true, force: true });
+    }
+  }
+  return ignored;
 }
 
 /**
@@ -403,7 +480,7 @@ export async function reconcileWorkingTree(
     const before = baseline.get(abs);
     if ((before?.initialSha1 ?? before?.sha1) !== current.get(abs)?.sha1) changedIgnoreRules.add(abs);
   }
-  const becameVisibleAfterIgnoreChange = (abs: string): boolean => {
+  const couldBeAffectedByIgnoreChange = (abs: string): boolean => {
     if (path.basename(abs) === ".gitignore") return false;
     for (const ignoreFile of changedIgnoreRules) {
       const dir = path.dirname(ignoreFile);
@@ -411,11 +488,15 @@ export async function reconcileWorkingTree(
     }
     return false;
   };
+  const newlyListedAfterIgnoreChange = [...current.keys()].filter(
+    (abs) => !baseline.has(abs) && couldBeAffectedByIgnoreChange(abs)
+  );
+  const ignoredBeforeTurn = await ignoredByBaselineRules(baseline, roots, newlyListedAfterIgnoreChange);
 
   for (const [abs, now] of current) {
     const before = baseline.get(abs);
     if (before && before.sha1 === now.sha1) continue; // unchanged
-    if (!before && becameVisibleAfterIgnoreChange(abs)) {
+    if (!before && ignoredBeforeTurn.has(abs)) {
       unsupported.push({ path: abs, reason: "ignore-rules-changed" });
       continue;
     }

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -187,13 +187,20 @@ export function toDisplayPath(filePath: string, cwd?: string): string {
 /**
  * Build a synthetic completed-edit `tool_call` update for a reconciled change.
  * Shaped so {@link diffBlocks} (edit/revert.ts) reads it back and the client
- * fs write-through routes it exactly like a recognized edit.
+ * fs write-through routes it exactly like a recognized edit. `turnToken`, when
+ * provided, keeps the tool-call ID unique across turns in the same session.
  */
-export function buildReconcileEditUpdate(edit: ReflectedEdit, index: number, cwd?: string): SessionUpdate {
+export function buildReconcileEditUpdate(
+  edit: ReflectedEdit,
+  index: number,
+  cwd?: string,
+  turnToken?: string
+): SessionUpdate {
   const shown = toDisplayPath(edit.path, cwd);
+  const suffix = turnToken !== undefined ? `${turnToken}-${index}` : `${index}`;
   return {
     sessionUpdate: "tool_call",
-    toolCallId: `agy-fs-reconcile-${index}`,
+    toolCallId: `agy-fs-reconcile-${suffix}`,
     name: edit.oldText === null ? "write_to_file" : "edit",
     title: `Edit ${shown}`,
     kind: "edit",

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -396,36 +396,57 @@ export async function snapshotWorkingTree(roots: string[]): Promise<WorkingTreeS
  */
 async function ignoredByBaselineRules(
   baseline: WorkingTreeSnapshot,
-  roots: string[],
   candidates: string[]
 ): Promise<Set<string>> {
   const ignored = new Set<string>();
-  for (const root of dedupeRoots(roots)) {
-    const underRoot = candidates.filter((abs) => abs.startsWith(root + path.sep));
-    if (underRoot.length === 0) continue;
+  const byRepository = new Map<string, Array<{ abs: string; canonical: string }>>();
+  for (const abs of candidates) {
     try {
-      await execFileAsync("git", ["-C", root, "rev-parse", "--is-inside-work-tree"]);
+      const canonical = path.join(await fs.realpath(path.dirname(abs)), path.basename(abs));
+      const { stdout } = await execFileAsync(
+        "git",
+        ["-C", path.dirname(abs), "rev-parse", "--show-toplevel"]
+      );
+      const repository = path.resolve(stdout.trim());
+      const existing = byRepository.get(repository);
+      const candidate = { abs, canonical };
+      if (existing) existing.push(candidate);
+      else byRepository.set(repository, [candidate]);
     } catch {
       // Non-git roots use the recursive walker, where .gitignore never changes
       // candidate visibility.
-      continue;
     }
+  }
 
+  for (const [repository, repositoryCandidates] of byRepository) {
     const temp = await fs.mkdtemp(path.join(os.tmpdir(), "agy-acp-ignore-"));
     try {
       await execFileAsync("git", ["-C", temp, "init", "-q"]);
       for (const [ignoreFile, snapshot] of baseline) {
-        if (path.basename(ignoreFile) !== ".gitignore" || !ignoreFile.startsWith(root + path.sep)) continue;
+        let canonicalIgnoreFile: string;
+        try {
+          canonicalIgnoreFile = path.join(
+            await fs.realpath(path.dirname(ignoreFile)),
+            path.basename(ignoreFile)
+          );
+        } catch {
+          continue;
+        }
+        if (
+          path.basename(ignoreFile) !== ".gitignore" ||
+          (canonicalIgnoreFile !== path.join(repository, ".gitignore") &&
+            !canonicalIgnoreFile.startsWith(repository + path.sep))
+        ) continue;
         const text = snapshot.initialText ?? snapshot.text;
         if (text == null) continue;
-        const relative = path.relative(root, ignoreFile);
+        const relative = path.relative(repository, canonicalIgnoreFile);
         const target = path.join(temp, relative);
         await fs.mkdir(path.dirname(target), { recursive: true });
         await fs.writeFile(target, text, "utf8");
       }
 
-      for (const abs of underRoot) {
-        const relative = path.relative(root, abs);
+      for (const { abs, canonical } of repositoryCandidates) {
+        const relative = path.relative(repository, canonical);
         try {
           await execFileAsync("git", ["-C", temp, "check-ignore", "-q", "--no-index", "--", relative]);
           ignored.add(abs);
@@ -491,7 +512,7 @@ export async function reconcileWorkingTree(
   const newlyListedAfterIgnoreChange = [...current.keys()].filter(
     (abs) => !baseline.has(abs) && couldBeAffectedByIgnoreChange(abs)
   );
-  const ignoredBeforeTurn = await ignoredByBaselineRules(baseline, roots, newlyListedAfterIgnoreChange);
+  const ignoredBeforeTurn = await ignoredByBaselineRules(baseline, newlyListedAfterIgnoreChange);
 
   for (const [abs, now] of current) {
     const before = baseline.get(abs);

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -362,6 +362,21 @@ export async function snapshotWorkingTree(rootPaths: string[]): Promise<WorkingT
   return { roots, files, excluded };
 }
 
+export interface ReportedContent {
+  path: string;
+  /**
+   * Content the reported update accounts for on this path: a full body, or the
+   * snippets it inserted. Disk is recorded only while it still holds all of
+   * them — divergence means a later change landed before the tool-call was
+   * polled, so the current bytes were never reported and reconciliation must
+   * still emit them. (This is the same attribution test the write-through and
+   * revert paths apply.) Omit it to record disk unconditionally, which only a
+   * caller that knows the client has the current state may do — a completed
+   * local revert.
+   */
+  reportedTexts?: string[];
+}
+
 /**
  * Record the current on-disk content of paths whose change has *already* been
  * reported to the client (a recognized structured edit, or a synthetic one this
@@ -371,17 +386,25 @@ export async function snapshotWorkingTree(rootPaths: string[]): Promise<WorkingT
  * reverted. Paths outside the configured roots are ignored, which keeps the
  * snapshot to files this workspace is responsible for.
  */
-export async function observeEditedPaths(snapshot: WorkingTreeSnapshot, paths: string[]): Promise<void> {
-  for (const filePath of paths) {
+export async function observeEditedPaths(
+  snapshot: WorkingTreeSnapshot,
+  reported: ReportedContent[]
+): Promise<void> {
+  for (const { path: filePath, reportedTexts } of reported) {
     const abs = path.resolve(filePath);
     const record = await readFileRecord(abs);
     const canonicalPath = record?.canonicalPath ?? (await canonicalizeMissing(abs));
     if (!rootFor(canonicalPath, snapshot.roots)) continue;
     if (!record) {
-      // The reported edit removed the file (a reverted creation, a delete).
-      // Forgetting it keeps a later recreation reportable as a creation.
-      snapshot.files.delete(canonicalPath);
+      // Nothing on disk. Only a caller that knows the client has the current
+      // state (a reverted creation) may forget the entry; otherwise something
+      // else removed the file and that deletion still has to be reported.
+      if (reportedTexts === undefined) snapshot.files.delete(canonicalPath);
       continue;
+    }
+    if (reportedTexts !== undefined) {
+      const text = record.text;
+      if (text === null || !reportedTexts.every((reported) => text.includes(reported))) continue;
     }
     const retained = snapshot.files.get(canonicalPath)?.path
       ?? displayPathFor(canonicalPath, snapshot.roots)

--- a/src/agy/edit/reconcile.ts
+++ b/src/agy/edit/reconcile.ts
@@ -362,19 +362,58 @@ export async function snapshotWorkingTree(rootPaths: string[]): Promise<WorkingT
   return { roots, files, excluded };
 }
 
+export interface ReportedBlock {
+  /** Text the block replaced, or null when it reported a whole file body. */
+  oldText: string | null;
+  newText: string;
+}
+
 export interface ReportedContent {
   path: string;
   /**
-   * Content the reported update accounts for on this path: a full body, or the
-   * snippets it inserted. Disk is recorded only while it still holds all of
-   * them — divergence means a later change landed before the tool-call was
-   * polled, so the current bytes were never reported and reconciliation must
-   * still emit them. (This is the same attribution test the write-through and
-   * revert paths apply.) Omit it to record disk unconditionally, which only a
-   * caller that knows the client has the current state may do — a completed
-   * local revert.
+   * The diff blocks the update reported for this path. Disk is recorded only
+   * when they account for every difference from the content already recorded;
+   * otherwise a change reached the file before the tool-call was polled, the
+   * current bytes were never reported, and reconciliation must still emit them.
+   * Omit to record disk unconditionally, which only a caller that knows the
+   * client has the current state may do — a completed local revert.
    */
-  reportedTexts?: string[];
+  blocks?: ReportedBlock[];
+  /** True when `blocks` carry the whole file body (a `write_to_file` call). */
+  wholeFile?: boolean;
+}
+
+/**
+ * True when the reported blocks account for every difference between the
+ * content already recorded for a path and what is on disk now.
+ *
+ * A whole-file write reports the entire body, so equality settles it. A
+ * targeted replacement is checked by applying each reported replacement to
+ * every occurrence of its target: reproducing disk exactly proves nothing
+ * unreported reached the file, while any other outcome fails closed, so a later
+ * edit to a different part of the file is reported as an unstructured change
+ * instead of being absorbed. This never *derives* recorded content — it only
+ * decides whether the bytes on disk were reported — so failing costs one extra,
+ * accurate synthetic edit rather than a lost or invented one.
+ */
+function reportedAccountsForDisk(
+  recorded: string | null | undefined,
+  blocks: ReportedBlock[],
+  wholeFile: boolean,
+  disk: string
+): boolean {
+  if (blocks.length === 0) return false;
+  if (wholeFile || blocks.some((block) => block.oldText === null)) {
+    return blocks.some((block) => block.newText === disk);
+  }
+  if (recorded == null) return false;
+  let expected = recorded;
+  for (const { oldText, newText } of blocks) {
+    // An empty target matches everywhere and would accept any file.
+    if (oldText === null || oldText === "" || !expected.includes(oldText)) return false;
+    expected = expected.split(oldText).join(newText);
+  }
+  return expected === disk;
 }
 
 /**
@@ -390,25 +429,24 @@ export async function observeEditedPaths(
   snapshot: WorkingTreeSnapshot,
   reported: ReportedContent[]
 ): Promise<void> {
-  for (const { path: filePath, reportedTexts } of reported) {
+  for (const { path: filePath, blocks, wholeFile } of reported) {
     const abs = path.resolve(filePath);
     const record = await readFileRecord(abs);
     const canonicalPath = record?.canonicalPath ?? (await canonicalizeMissing(abs));
     if (!rootFor(canonicalPath, snapshot.roots)) continue;
+    const existing = snapshot.files.get(canonicalPath);
     if (!record) {
       // Nothing on disk. Only a caller that knows the client has the current
       // state (a reverted creation) may forget the entry; otherwise something
       // else removed the file and that deletion still has to be reported.
-      if (reportedTexts === undefined) snapshot.files.delete(canonicalPath);
+      if (blocks === undefined) snapshot.files.delete(canonicalPath);
       continue;
     }
-    if (reportedTexts !== undefined) {
-      const text = record.text;
-      if (text === null || !reportedTexts.every((reported) => text.includes(reported))) continue;
+    if (blocks !== undefined) {
+      if (record.text === null) continue;
+      if (!reportedAccountsForDisk(existing?.text, blocks, wholeFile === true, record.text)) continue;
     }
-    const retained = snapshot.files.get(canonicalPath)?.path
-      ?? displayPathFor(canonicalPath, snapshot.roots)
-      ?? abs;
+    const retained = existing?.path ?? displayPathFor(canonicalPath, snapshot.roots) ?? abs;
     snapshot.files.set(canonicalPath, { ...record, path: retained });
   }
 }

--- a/src/agy/edit/revert.ts
+++ b/src/agy/edit/revert.ts
@@ -10,6 +10,11 @@ export interface DiffBlock {
   path: string;
   oldText: string | null;
   newText: string;
+  /**
+   * 1-based start line of the targeted occurrence when the translator knew it
+   * (agy `StartLine` on replace chunks). Used to disambiguate repeated snippets.
+   */
+  line?: number;
 }
 
 export function diffBlocks(toolCall: SessionUpdate): DiffBlock[] {
@@ -24,7 +29,10 @@ export function diffBlocks(toolCall: SessionUpdate): DiffBlock[] {
     const newText = typeof block.newText === "string" ? block.newText : null;
     if (!path || newText === null) continue;
     const oldText = typeof block.oldText === "string" ? block.oldText : null;
-    blocks.push({ path, oldText, newText });
+    const line = typeof block.line === "number" && Number.isFinite(block.line) && block.line >= 1
+      ? Math.floor(block.line)
+      : undefined;
+    blocks.push({ path, oldText, newText, ...(line !== undefined ? { line } : {}) });
   }
   return blocks;
 }

--- a/src/agy/edit/revert.ts
+++ b/src/agy/edit/revert.ts
@@ -10,11 +10,6 @@ export interface DiffBlock {
   path: string;
   oldText: string | null;
   newText: string;
-  /**
-   * 1-based start line of the targeted occurrence when the translator knew it
-   * (agy `StartLine` on replace chunks). Used to disambiguate repeated snippets.
-   */
-  line?: number;
 }
 
 export function diffBlocks(toolCall: SessionUpdate): DiffBlock[] {
@@ -29,10 +24,7 @@ export function diffBlocks(toolCall: SessionUpdate): DiffBlock[] {
     const newText = typeof block.newText === "string" ? block.newText : null;
     if (!path || newText === null) continue;
     const oldText = typeof block.oldText === "string" ? block.oldText : null;
-    const line = typeof block.line === "number" && Number.isFinite(block.line) && block.line >= 1
-      ? Math.floor(block.line)
-      : undefined;
-    blocks.push({ path, oldText, newText, ...(line !== undefined ? { line } : {}) });
+    blocks.push({ path, oldText, newText });
   }
   return blocks;
 }

--- a/src/agy/edit/revert.ts
+++ b/src/agy/edit/revert.ts
@@ -34,8 +34,12 @@ export function diffBlocks(toolCall: SessionUpdate): DiffBlock[] {
  * block. Only acts when the file's current content still matches what the
  * edit wrote — if it has diverged further (a later edit landed on top), the
  * block is left alone rather than guessing.
+ *
+ * Returns the paths actually restored, so callers can tell a real undo apart
+ * from a diverged block they must keep reporting.
  */
-export function revertEditToolCall(toolCall: SessionUpdate): void {
+export function revertEditToolCall(toolCall: SessionUpdate): string[] {
+  const restored: string[] = [];
   for (const { path, oldText, newText } of diffBlocks(toolCall)) {
     const current = existsSync(path) ? readFileSync(path, "utf8") : null;
     if (current === null) continue;
@@ -43,14 +47,20 @@ export function revertEditToolCall(toolCall: SessionUpdate): void {
     if (oldText === null) {
       // This block created the file; only remove it if nothing else touched
       // it since.
-      if (current === newText) rmSync(path);
+      if (current === newText) {
+        rmSync(path);
+        restored.push(path);
+      }
       continue;
     }
 
     if (current === newText) {
       writeFileSync(path, oldText, "utf8");
+      restored.push(path);
     } else if (current.includes(newText)) {
       writeFileSync(path, current.replace(newText, oldText), "utf8");
+      restored.push(path);
     }
   }
+  return restored;
 }

--- a/src/agy/edit/revert.ts
+++ b/src/agy/edit/revert.ts
@@ -35,12 +35,15 @@ export function diffBlocks(toolCall: SessionUpdate): DiffBlock[] {
  * edit wrote — if it has diverged further (a later edit landed on top), the
  * block is left alone rather than guessing.
  *
- * Returns the paths actually restored, so callers can tell a real undo apart
- * from a diverged block they must keep reporting.
+ * Returns the blocks actually restored, so callers can attribute exactly the
+ * restoration that happened: a diverged block that was declined still holds
+ * content the client has not seen, and a restored block says nothing about
+ * the rest of its file.
  */
-export function revertEditToolCall(toolCall: SessionUpdate): string[] {
-  const restored: string[] = [];
-  for (const { path, oldText, newText } of diffBlocks(toolCall)) {
+export function revertEditToolCall(toolCall: SessionUpdate): DiffBlock[] {
+  const restored: DiffBlock[] = [];
+  for (const block of diffBlocks(toolCall)) {
+    const { path, oldText, newText } = block;
     const current = existsSync(path) ? readFileSync(path, "utf8") : null;
     if (current === null) continue;
 
@@ -49,17 +52,17 @@ export function revertEditToolCall(toolCall: SessionUpdate): string[] {
       // it since.
       if (current === newText) {
         rmSync(path);
-        restored.push(path);
+        restored.push(block);
       }
       continue;
     }
 
     if (current === newText) {
       writeFileSync(path, oldText, "utf8");
-      restored.push(path);
+      restored.push(block);
     } else if (current.includes(newText)) {
       writeFileSync(path, current.replace(newText, oldText), "utf8");
-      restored.push(path);
+      restored.push(block);
     }
   }
   return restored;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -980,6 +980,72 @@ describe("permission bridge", () => {
     fs.rmSync(conversations, { recursive: true, force: true });
   });
 
+  it("reports an unrelated change that survives a rejected edit's revert", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const conversations = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-conv-"));
+    const targetFile = path.join(dir, "a.txt");
+    fs.writeFileSync(targetFile, "alpha\nOLD\nomega\n", "utf8");
+    const rawInputJson = JSON.stringify({
+      TargetFile: targetFile,
+      TargetContent: "OLD",
+      ReplacementContent: "NEW"
+    });
+    const pty = new FakePty(() => {
+      // agy applied the snippet replacement, then a formatter rewrote another
+      // section before the tool-call was polled.
+      fs.writeFileSync(targetFile, "alpha\nNEW\nomega\n", "utf8");
+      fs.writeFileSync(targetFile, "ALPHA\nNEW\nomega\n", "utf8");
+      const db = createConversationDb(conversations, "reject-keeps-shell-change");
+      insertStep(db, {
+        idx: 1,
+        stepType: 5,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({ callId: "edit-1", namePrimary: "replace_file_content", rawInputJson })
+          })
+        })
+      });
+      db.close();
+    });
+    const session = new AgyCliSession(
+      {
+        ...defaultConfig(),
+        cwd: dir,
+        conversationsDir: conversations,
+        interactivePermissions: true,
+        printTimeout: "3s"
+      },
+      undefined,
+      { spawn: () => { pty.start(); return pty; } } as PtyFactory
+    );
+    const updates: SessionUpdate[] = [];
+    const result = session.prompt("edit it", async (update) => { updates.push(update); }, async () => {
+      const db = new (await import("better-sqlite3")).default(path.join(conversations, "reject-keeps-shell-change.db"));
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 0);
+      return "reject-once";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    // The revert restored only the reported snippet; the formatter's change
+    // survived and must still be reported, not folded into the rejection.
+    expect(fs.readFileSync(targetFile, "utf8")).toBe("ALPHA\nOLD\nomega\n");
+    const reconciled = updates.filter((update) =>
+      String((update as unknown as { toolCallId?: string }).toolCallId).startsWith("agy-fs-reconcile")
+    );
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]).toMatchObject({
+      kind: "edit",
+      status: "completed",
+      content: [{ type: "diff", path: targetFile, oldText: "alpha\nOLD\nomega\n", newText: "ALPHA\nOLD\nomega\n" }]
+    });
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(conversations, { recursive: true, force: true });
+  });
+
   it("leaves an already-applied edit in place when the client keeps it", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const targetFile = path.join(dir, "target.txt");

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -914,6 +914,72 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("reports the surviving content when a rejected edit's revert cannot restore it", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const conversations = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-conv-"));
+    const targetFile = path.join(dir, "a.txt");
+    fs.writeFileSync(targetFile, "before", "utf8");
+    const rawInputJson = JSON.stringify({
+      TargetFile: targetFile,
+      TargetContent: "before",
+      ReplacementContent: "structured"
+    });
+    const pty = new FakePty(() => {
+      // agy applied the structured edit, then a shell command overwrote it, so
+      // the revert has nothing it can safely restore.
+      fs.writeFileSync(targetFile, "structured", "utf8");
+      fs.writeFileSync(targetFile, "shell final", "utf8");
+      const db = createConversationDb(conversations, "diverged-reject");
+      insertStep(db, {
+        idx: 1,
+        stepType: 5,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({ callId: "edit-1", namePrimary: "replace_file_content", rawInputJson })
+          })
+        })
+      });
+      db.close();
+    });
+    const session = new AgyCliSession(
+      {
+        ...defaultConfig(),
+        cwd: dir,
+        conversationsDir: conversations,
+        interactivePermissions: true,
+        printTimeout: "3s"
+      },
+      undefined,
+      { spawn: () => { pty.start(); return pty; } } as PtyFactory
+    );
+    const updates: SessionUpdate[] = [];
+    const result = session.prompt("edit it", async (update) => { updates.push(update); }, async () => {
+      const db = new (await import("better-sqlite3")).default(path.join(conversations, "diverged-reject.db"));
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 0);
+      return "reject-once";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    // Rejecting could not undo the diverged file, so its surviving content is
+    // reported instead of being suppressed as already reflected.
+    const reconciled = updates.filter((update) =>
+      String((update as unknown as { toolCallId?: string }).toolCallId).startsWith("agy-fs-reconcile")
+    );
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]).toMatchObject({
+      kind: "edit",
+      status: "completed",
+      content: [{ type: "diff", path: targetFile, oldText: "before", newText: "shell final" }]
+    });
+    expect(fs.readFileSync(targetFile, "utf8")).toBe("shell final");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(conversations, { recursive: true, force: true });
+  });
+
   it("leaves an already-applied edit in place when the client keeps it", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const targetFile = path.join(dir, "target.txt");

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1273,6 +1273,56 @@ describe("prompt", () => {
     expect(fake.stdinEnded).toBe(true);
   });
 
+  it("awaits print-mode reconciled filesystem write-through before ending the turn", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-print-reconcile-"));
+    try {
+      const file = path.join(dir, "a.txt");
+      fs.writeFileSync(file, "before", "utf8");
+
+      let releaseWrite!: () => void;
+      const writeGate = new Promise<void>((resolve) => { releaseWrite = resolve; });
+      let markWriteStarted!: () => void;
+      const writeStarted = new Promise<void>((resolve) => { markWriteStarted = resolve; });
+      const updates: SessionUpdate[] = [];
+      const session = new AgyCliSession(
+        { ...defaultConfig(), cwd: dir, conversationsDir: path.join(dir, "conversations") },
+        (command, args, options) => {
+          fs.writeFileSync(file, "after", "utf8");
+          return new FakeProcess([]).spawnFactory([])(command, args, options);
+        }
+      );
+
+      let settled = false;
+      const prompt = session.prompt(
+        "edit it",
+        async (update) => { updates.push(update); },
+        undefined,
+        {
+          readTextFile: async () => {},
+          writeTextFile: async (target, content) => {
+            expect(fs.readFileSync(target, "utf8")).toBe("before");
+            markWriteStarted();
+            await writeGate;
+            fs.writeFileSync(target, content, "utf8");
+          }
+        }
+      ).finally(() => { settled = true; });
+
+      await writeStarted;
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+      expect(fs.readFileSync(file, "utf8")).toBe("before");
+
+      releaseWrite();
+      await expect(prompt).resolves.toEqual({ stopReason: "end_turn" });
+      expect(fs.readFileSync(file, "utf8")).toBe("after");
+      expect(updates).toHaveLength(1);
+      expect(updates[0]).toMatchObject({ kind: "edit", status: "completed" });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("can write prompt through stdin", async () => {
     const fake = new FakeProcess(["ok"]);
     const calls: SpawnCall[] = [];

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1366,11 +1366,16 @@ describe("prompt", () => {
 
 describe("cancel", () => {
   it("sends SIGINT (not SIGTERM) so agy can flush its conversation database", async () => {
+    const calls: SpawnCall[] = [];
     const fake = new FakeProcess([], { blockStdout: true, exitCode: null });
-    const session = new AgyCliSession(defaultConfig(), fake.spawnFactory([]));
+    const session = new AgyCliSession(defaultConfig(), fake.spawnFactory(calls));
     const pending = collectUpdates(session, "hello");
 
-    await new Promise((resolve) => setImmediate(resolve));
+    // Print-mode turns snapshot the working tree before spawn; wait until the
+    // child exists so cancel has a process to signal.
+    await vi.waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
     await session.cancel();
 
     expect(fake.killedWith).toBe("SIGINT");

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1323,6 +1323,59 @@ describe("prompt", () => {
     }
   });
 
+  it("does not re-emit a structured edit whose reported text no longer matches the pre-turn file", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-structured-reconcile-"));
+    const conversations = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-structured-conv-"));
+    try {
+      const file = path.join(dir, "a.txt");
+      fs.writeFileSync(file, "before", "utf8");
+      const rawInputJson = JSON.stringify({
+        TargetFile: file,
+        TargetContent: "shell",
+        ReplacementContent: "final"
+      });
+      const updates: SessionUpdate[] = [];
+      const session = new AgyCliSession(
+        { ...defaultConfig(), cwd: dir, conversationsDir: conversations },
+        (command, args, options) => {
+          // A shell command edited the file first, so the structured replace's
+          // reported oldText ("shell") never existed in the pre-turn file.
+          fs.writeFileSync(file, "shell", "utf8");
+          fs.writeFileSync(file, "final", "utf8");
+          const db = createConversationDb(conversations, "structured-reconcile");
+          insertStep(db, {
+            idx: 1,
+            stepType: 5,
+            status: 3,
+            stepPayload: encodeStepPayload({
+              toolRun: encodeToolRun({
+                call: encodeToolCall({ callId: "edit-1", namePrimary: "replace_file_content", rawInputJson })
+              })
+            })
+          });
+          db.close();
+          return new FakeProcess([]).spawnFactory([])(command, args, options);
+        }
+      );
+
+      const outcome = await session.prompt("edit it", async (update) => { updates.push(update); });
+
+      expect(outcome).toEqual({ stopReason: "end_turn" });
+      // The structured edit alone: reconciliation must not add a second,
+      // contradictory before→final edit for the same file.
+      expect(updates).toHaveLength(1);
+      expect(updates[0]).toMatchObject({ kind: "edit", status: "completed" });
+      const reconciled = updates.filter((update) =>
+        String((update as unknown as { toolCallId?: string }).toolCallId).startsWith("agy-fs-reconcile")
+      );
+      expect(reconciled).toEqual([]);
+      expect(fs.readFileSync(file, "utf8")).toBe("final");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(conversations, { recursive: true, force: true });
+    }
+  });
+
   it("can write prompt through stdin", async () => {
     const fake = new FakeProcess(["ok"]);
     const calls: SpawnCall[] = [];

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1389,17 +1389,13 @@ describe("prompt", () => {
     }
   });
 
-  it("does not re-emit a structured edit whose reported text no longer matches the pre-turn file", async () => {
+  it("does not re-emit a whole-file write whose reported oldText never existed pre-turn", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-structured-reconcile-"));
     const conversations = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-structured-conv-"));
     try {
       const file = path.join(dir, "a.txt");
       fs.writeFileSync(file, "before", "utf8");
-      const rawInputJson = JSON.stringify({
-        TargetFile: file,
-        TargetContent: "shell",
-        ReplacementContent: "final"
-      });
+      const rawInputJson = JSON.stringify({ TargetFile: file, CodeContent: "final" });
       const updates: SessionUpdate[] = [];
       const session = new AgyCliSession(
         { ...defaultConfig(), cwd: dir, conversationsDir: conversations },

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2487,6 +2487,78 @@ describe("StreamPoller", () => {
     db.close();
   });
 
+  it("preserves full-write oldText across pending completion and historical rereads", () => {
+    const db = createConversationDb(dir, "conv-poll-write-history");
+    const firstWrite = encodeStepPayload({
+      toolRun: encodeToolRun({
+        call: encodeToolCall({
+          callId: "write-a",
+          namePrimary: "write_to_file",
+          rawInputJson: JSON.stringify({ TargetFile: "/repo/a.txt", CodeContent: "A" })
+        })
+      })
+    });
+    insertStep(db, { idx: 1, stepType: 5, status: 9, stepPayload: firstWrite });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-poll-write-history",
+      baseStepIdx: -1,
+      skipNarration: false,
+      cwd: "/repo",
+      snapshot: null
+    });
+
+    const pending = poller.poll() as Array<{ status?: string; content?: Array<Record<string, unknown>> }>;
+    expect(pending[0]).toMatchObject({ status: "pending" });
+    expect(pending[0]?.content?.[0]).toMatchObject({ oldText: null, newText: "A" });
+
+    updateStep(db, 1, { status: 3, stepPayload: firstWrite });
+    const completed = poller.poll() as Array<{ status?: string; content?: Array<Record<string, unknown>> }>;
+    expect(completed[0]).toMatchObject({ status: "completed" });
+    expect(completed[0]?.content?.[0]).toMatchObject({ oldText: null, newText: "A" });
+
+    insertStep(db, {
+      idx: 2,
+      stepType: 5,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({
+            callId: "write-b",
+            namePrimary: "write_to_file",
+            rawInputJson: JSON.stringify({ TargetFile: "/repo/a.txt", CodeContent: "B" })
+          })
+        })
+      })
+    });
+    const secondWrite = poller.poll() as Array<{
+      toolCallId?: string;
+      content?: Array<Record<string, unknown>>;
+    }>;
+    expect(secondWrite).toHaveLength(1);
+    expect(secondWrite[0]).toMatchObject({ toolCallId: "write-b" });
+    expect(secondWrite[0]?.content?.[0]).toMatchObject({ oldText: "A", newText: "B" });
+
+    // A later unrelated row makes StreamPoller translate rows 1-3 again. The
+    // completed writes must derive the same snapshots and remain deduplicated.
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({ agentText: "done" })
+    });
+    expect(poller.poll()).toEqual([
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "3",
+        content: { type: "text", text: "done" }
+      }
+    ]);
+
+    poller.close();
+    db.close();
+  });
+
   it("increments revision for auxiliary-column-only mutations", () => {
     const db = createConversationDb(dir, "conv-poll-permission");
     insertStep(db, {

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -168,6 +168,63 @@ describe("reconcileWorkingTree", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("does not invent a creation when removing an ignore rule exposes an existing file", async () => {
+    const dir = gitRepo();
+    const ignoreFile = path.join(dir, ".gitignore");
+    const ignoredFile = path.join(dir, "ignored.txt");
+    fs.writeFileSync(ignoreFile, "ignored.txt\n", "utf8");
+    fs.writeFileSync(ignoredFile, "pre-existing", "utf8");
+    execFileSync("git", ["-C", dir, "add", ".gitignore"]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    expect(baseline.has(ignoredFile)).toBe(false);
+    fs.writeFileSync(ignoreFile, "", "utf8");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    expect(reflected).toEqual([{ path: ignoreFile, oldText: "ignored.txt\n", newText: "" }]);
+    expect(unsupported).toEqual([{ path: ignoredFile, reason: "ignore-rules-changed" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("retains ignore-change detection after a structured edit advances the baseline", async () => {
+    const dir = gitRepo();
+    const ignoreFile = path.join(dir, ".gitignore");
+    const ignoredFile = path.join(dir, "ignored.txt");
+    fs.writeFileSync(ignoreFile, "ignored.txt\n", "utf8");
+    fs.writeFileSync(ignoredFile, "pre-existing", "utf8");
+    execFileSync("git", ["-C", dir, "add", ".gitignore"]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    applyDiffBlockToSnapshot(baseline, ignoreFile, "ignored.txt\n", "");
+    fs.writeFileSync(ignoreFile, "", "utf8");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([{ path: ignoredFile, reason: "ignore-rules-changed" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not report a baseline file as deleted when a new ignore rule hides it", async () => {
+    const dir = gitRepo();
+    const ignoreFile = path.join(dir, ".gitignore");
+    const file = path.join(dir, "later-ignored.txt");
+    fs.writeFileSync(ignoreFile, "", "utf8");
+    fs.writeFileSync(file, "unchanged", "utf8");
+    execFileSync("git", ["-C", dir, "add", ".gitignore"]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    expect(baseline.has(file)).toBe(true);
+    fs.writeFileSync(ignoreFile, "later-ignored.txt\n", "utf8");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    expect(reflected).toEqual([{ path: ignoreFile, oldText: "", newText: "later-ignored.txt\n" }]);
+    expect(unsupported).toEqual([]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("reports a binary change as unsupported instead of diffing it", async () => {
     const dir = gitRepo();
     const baseline = await snapshotWorkingTree([dir]);
@@ -240,6 +297,24 @@ describe("reconcileWorkingTree", () => {
     expect(snap!.text).toBeNull();
     expect(snap!.size).toBe(MAX_TEXT_BYTES + 1);
     expect(snap!.sha1.startsWith("oversized:")).toBe(true);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("detects an oversized same-size replacement even when mtime is preserved", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "huge.bin");
+    fs.writeFileSync(file, Buffer.alloc(MAX_TEXT_BYTES + 1, 1));
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    const originalTimes = fs.statSync(file);
+    fs.writeFileSync(file, Buffer.alloc(MAX_TEXT_BYTES + 1, 2));
+    fs.utimesSync(file, originalTimes.atime, originalTimes.mtime);
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([{ path: file, reason: "oversized" }]);
 
     fs.rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from "vitest";
 import {
   MAX_TEXT_BYTES,
   buildReconcileEditUpdate,
+  isValidUtf8,
   reconcileWorkingTree,
+  refreshSnapshotPath,
   snapshotWorkingTree
 } from "../src/agy/edit/reconcile.js";
 import { diffBlocks } from "../src/agy/edit/revert.js";
@@ -33,7 +35,7 @@ describe("reconcileWorkingTree", () => {
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(file, "after", "utf8");
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir], []);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
     expect(unsupported).toEqual([]);
     expect(reflected).toEqual([{ path: file, oldText: "before", newText: "after" }]);
 
@@ -46,23 +48,45 @@ describe("reconcileWorkingTree", () => {
     const file = path.join(dir, "new.txt");
     fs.writeFileSync(file, "created", "utf8");
 
-    const { reflected } = await reconcileWorkingTree(baseline, [dir], []);
+    const { reflected } = await reconcileWorkingTree(baseline, [dir]);
     expect(reflected).toEqual([{ path: file, oldText: null, newText: "created" }]);
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("skips a path already reflected by a recognized edit", async () => {
+  it("does not re-emit a path after the baseline is advanced past a recognized edit", async () => {
     const dir = gitRepo();
     const file = path.join(dir, "a.txt");
     fs.writeFileSync(file, "before", "utf8");
     execFileSync("git", ["-C", dir, "add", "."]);
 
     const baseline = await snapshotWorkingTree([dir]);
-    fs.writeFileSync(file, "after", "utf8");
+    fs.writeFileSync(file, "after-structured", "utf8");
+    // Simulate a recognized edit landing: advance baseline to post-edit content.
+    await refreshSnapshotPath(baseline, file);
 
-    const { reflected } = await reconcileWorkingTree(baseline, [dir], [file]);
+    const { reflected } = await reconcileWorkingTree(baseline, [dir]);
     expect(reflected).toEqual([]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("still reflects a later unstructured change after a recognized edit on the same path", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    // Structured edit lands first.
+    fs.writeFileSync(file, "mid", "utf8");
+    await refreshSnapshotPath(baseline, file);
+    // Then a shell / unrecognized edit further changes the same file.
+    fs.writeFileSync(file, "final", "utf8");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    expect(unsupported).toEqual([]);
+    expect(reflected).toEqual([{ path: file, oldText: "mid", newText: "final" }]);
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -75,7 +99,7 @@ describe("reconcileWorkingTree", () => {
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(path.join(dir, "ignored.txt"), "secret", "utf8");
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir], []);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
     expect(reflected).toEqual([]);
     expect(unsupported).toEqual([]);
 
@@ -88,7 +112,39 @@ describe("reconcileWorkingTree", () => {
     const file = path.join(dir, "blob.bin");
     fs.writeFileSync(file, Buffer.from([0x00, 0x01, 0x02, 0x00]));
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir], []);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([{ path: file, reason: "binary" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reports invalid UTF-8 (NUL-free) as binary, not as text", async () => {
+    const dir = gitRepo();
+    const baseline = await snapshotWorkingTree([dir]);
+    const file = path.join(dir, "bad.bin");
+    // Lone 0xff is not valid UTF-8 and has no NUL — previously misclassified as text.
+    fs.writeFileSync(file, Buffer.from([0xff]));
+
+    expect(isValidUtf8(Buffer.from([0xff]))).toBe(false);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([{ path: file, reason: "binary" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reports a binary-to-text replacement as unsupported, not as a create", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "blob.bin");
+    fs.writeFileSync(file, Buffer.from([0x00, 0x01]));
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    expect(baseline.get(file)?.text).toBeNull();
+    fs.writeFileSync(file, "now text", "utf8");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
     expect(reflected).toEqual([]);
     expect(unsupported).toEqual([{ path: file, reason: "binary" }]);
 
@@ -101,9 +157,27 @@ describe("reconcileWorkingTree", () => {
     const file = path.join(dir, "big.txt");
     fs.writeFileSync(file, "a".repeat(MAX_TEXT_BYTES + 1), "utf8");
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir], []);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
     expect(reflected).toEqual([]);
     expect(unsupported).toEqual([{ path: file, reason: "oversized" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not buffer an oversized baseline file into memory as text", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "huge.bin");
+    // Write just over the limit; snapshot must record size+null text without
+    // treating it as routable text content.
+    fs.writeFileSync(file, Buffer.alloc(MAX_TEXT_BYTES + 1, 1));
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    const snap = baseline.get(file);
+    expect(snap).toBeDefined();
+    expect(snap!.text).toBeNull();
+    expect(snap!.size).toBe(MAX_TEXT_BYTES + 1);
+    expect(snap!.sha1.startsWith("oversized:")).toBe(true);
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -117,7 +191,7 @@ describe("reconcileWorkingTree", () => {
     const baseline = await snapshotWorkingTree([dir]);
     fs.rmSync(file);
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir], []);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
     expect(reflected).toEqual([]);
     expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
 
@@ -130,7 +204,7 @@ describe("reconcileWorkingTree", () => {
     execFileSync("git", ["-C", dir, "add", "."]);
 
     const baseline = await snapshotWorkingTree([dir]);
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir], []);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
     expect(reflected).toEqual([]);
     expect(unsupported).toEqual([]);
 
@@ -147,10 +221,51 @@ describe("reconcileWorkingTree", () => {
     // A change under node_modules must be skipped by the walk.
     fs.writeFileSync(path.join(dir, "node_modules", "dep.js"), "changed", "utf8");
 
-    const { reflected } = await reconcileWorkingTree(baseline, [dir], []);
+    const { reflected } = await reconcileWorkingTree(baseline, [dir]);
     expect(reflected).toEqual([{ path: path.join(dir, "src.txt"), oldText: null, newText: "hello" }]);
 
     fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("recurses into a checked-out git submodule", async () => {
+    const root = tmpDir();
+    const subSrc = path.join(root, "sub-src");
+    const parent = path.join(root, "parent");
+    fs.mkdirSync(subSrc);
+    fs.mkdirSync(parent);
+
+    execFileSync("git", ["-C", subSrc, "init", "-q"]);
+    execFileSync("git", ["-C", subSrc, "config", "user.email", "t@t"]);
+    execFileSync("git", ["-C", subSrc, "config", "user.name", "t"]);
+    fs.writeFileSync(path.join(subSrc, "inside.txt"), "sub-before", "utf8");
+    execFileSync("git", ["-C", subSrc, "add", "."]);
+    execFileSync("git", ["-C", subSrc, "commit", "-qm", "sub"]);
+
+    execFileSync("git", ["-C", parent, "init", "-q"]);
+    execFileSync("git", ["-C", parent, "config", "user.email", "t@t"]);
+    execFileSync("git", ["-C", parent, "config", "user.name", "t"]);
+    fs.writeFileSync(path.join(parent, "root.txt"), "root", "utf8");
+    execFileSync("git", ["-C", parent, "add", "."]);
+    execFileSync("git", ["-C", parent, "commit", "-qm", "root"]);
+    // protocol.file.allow must be on the invoking process (-c), not only the
+    // repo config — submodule add clones via the file transport.
+    execFileSync("git", [
+      "-C", parent,
+      "-c", "protocol.file.allow=always",
+      "submodule", "add", subSrc, "vendor"
+    ]);
+    execFileSync("git", ["-C", parent, "commit", "-qm", "add vendor"]);
+
+    const inside = path.join(parent, "vendor", "inside.txt");
+    const baseline = await snapshotWorkingTree([parent]);
+    expect(baseline.has(inside)).toBe(true);
+
+    fs.writeFileSync(inside, "sub-after", "utf8");
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [parent]);
+    expect(unsupported).toEqual([]);
+    expect(reflected).toEqual([{ path: inside, oldText: "sub-before", newText: "sub-after" }]);
+
+    fs.rmSync(root, { recursive: true, force: true });
   });
 });
 

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -848,6 +848,46 @@ describe("reconcileWorkingTree", () => {
 
     fs.rmSync(root, { recursive: true, force: true });
   });
+
+  it("does not recurse into a deinitialized submodule", async () => {
+    // A deinitialized submodule's gitlink remains as an empty directory where
+    // git discovers the *parent* repository and lists the gitlink itself as
+    // "./" — recursing into it would repeat the same listing forever and the
+    // snapshot would never complete.
+    const root = tmpDir();
+    const subSrc = path.join(root, "sub-src");
+    const parent = path.join(root, "parent");
+    fs.mkdirSync(subSrc);
+    fs.mkdirSync(parent);
+
+    execFileSync("git", ["-C", subSrc, "init", "-q"]);
+    execFileSync("git", ["-C", subSrc, "config", "user.email", "t@t"]);
+    execFileSync("git", ["-C", subSrc, "config", "user.name", "t"]);
+    fs.writeFileSync(path.join(subSrc, "inside.txt"), "sub", "utf8");
+    execFileSync("git", ["-C", subSrc, "add", "."]);
+    execFileSync("git", ["-C", subSrc, "commit", "-qm", "sub"]);
+
+    execFileSync("git", ["-C", parent, "init", "-q"]);
+    execFileSync("git", ["-C", parent, "config", "user.email", "t@t"]);
+    execFileSync("git", ["-C", parent, "config", "user.name", "t"]);
+    fs.writeFileSync(path.join(parent, "root.txt"), "root", "utf8");
+    execFileSync("git", ["-C", parent, "add", "."]);
+    execFileSync("git", ["-C", parent, "commit", "-qm", "root"]);
+    execFileSync("git", [
+      "-C", parent,
+      "-c", "protocol.file.allow=always",
+      "submodule", "add", subSrc, "vendor"
+    ]);
+    execFileSync("git", ["-C", parent, "commit", "-qm", "add vendor"]);
+    execFileSync("git", ["-C", parent, "submodule", "deinit", "-f", "vendor"]);
+
+    const baseline = await snapshotWorkingTree([parent]);
+    expect(emittedPaths(baseline).sort()).toEqual(
+      [path.join(parent, ".gitmodules"), path.join(parent, "root.txt")].sort()
+    );
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
 });
 
 describe("buildReconcileEditUpdate", () => {

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -68,7 +68,7 @@ describe("reconcileWorkingTree", () => {
 
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(file, "after-structured", "utf8");
-    await observeEditedPaths(baseline, [file]);
+    await observeEditedPaths(baseline, [{ path: file }]);
 
     expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
@@ -83,7 +83,7 @@ describe("reconcileWorkingTree", () => {
 
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(file, "structured", "utf8");
-    await observeEditedPaths(baseline, [file]);
+    await observeEditedPaths(baseline, [{ path: file }]);
     fs.writeFileSync(file, "shell", "utf8");
 
     const { reflected, unsupported } = await reconcileWorkingTree(baseline);
@@ -107,9 +107,45 @@ describe("reconcileWorkingTree", () => {
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(file, "shell", "utf8");
     fs.writeFileSync(file, "final", "utf8");
-    await observeEditedPaths(baseline, [file]);
+    await observeEditedPaths(baseline, [{ path: file, reportedTexts: ["final"] }]);
 
     expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("leaves a path the reported edit no longer accounts for to reconciliation", async () => {
+    // The reported content is gone from disk, so this update never told the
+    // client what the file now holds: reconciliation still has to.
+    const dir = gitRepo();
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(file, "overwritten by shell", "utf8");
+    await observeEditedPaths(baseline, [{ path: file, reportedTexts: ["structured"] }]);
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
+    expect(unsupported).toEqual([]);
+    expect(reflected).toEqual([{ path: file, oldText: "before", newText: "overwritten by shell" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("keeps reporting a deletion when the reported edit did not cause it", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.rmSync(file);
+    await observeEditedPaths(baseline, [{ path: file, reportedTexts: ["structured"] }]);
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -122,10 +158,10 @@ describe("reconcileWorkingTree", () => {
 
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(file, "edited", "utf8");
-    await observeEditedPaths(baseline, [file]);
+    await observeEditedPaths(baseline, [{ path: file }]);
     // Local review rejected the edit: revert put the pre-edit text back.
     fs.writeFileSync(file, "before", "utf8");
-    await observeEditedPaths(baseline, [file]);
+    await observeEditedPaths(baseline, [{ path: file }]);
 
     expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
@@ -176,7 +212,7 @@ describe("reconcileWorkingTree", () => {
 
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(ignoreFile, "", "utf8");
-    await observeEditedPaths(baseline, [ignoreFile]);
+    await observeEditedPaths(baseline, [{ path: ignoreFile }]);
 
     const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([]);
@@ -392,7 +428,7 @@ describe("reconcileWorkingTree", () => {
     fs.writeFileSync(file, "created", "utf8");
 
     const baseline = await snapshotWorkingTree([dir]);
-    await observeEditedPaths(baseline, [file]);
+    await observeEditedPaths(baseline, [{ path: file }]);
     expect(baseline.files.size).toBe(0);
     fs.rmSync(file);
 
@@ -432,7 +468,7 @@ describe("reconcileWorkingTree", () => {
     const baseline = await snapshotWorkingTree([dir]);
     fs.mkdirSync(createdDir);
     fs.writeFileSync(file, "created", "utf8");
-    await observeEditedPaths(baseline, [file]);
+    await observeEditedPaths(baseline, [{ path: file }]);
     fs.rmSync(createdDir, { recursive: true });
 
     const { reflected, unsupported } = await reconcileWorkingTree(baseline);
@@ -450,7 +486,7 @@ describe("reconcileWorkingTree", () => {
 
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(file, "created", "utf8");
-    await observeEditedPaths(baseline, [file]);
+    await observeEditedPaths(baseline, [{ path: file }]);
 
     expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
@@ -465,7 +501,7 @@ describe("reconcileWorkingTree", () => {
 
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(file, "created", "utf8");
-    await observeEditedPaths(baseline, [file]);
+    await observeEditedPaths(baseline, [{ path: file }]);
     fs.writeFileSync(file, "changed by shell", "utf8");
 
     const { reflected, unsupported } = await reconcileWorkingTree(baseline);
@@ -509,7 +545,7 @@ describe("reconcileWorkingTree", () => {
       fs.writeFileSync(file, "after", "utf8");
       // A structured tool may report the canonical absolute path even though
       // the workspace scan retained the cwd alias.
-      await observeEditedPaths(baseline, [file]);
+      await observeEditedPaths(baseline, [{ path: file }]);
 
       expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
@@ -558,7 +594,7 @@ describe("reconcileWorkingTree", () => {
       const aliasedFile = path.join(alias, "new.txt");
       const baseline = await snapshotWorkingTree([alias, dir]);
       fs.writeFileSync(file, "structured", "utf8");
-      await observeEditedPaths(baseline, [file]);
+      await observeEditedPaths(baseline, [{ path: file }]);
 
       expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
@@ -612,7 +648,7 @@ describe("reconcileWorkingTree", () => {
       fs.symlinkSync(outside, link, "dir");
       const baseline = await snapshotWorkingTree([dir]);
       fs.writeFileSync(file, "created", "utf8");
-      await observeEditedPaths(baseline, [file]);
+      await observeEditedPaths(baseline, [{ path: file }]);
       fs.rmSync(file);
       fs.rmSync(link);
 
@@ -633,7 +669,7 @@ describe("reconcileWorkingTree", () => {
       const baseline = await snapshotWorkingTree([dir]);
       fs.writeFileSync(file, "created", "utf8");
       fs.writeFileSync(target, "outside", "utf8");
-      await observeEditedPaths(baseline, [file]);
+      await observeEditedPaths(baseline, [{ path: file }]);
       fs.rmSync(file);
       fs.symlinkSync(target, file);
 
@@ -658,7 +694,7 @@ describe("reconcileWorkingTree", () => {
       const baseline = await snapshotWorkingTree([dir]);
       fs.mkdirSync(createdDir);
       fs.writeFileSync(file, "created", "utf8");
-      await observeEditedPaths(baseline, [file]);
+      await observeEditedPaths(baseline, [{ path: file }]);
       fs.rmSync(createdDir, { recursive: true });
       fs.writeFileSync(target, "outside secret", "utf8");
       fs.symlinkSync(outside, createdDir, "dir");

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -436,6 +436,45 @@ describe("reconcileWorkingTree", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("attributes an oversized whole-file write by digest instead of warning about it", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "big.txt");
+    fs.writeFileSync(file, "a".repeat(MAX_TEXT_BYTES + 1), "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    const written = "b".repeat(MAX_TEXT_BYTES + 1);
+    fs.writeFileSync(file, written, "utf8");
+    await observeEditedPaths(baseline, [
+      { path: file, wholeFile: true, blocks: [{ oldText: null, newText: written }] }
+    ]);
+
+    // The client was told the whole body, so there is nothing left to warn
+    // about even though the file is too large to diff.
+    expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("still warns about an oversized file the reported write does not account for", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "big.txt");
+    fs.writeFileSync(file, "a".repeat(MAX_TEXT_BYTES + 1), "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(file, "b".repeat(MAX_TEXT_BYTES + 1), "utf8");
+    await observeEditedPaths(baseline, [
+      { path: file, wholeFile: true, blocks: [{ oldText: null, newText: "not what is on disk" }] }
+    ]);
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([{ path: file, reason: "oversized" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("reports a deleted file as unsupported", async () => {
     const dir = gitRepo();
     const file = path.join(dir, "a.txt");

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -402,6 +402,29 @@ describe("reconcileWorkingTree", () => {
     fs.rmSync(outside, { recursive: true, force: true });
   });
 
+  it.skipIf(process.platform === "win32")(
+    "ignores files a root retargeted mid-turn exposes from outside the workspace",
+    async () => {
+      const dir = gitRepo();
+      const extraRoot = tmpDir();
+      const outside = tmpDir();
+      fs.writeFileSync(path.join(outside, "secret.txt"), "outside secret", "utf8");
+
+      const baseline = await snapshotWorkingTree([dir, extraRoot]);
+      // The additional root is replaced by a symlink pointing out of the
+      // workspace; its listing now reaches files no root ever contained.
+      fs.rmSync(extraRoot, { recursive: true });
+      fs.symlinkSync(outside, extraRoot, "dir");
+
+      expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
+      expect(fs.readFileSync(path.join(outside, "secret.txt"), "utf8")).toBe("outside secret");
+
+      fs.rmSync(extraRoot, { recursive: true, force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  );
+
   it("reports deletion of an in-root file created by a structured edit", async () => {
     const dir = gitRepo();
     const createdDir = path.join(dir, "created");

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -387,6 +387,32 @@ describe("reconcileWorkingTree", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it.skipIf(process.platform === "win32")(
+    "deduplicates workspace roots that alias the same checkout",
+    async () => {
+      const dir = gitRepo();
+      const aliasParent = tmpDir();
+      const alias = path.join(aliasParent, "alias");
+      fs.symlinkSync(dir, alias, "dir");
+      const file = path.join(dir, "a.txt");
+      const aliasedFile = path.join(alias, "a.txt");
+      fs.writeFileSync(file, "before", "utf8");
+      execFileSync("git", ["-C", dir, "add", "."]);
+
+      // Keep the first spelling (cwd) while deduplicating by physical root.
+      const baseline = await snapshotWorkingTree([alias, dir]);
+      expect([...baseline.keys()].filter((p) => p.endsWith("a.txt"))).toEqual([aliasedFile]);
+      fs.writeFileSync(file, "after", "utf8");
+
+      const { reflected, unsupported } = await reconcileWorkingTree(baseline, [alias, dir]);
+      expect(unsupported).toEqual([]);
+      expect(reflected).toEqual([{ path: aliasedFile, oldText: "before", newText: "after" }]);
+
+      fs.rmSync(aliasParent, { recursive: true, force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  );
+
   it("does not follow a tracked symlink to a directory", async () => {
     const dir = gitRepo();
     const outside = tmpDir();

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -93,12 +93,11 @@ describe("reconcileWorkingTree", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("observes disk instead of replaying a reported diff that no longer matches", async () => {
-    // A shell command changed the file before the structured write completed,
-    // so the reported oldText ("shell") is not the pre-turn text ("before").
-    // Observing disk keeps the client's view consistent; replaying the reported
-    // snippet against the pre-turn text would fail and emit a second,
-    // contradictory before→final edit.
+  it("accepts a whole-file write whose reported oldText never existed pre-turn", async () => {
+    // A shell command changed the file before the write completed, so the
+    // reported oldText ("shell") is not the pre-turn text. The reported body is
+    // the whole file and equals disk, so nothing unreported survives and no
+    // second, contradictory before→final edit is emitted.
     const dir = gitRepo();
     const file = path.join(dir, "a.txt");
     fs.writeFileSync(file, "before", "utf8");
@@ -107,15 +106,70 @@ describe("reconcileWorkingTree", () => {
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(file, "shell", "utf8");
     fs.writeFileSync(file, "final", "utf8");
-    await observeEditedPaths(baseline, [{ path: file, reportedTexts: ["final"] }]);
+    await observeEditedPaths(baseline, [
+      { path: file, wholeFile: true, blocks: [{ oldText: "shell", newText: "final" }] }
+    ]);
 
     expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("accepts a replacement that accounts for every difference on disk", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "alpha\nOLD\nomega\n", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(file, "alpha\nNEW\nomega\n", "utf8");
+    await observeEditedPaths(baseline, [{ path: file, blocks: [{ oldText: "OLD", newText: "NEW" }] }]);
+
+    expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reflects a later edit outside the reported replacement", async () => {
+    // A formatter (or shell command) rewrote another section before the
+    // tool-call was polled. Disk still contains the reported snippet, but the
+    // rest of the file changed too, so the surviving content must be reported.
+    const dir = gitRepo();
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "alpha\nOLD\nomega\n", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(file, "ALPHA\nNEW\nomega\n", "utf8");
+    await observeEditedPaths(baseline, [{ path: file, blocks: [{ oldText: "OLD", newText: "NEW" }] }]);
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
+    expect(unsupported).toEqual([]);
+    expect(reflected).toEqual([
+      { path: file, oldText: "alpha\nOLD\nomega\n", newText: "ALPHA\nNEW\nomega\n" }
+    ]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not accept an empty replacement target as accounting for any file", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(file, "changed by shell", "utf8");
+    await observeEditedPaths(baseline, [{ path: file, blocks: [{ oldText: "", newText: "" }] }]);
+
+    const { reflected } = await reconcileWorkingTree(baseline);
+    expect(reflected).toEqual([{ path: file, oldText: "before", newText: "changed by shell" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("leaves a path the reported edit no longer accounts for to reconciliation", async () => {
-    // The reported content is gone from disk, so this update never told the
+    // The reported target is gone from disk, so this update never told the
     // client what the file now holds: reconciliation still has to.
     const dir = gitRepo();
     const file = path.join(dir, "a.txt");
@@ -124,7 +178,9 @@ describe("reconcileWorkingTree", () => {
 
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(file, "overwritten by shell", "utf8");
-    await observeEditedPaths(baseline, [{ path: file, reportedTexts: ["structured"] }]);
+    await observeEditedPaths(baseline, [
+      { path: file, blocks: [{ oldText: "structured", newText: "changed" }] }
+    ]);
 
     const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(unsupported).toEqual([]);
@@ -141,7 +197,9 @@ describe("reconcileWorkingTree", () => {
 
     const baseline = await snapshotWorkingTree([dir]);
     fs.rmSync(file);
-    await observeEditedPaths(baseline, [{ path: file, reportedTexts: ["structured"] }]);
+    await observeEditedPaths(baseline, [
+      { path: file, blocks: [{ oldText: "before", newText: "structured" }] }
+    ]);
 
     const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([]);

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -173,4 +173,14 @@ describe("buildReconcileEditUpdate", () => {
     const update = buildReconcileEditUpdate({ path: "/repo/new.txt", oldText: null, newText: "x" }, 1, "/repo");
     expect(update).toMatchObject({ toolCallId: "agy-fs-reconcile-1", name: "write_to_file" });
   });
+
+  it("qualifies the tool-call ID with a per-turn token when provided", () => {
+    const edit = { path: "/repo/a.txt", oldText: null, newText: "x" };
+    const turn0 = buildReconcileEditUpdate(edit, 0, "/repo", "0");
+    const turn1 = buildReconcileEditUpdate(edit, 0, "/repo", "1");
+    expect(turn0).toMatchObject({ toolCallId: "agy-fs-reconcile-0-0" });
+    expect(turn1).toMatchObject({ toolCallId: "agy-fs-reconcile-1-0" });
+    // Same index in different turns must not collide.
+    expect((turn0 as { toolCallId: string }).toolCallId).not.toBe((turn1 as { toolCallId: string }).toolCallId);
+  });
 });

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -403,15 +403,36 @@ describe("reconcileWorkingTree", () => {
       const baseline = await snapshotWorkingTree([alias, dir]);
       expect([...baseline.keys()].filter((p) => p.endsWith("a.txt"))).toEqual([aliasedFile]);
       fs.writeFileSync(file, "after", "utf8");
+      // A structured tool may report the canonical absolute path even though
+      // the workspace scan retained the cwd alias.
+      applyDiffBlockToSnapshot(baseline, file, "before", "after");
 
       const { reflected, unsupported } = await reconcileWorkingTree(baseline, [alias, dir]);
       expect(unsupported).toEqual([]);
-      expect(reflected).toEqual([{ path: aliasedFile, oldText: "before", newText: "after" }]);
+      expect(reflected).toEqual([]);
 
       fs.rmSync(aliasParent, { recursive: true, force: true });
       fs.rmSync(dir, { recursive: true, force: true });
     }
   );
+
+  it("does not report structured-only baseline entries as deletions", async () => {
+    const dir = gitRepo();
+    const outside = tmpDir();
+    const file = path.join(outside, "structured.txt");
+    fs.writeFileSync(file, "created", "utf8");
+
+    const baseline = await snapshotWorkingTree([dir]);
+    applyDiffBlockToSnapshot(baseline, file, null, "created");
+    expect(baseline.get(file)?.candidate).toBe(false);
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
 
   it("does not follow a tracked symlink to a directory", async () => {
     const dir = gitRepo();

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -430,7 +430,7 @@ describe("reconcileWorkingTree", () => {
     fs.rmSync(outside, { recursive: true, force: true });
   });
 
-  it("recurses into a checked-out git submodule", async () => {
+  it("recurses into a checked-out submodule without applying parent ignore rules", async () => {
     const root = tmpDir();
     const subSrc = path.join(root, "sub-src");
     const parent = path.join(root, "parent");
@@ -457,16 +457,29 @@ describe("reconcileWorkingTree", () => {
       "-c", "protocol.file.allow=always",
       "submodule", "add", subSrc, "vendor"
     ]);
+    const parentIgnore = path.join(parent, ".gitignore");
+    fs.writeFileSync(parentIgnore, "*.txt\n", "utf8");
+    execFileSync("git", ["-C", parent, "add", ".gitignore"]);
     execFileSync("git", ["-C", parent, "commit", "-qm", "add vendor"]);
 
     const inside = path.join(parent, "vendor", "inside.txt");
+    const created = path.join(parent, "vendor", "new.txt");
     const baseline = await snapshotWorkingTree([parent]);
     expect(baseline.has(inside)).toBe(true);
 
+    // Parent ignore rules do not cross the nested repository boundary. Changing
+    // the parent rule must not make the submodule creation look newly exposed.
+    fs.writeFileSync(parentIgnore, "*.log\n", "utf8");
     fs.writeFileSync(inside, "sub-after", "utf8");
+    fs.writeFileSync(created, "sub-created", "utf8");
     const { reflected, unsupported } = await reconcileWorkingTree(baseline, [parent]);
     expect(unsupported).toEqual([]);
-    expect(reflected).toEqual([{ path: inside, oldText: "sub-before", newText: "sub-after" }]);
+    expect(reflected).toHaveLength(3);
+    expect(reflected).toEqual(expect.arrayContaining([
+      { path: parentIgnore, oldText: "*.txt\n", newText: "*.log\n" },
+      { path: inside, oldText: "sub-before", newText: "sub-after" },
+      { path: created, oldText: null, newText: "sub-created" }
+    ]));
 
     fs.rmSync(root, { recursive: true, force: true });
   });

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -5,13 +5,12 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   MAX_TEXT_BYTES,
-  applyDiffBlockToSnapshot,
-  applyDiffBlocksToSnapshot,
   buildReconcileEditUpdate,
   isValidUtf8,
+  observeEditedPaths,
   reconcileWorkingTree,
-  replaceOccurrence,
-  snapshotWorkingTree
+  snapshotWorkingTree,
+  type WorkingTreeSnapshot
 } from "../src/agy/edit/reconcile.js";
 import { diffBlocks } from "../src/agy/edit/revert.js";
 
@@ -27,6 +26,11 @@ function gitRepo(): string {
   return dir;
 }
 
+/** Absolute path each snapshot entry would emit, in listing order. */
+function emittedPaths(snapshot: WorkingTreeSnapshot): string[] {
+  return [...snapshot.files.values()].map((file) => file.path);
+}
+
 describe("reconcileWorkingTree", () => {
   it("reflects a modified tracked file with the pre-edit content as oldText", async () => {
     const dir = gitRepo();
@@ -37,7 +41,7 @@ describe("reconcileWorkingTree", () => {
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(file, "after", "utf8");
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(unsupported).toEqual([]);
     expect(reflected).toEqual([{ path: file, oldText: "before", newText: "after" }]);
 
@@ -50,13 +54,13 @@ describe("reconcileWorkingTree", () => {
     const file = path.join(dir, "new.txt");
     fs.writeFileSync(file, "created", "utf8");
 
-    const { reflected } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([{ path: file, oldText: null, newText: "created" }]);
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("does not re-emit a path after the baseline is advanced past a recognized edit", async () => {
+  it("does not re-emit a path whose reported content was observed", async () => {
     const dir = gitRepo();
     const file = path.join(dir, "a.txt");
     fs.writeFileSync(file, "before", "utf8");
@@ -64,11 +68,9 @@ describe("reconcileWorkingTree", () => {
 
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(file, "after-structured", "utf8");
-    // Advance from the structured diff content (not a disk reread).
-    applyDiffBlockToSnapshot(baseline, file, "before", "after-structured");
+    await observeEditedPaths(baseline, [file]);
 
-    const { reflected } = await reconcileWorkingTree(baseline, [dir]);
-    expect(reflected).toEqual([]);
+    expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -80,77 +82,54 @@ describe("reconcileWorkingTree", () => {
     execFileSync("git", ["-C", dir, "add", "."]);
 
     const baseline = await snapshotWorkingTree([dir]);
-    // Structured edit mid, then a shell edit to final — both may be on disk
-    // before the structured tool-call is observed. Baseline must advance from
-    // the diff content, not a disk reread (which would see "final").
-    fs.writeFileSync(file, "final", "utf8");
-    applyDiffBlockToSnapshot(baseline, file, "before", "mid");
+    fs.writeFileSync(file, "structured", "utf8");
+    await observeEditedPaths(baseline, [file]);
+    fs.writeFileSync(file, "shell", "utf8");
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(unsupported).toEqual([]);
-    expect(reflected).toEqual([{ path: file, oldText: "mid", newText: "final" }]);
+    expect(reflected).toEqual([{ path: file, oldText: "structured", newText: "shell" }]);
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies partial replace snippets to the baseline without reading disk", async () => {
+  it("observes disk instead of replaying a reported diff that no longer matches", async () => {
+    // A shell command changed the file before the structured write completed,
+    // so the reported oldText ("shell") is not the pre-turn text ("before").
+    // Observing disk keeps the client's view consistent; replaying the reported
+    // snippet against the pre-turn text would fail and emit a second,
+    // contradictory before→final edit.
     const dir = gitRepo();
     const file = path.join(dir, "a.txt");
-    fs.writeFileSync(file, "before\nOLD\nafter", "utf8");
+    fs.writeFileSync(file, "before", "utf8");
     execFileSync("git", ["-C", dir, "add", "."]);
 
     const baseline = await snapshotWorkingTree([dir]);
-    // Disk already has a later shell edit; structured replace was OLD→NEW.
-    fs.writeFileSync(file, "before\nSHELL\nafter", "utf8");
-    applyDiffBlockToSnapshot(baseline, file, "OLD", "NEW");
-    expect(baseline.get(file)?.text).toBe("before\nNEW\nafter");
+    fs.writeFileSync(file, "shell", "utf8");
+    fs.writeFileSync(file, "final", "utf8");
+    await observeEditedPaths(baseline, [file]);
 
-    const { reflected } = await reconcileWorkingTree(baseline, [dir]);
-    expect(reflected).toEqual([{ path: file, oldText: "before\nNEW\nafter", newText: "before\nSHELL\nafter" }]);
+    expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("replaces the StartLine-targeted occurrence when a snippet repeats", () => {
-    const text = "x\nOLD\ny\nOLD\nz";
-    // First occurrence (default) — line 2.
-    expect(replaceOccurrence(text, "OLD", "NEW")).toBe("x\nNEW\ny\nOLD\nz");
-    // Second occurrence via StartLine 4.
-    expect(replaceOccurrence(text, "OLD", "NEW", 4)).toBe("x\nOLD\ny\nNEW\nz");
-    // applyDiffBlockToSnapshot carries the same line disambiguation.
-    const snap = new Map([
-      ["/r/a.txt", { sha1: "x", size: text.length, text }]
-    ]);
-    applyDiffBlockToSnapshot(snap, "/r/a.txt", "OLD", "NEW", 4);
-    expect(snap.get("/r/a.txt")?.text).toBe("x\nOLD\ny\nNEW\nz");
-  });
+  it("re-observing a reverted edit does not report the restoration as a change", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
 
-  it("applies multi-replace StartLines against the original text, not intermediate state", () => {
-    // Line 2 is a 3-line block; replacing it with one line shifts later lines up.
-    // Chunk 2's StartLine 6 is relative to the *original* file.
-    const original = "keep\nAAA\nBBB\nCCC\nmid\nOLD\nend";
-    // lines: 1 keep, 2 AAA, 3 BBB, 4 CCC, 5 mid, 6 OLD, 7 end
-    const snap = new Map([
-      ["/r/a.txt", { sha1: "x", size: original.length, text: original }]
-    ]);
-    applyDiffBlocksToSnapshot(snap, "/r/a.txt", [
-      { oldText: "AAA\nBBB\nCCC", newText: "X", line: 2 },
-      { oldText: "OLD", newText: "NEW", line: 6 }
-    ]);
-    expect(snap.get("/r/a.txt")?.text).toBe("keep\nX\nmid\nNEW\nend");
-  });
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(file, "edited", "utf8");
+    await observeEditedPaths(baseline, [file]);
+    // Local review rejected the edit: revert put the pre-edit text back.
+    fs.writeFileSync(file, "before", "utf8");
+    await observeEditedPaths(baseline, [file]);
 
-  it("round-trips StartLine through diffBlocks when present on the content block", () => {
-    const update = {
-      sessionUpdate: "tool_call",
-      toolCallId: "t1",
-      kind: "edit",
-      status: "completed",
-      content: [{ type: "diff", path: "/r/a.txt", oldText: "OLD", newText: "NEW", line: 4 }]
-    };
-    expect(diffBlocks(update as never)).toEqual([
-      { path: "/r/a.txt", oldText: "OLD", newText: "NEW", line: 4 }
-    ]);
+    expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
+
+    fs.rmSync(dir, { recursive: true, force: true });
   });
 
   it("ignores gitignored files", async () => {
@@ -161,9 +140,7 @@ describe("reconcileWorkingTree", () => {
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(path.join(dir, "ignored.txt"), "secret", "utf8");
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
-    expect(reflected).toEqual([]);
-    expect(unsupported).toEqual([]);
+    expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -177,17 +154,19 @@ describe("reconcileWorkingTree", () => {
     execFileSync("git", ["-C", dir, "add", ".gitignore"]);
 
     const baseline = await snapshotWorkingTree([dir]);
-    expect(baseline.has(ignoredFile)).toBe(false);
+    expect(emittedPaths(baseline)).not.toContain(ignoredFile);
+    expect(baseline.excluded).toContain(ignoredFile);
     fs.writeFileSync(ignoreFile, "", "utf8");
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([{ path: ignoreFile, oldText: "ignored.txt\n", newText: "" }]);
-    expect(unsupported).toEqual([{ path: ignoredFile, reason: "ignore-rules-changed" }]);
+    expect(unsupported).toEqual([{ path: ignoredFile, reason: "previously-excluded" }]);
+    expect(fs.readFileSync(ignoredFile, "utf8")).toBe("pre-existing");
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("retains ignore-change detection after a structured edit advances the baseline", async () => {
+  it("keeps pre-turn exclusions intact after observing a structured ignore-rule edit", async () => {
     const dir = gitRepo();
     const ignoreFile = path.join(dir, ".gitignore");
     const ignoredFile = path.join(dir, "ignored.txt");
@@ -196,12 +175,12 @@ describe("reconcileWorkingTree", () => {
     execFileSync("git", ["-C", dir, "add", ".gitignore"]);
 
     const baseline = await snapshotWorkingTree([dir]);
-    applyDiffBlockToSnapshot(baseline, ignoreFile, "ignored.txt\n", "");
     fs.writeFileSync(ignoreFile, "", "utf8");
+    await observeEditedPaths(baseline, [ignoreFile]);
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([]);
-    expect(unsupported).toEqual([{ path: ignoredFile, reason: "ignore-rules-changed" }]);
+    expect(unsupported).toEqual([{ path: ignoredFile, reason: "previously-excluded" }]);
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -218,7 +197,7 @@ describe("reconcileWorkingTree", () => {
     fs.mkdirSync(path.dirname(createdFile), { recursive: true });
     fs.writeFileSync(createdFile, "export {};\n", "utf8");
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(reflected).toHaveLength(2);
     expect(reflected).toEqual(expect.arrayContaining([
       { path: ignoreFile, oldText: "", newText: "dist/\n" },
@@ -238,12 +217,34 @@ describe("reconcileWorkingTree", () => {
     execFileSync("git", ["-C", dir, "add", ".gitignore"]);
 
     const baseline = await snapshotWorkingTree([dir]);
-    expect(baseline.has(file)).toBe(true);
+    expect(emittedPaths(baseline)).toContain(file);
     fs.writeFileSync(ignoreFile, "later-ignored.txt\n", "utf8");
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([{ path: ignoreFile, oldText: "", newText: "later-ignored.txt\n" }]);
     expect(unsupported).toEqual([]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reflects a change to a file a new ignore rule hides", async () => {
+    const dir = gitRepo();
+    const ignoreFile = path.join(dir, ".gitignore");
+    const file = path.join(dir, "later-ignored.txt");
+    fs.writeFileSync(ignoreFile, "", "utf8");
+    fs.writeFileSync(file, "before", "utf8");
+    execFileSync("git", ["-C", dir, "add", ".gitignore"]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(ignoreFile, "later-ignored.txt\n", "utf8");
+    fs.writeFileSync(file, "after", "utf8");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
+    expect(unsupported).toEqual([]);
+    expect(reflected).toEqual(expect.arrayContaining([
+      { path: ignoreFile, oldText: "", newText: "later-ignored.txt\n" },
+      { path: file, oldText: "before", newText: "after" }
+    ]));
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -254,7 +255,7 @@ describe("reconcileWorkingTree", () => {
     const file = path.join(dir, "blob.bin");
     fs.writeFileSync(file, Buffer.from([0x00, 0x01, 0x02, 0x00]));
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([]);
     expect(unsupported).toEqual([{ path: file, reason: "binary" }]);
 
@@ -265,11 +266,12 @@ describe("reconcileWorkingTree", () => {
     const dir = gitRepo();
     const baseline = await snapshotWorkingTree([dir]);
     const file = path.join(dir, "bad.bin");
-    // Lone 0xff is not valid UTF-8 and has no NUL — previously misclassified as text.
+    // Lone 0xff is not valid UTF-8 and has no NUL — text write-through would
+    // rewrite it as U+FFFD.
     fs.writeFileSync(file, Buffer.from([0xff]));
 
     expect(isValidUtf8(Buffer.from([0xff]))).toBe(false);
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([]);
     expect(unsupported).toEqual([{ path: file, reason: "binary" }]);
 
@@ -283,10 +285,10 @@ describe("reconcileWorkingTree", () => {
     execFileSync("git", ["-C", dir, "add", "."]);
 
     const baseline = await snapshotWorkingTree([dir]);
-    expect(baseline.get(file)?.text).toBeNull();
+    expect(baseline.files.get(fs.realpathSync(file))?.text).toBeNull();
     fs.writeFileSync(file, "now text", "utf8");
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([]);
     expect(unsupported).toEqual([{ path: file, reason: "binary" }]);
 
@@ -299,7 +301,7 @@ describe("reconcileWorkingTree", () => {
     const file = path.join(dir, "big.txt");
     fs.writeFileSync(file, "a".repeat(MAX_TEXT_BYTES + 1), "utf8");
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([]);
     expect(unsupported).toEqual([{ path: file, reason: "oversized" }]);
 
@@ -309,17 +311,15 @@ describe("reconcileWorkingTree", () => {
   it("does not buffer an oversized baseline file into memory as text", async () => {
     const dir = gitRepo();
     const file = path.join(dir, "huge.bin");
-    // Write just over the limit; snapshot must record size+null text without
-    // treating it as routable text content.
     fs.writeFileSync(file, Buffer.alloc(MAX_TEXT_BYTES + 1, 1));
     execFileSync("git", ["-C", dir, "add", "."]);
 
     const baseline = await snapshotWorkingTree([dir]);
-    const snap = baseline.get(file);
-    expect(snap).toBeDefined();
-    expect(snap!.text).toBeNull();
-    expect(snap!.size).toBe(MAX_TEXT_BYTES + 1);
-    expect(snap!.sha1.startsWith("oversized:")).toBe(true);
+    const record = baseline.files.get(fs.realpathSync(file));
+    expect(record).toBeDefined();
+    expect(record!.text).toBeNull();
+    expect(record!.size).toBe(MAX_TEXT_BYTES + 1);
+    expect(record!.sha1.startsWith("oversized:")).toBe(true);
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -335,7 +335,7 @@ describe("reconcileWorkingTree", () => {
     fs.writeFileSync(file, Buffer.alloc(MAX_TEXT_BYTES + 1, 2));
     fs.utimesSync(file, originalTimes.atime, originalTimes.mtime);
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([]);
     expect(unsupported).toEqual([{ path: file, reason: "oversized" }]);
 
@@ -351,7 +351,7 @@ describe("reconcileWorkingTree", () => {
     const baseline = await snapshotWorkingTree([dir]);
     fs.rmSync(file);
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([]);
     expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
 
@@ -364,9 +364,7 @@ describe("reconcileWorkingTree", () => {
     execFileSync("git", ["-C", dir, "add", "."]);
 
     const baseline = await snapshotWorkingTree([dir]);
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
-    expect(reflected).toEqual([]);
-    expect(unsupported).toEqual([]);
+    expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -381,10 +379,92 @@ describe("reconcileWorkingTree", () => {
     // A change under node_modules must be skipped by the walk.
     fs.writeFileSync(path.join(dir, "node_modules", "dep.js"), "changed", "utf8");
 
-    const { reflected } = await reconcileWorkingTree(baseline, [dir]);
+    const { reflected } = await reconcileWorkingTree(baseline);
     expect(reflected).toEqual([{ path: path.join(dir, "src.txt"), oldText: null, newText: "hello" }]);
 
     fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("ignores observed paths outside the configured roots", async () => {
+    const dir = gitRepo();
+    const outside = tmpDir();
+    const file = path.join(outside, "structured.txt");
+    fs.writeFileSync(file, "created", "utf8");
+
+    const baseline = await snapshotWorkingTree([dir]);
+    await observeEditedPaths(baseline, [file]);
+    expect(baseline.files.size).toBe(0);
+    fs.rmSync(file);
+
+    expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
+
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  it("reports deletion of an in-root file created by a structured edit", async () => {
+    const dir = gitRepo();
+    const createdDir = path.join(dir, "created");
+    const file = path.join(createdDir, "structured.txt");
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.mkdirSync(createdDir);
+    fs.writeFileSync(file, "created", "utf8");
+    await observeEditedPaths(baseline, [file]);
+    fs.rmSync(createdDir, { recursive: true });
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not report a surviving ignored structured creation as deleted", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "ignored.txt");
+    fs.writeFileSync(path.join(dir, ".gitignore"), "ignored.txt\n", "utf8");
+    execFileSync("git", ["-C", dir, "add", ".gitignore"]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(file, "created", "utf8");
+    await observeEditedPaths(baseline, [file]);
+
+    expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reflects a later change to an ignored file a structured edit created", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "ignored.txt");
+    fs.writeFileSync(path.join(dir, ".gitignore"), "ignored.txt\n", "utf8");
+    execFileSync("git", ["-C", dir, "add", ".gitignore"]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(file, "created", "utf8");
+    await observeEditedPaths(baseline, [file]);
+    fs.writeFileSync(file, "changed by shell", "utf8");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
+    expect(unsupported).toEqual([]);
+    expect(reflected).toEqual([{ path: file, oldText: "created", newText: "changed by shell" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not follow a tracked symlink to a directory", async () => {
+    const dir = gitRepo();
+    const outside = tmpDir();
+    fs.writeFileSync(path.join(outside, "secret.txt"), "nope", "utf8");
+    fs.symlinkSync(outside, path.join(dir, "linkdir"));
+    execFileSync("git", ["-C", dir, "add", "-A"]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    expect(emittedPaths(baseline).some((p) => p.includes("secret.txt"))).toBe(false);
+    expect(emittedPaths(baseline)).not.toContain(path.join(dir, "linkdir"));
+
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
   });
 
   it.skipIf(process.platform === "win32")(
@@ -401,15 +481,14 @@ describe("reconcileWorkingTree", () => {
 
       // Keep the first spelling (cwd) while deduplicating by physical root.
       const baseline = await snapshotWorkingTree([alias, dir]);
-      expect([...baseline.keys()].filter((p) => p.endsWith("a.txt"))).toEqual([aliasedFile]);
+      expect(baseline.roots).toHaveLength(1);
+      expect(emittedPaths(baseline)).toEqual([aliasedFile]);
       fs.writeFileSync(file, "after", "utf8");
       // A structured tool may report the canonical absolute path even though
       // the workspace scan retained the cwd alias.
-      applyDiffBlockToSnapshot(baseline, file, "before", "after");
+      await observeEditedPaths(baseline, [file]);
 
-      const { reflected, unsupported } = await reconcileWorkingTree(baseline, [alias, dir]);
-      expect(unsupported).toEqual([]);
-      expect(reflected).toEqual([]);
+      expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
       fs.rmSync(aliasParent, { recursive: true, force: true });
       fs.rmSync(dir, { recursive: true, force: true });
@@ -431,10 +510,10 @@ describe("reconcileWorkingTree", () => {
       execFileSync("git", ["-C", dir, "add", "."]);
 
       const baseline = await snapshotWorkingTree([alias, dir]);
-      expect([...baseline.keys()].filter((p) => p.endsWith("a.txt"))).toEqual([aliasedFile]);
+      expect(emittedPaths(baseline).filter((p) => p.endsWith("a.txt"))).toEqual([aliasedFile]);
       fs.writeFileSync(file, "after", "utf8");
 
-      const { reflected, unsupported } = await reconcileWorkingTree(baseline, [alias, dir]);
+      const { reflected, unsupported } = await reconcileWorkingTree(baseline);
       expect(unsupported).toEqual([]);
       expect(reflected).toEqual([{ path: aliasedFile, oldText: "before", newText: "after" }]);
 
@@ -456,12 +535,12 @@ describe("reconcileWorkingTree", () => {
       const aliasedFile = path.join(alias, "new.txt");
       const baseline = await snapshotWorkingTree([alias, dir]);
       fs.writeFileSync(file, "structured", "utf8");
-      applyDiffBlockToSnapshot(baseline, file, null, "structured");
+      await observeEditedPaths(baseline, [file]);
 
-      expect(await reconcileWorkingTree(baseline, [alias, dir])).toEqual({ reflected: [], unsupported: [] });
+      expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
       fs.writeFileSync(file, "later", "utf8");
-      const { reflected, unsupported } = await reconcileWorkingTree(baseline, [alias, dir]);
+      const { reflected, unsupported } = await reconcileWorkingTree(baseline);
       expect(unsupported).toEqual([]);
       expect(reflected).toEqual([{ path: aliasedFile, oldText: "structured", newText: "later" }]);
 
@@ -470,42 +549,38 @@ describe("reconcileWorkingTree", () => {
     }
   );
 
-  it("reports deletion of an in-root file created by a structured edit", async () => {
-    const dir = gitRepo();
-    const createdDir = path.join(dir, "created");
-    const file = path.join(createdDir, "structured.txt");
-    const baseline = await snapshotWorkingTree([dir]);
-    fs.mkdirSync(createdDir);
-    fs.writeFileSync(file, "created", "utf8");
-    applyDiffBlockToSnapshot(baseline, file, null, "created");
-    expect(baseline.get(file)?.candidate).toBe(false);
-    fs.rmSync(createdDir, { recursive: true });
+  it.skipIf(process.platform === "win32")(
+    "matches ignore-rule exposure across a symlinked root and its canonical parent",
+    async () => {
+      const dir = gitRepo();
+      const subdir = path.join(dir, "subdir");
+      const aliasParent = tmpDir();
+      const alias = path.join(aliasParent, "alias");
+      const ignoreFile = path.join(dir, ".gitignore");
+      const hidden = path.join(subdir, "hidden.txt");
+      fs.mkdirSync(subdir);
+      fs.symlinkSync(subdir, alias, "dir");
+      fs.writeFileSync(ignoreFile, "subdir/hidden.txt\n", "utf8");
+      fs.writeFileSync(hidden, "pre-existing", "utf8");
+      execFileSync("git", ["-C", dir, "add", ".gitignore"]);
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
-    expect(reflected).toEqual([]);
-    expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
+      // cwd is the symlinked subdirectory; the extra root is its canonical parent.
+      const baseline = await snapshotWorkingTree([alias, dir]);
+      expect(emittedPaths(baseline).some((p) => p.endsWith("hidden.txt"))).toBe(false);
+      fs.writeFileSync(ignoreFile, "", "utf8");
 
-    fs.rmSync(dir, { recursive: true, force: true });
-  });
+      const { reflected, unsupported } = await reconcileWorkingTree(baseline);
+      expect(reflected).toEqual([{ path: ignoreFile, oldText: "subdir/hidden.txt\n", newText: "" }]);
+      expect(unsupported).toEqual([{ path: path.join(alias, "hidden.txt"), reason: "previously-excluded" }]);
+      expect(fs.readFileSync(hidden, "utf8")).toBe("pre-existing");
 
-  it("does not report a surviving ignored structured creation as deleted", async () => {
-    const dir = gitRepo();
-    const file = path.join(dir, "ignored.txt");
-    fs.writeFileSync(path.join(dir, ".gitignore"), "ignored.txt\n", "utf8");
-    execFileSync("git", ["-C", dir, "add", ".gitignore"]);
-    const baseline = await snapshotWorkingTree([dir]);
-    fs.writeFileSync(file, "created", "utf8");
-    applyDiffBlockToSnapshot(baseline, file, null, "created");
-
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
-    expect(reflected).toEqual([]);
-    expect(unsupported).toEqual([]);
-
-    fs.rmSync(dir, { recursive: true, force: true });
-  });
+      fs.rmSync(aliasParent, { recursive: true, force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  );
 
   it.skipIf(process.platform === "win32")(
-    "uses structured physical identity after an in-root symlink to outside is removed",
+    "ignores a structured path that resolves outside the roots through a symlink",
     async () => {
       const dir = gitRepo();
       const outside = tmpDir();
@@ -514,11 +589,11 @@ describe("reconcileWorkingTree", () => {
       fs.symlinkSync(outside, link, "dir");
       const baseline = await snapshotWorkingTree([dir]);
       fs.writeFileSync(file, "created", "utf8");
-      applyDiffBlockToSnapshot(baseline, file, null, "created");
+      await observeEditedPaths(baseline, [file]);
       fs.rmSync(file);
       fs.rmSync(link);
 
-      expect(await reconcileWorkingTree(baseline, [dir])).toEqual({ reflected: [], unsupported: [] });
+      expect(await reconcileWorkingTree(baseline)).toEqual({ reflected: [], unsupported: [] });
 
       fs.rmSync(dir, { recursive: true, force: true });
       fs.rmSync(outside, { recursive: true, force: true });
@@ -526,7 +601,7 @@ describe("reconcileWorkingTree", () => {
   );
 
   it.skipIf(process.platform === "win32")(
-    "reports an in-root structured file replaced by an outside symlink as deleted",
+    "reports an in-root observed file replaced by an outside symlink as deleted",
     async () => {
       const dir = gitRepo();
       const outside = tmpDir();
@@ -535,11 +610,11 @@ describe("reconcileWorkingTree", () => {
       const baseline = await snapshotWorkingTree([dir]);
       fs.writeFileSync(file, "created", "utf8");
       fs.writeFileSync(target, "outside", "utf8");
-      applyDiffBlockToSnapshot(baseline, file, null, "created");
+      await observeEditedPaths(baseline, [file]);
       fs.rmSync(file);
       fs.symlinkSync(target, file);
 
-      const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+      const { reflected, unsupported } = await reconcileWorkingTree(baseline);
       expect(reflected).toEqual([]);
       expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
       expect(fs.readFileSync(target, "utf8")).toBe("outside");
@@ -560,12 +635,12 @@ describe("reconcileWorkingTree", () => {
       const baseline = await snapshotWorkingTree([dir]);
       fs.mkdirSync(createdDir);
       fs.writeFileSync(file, "created", "utf8");
-      applyDiffBlockToSnapshot(baseline, file, null, "created");
+      await observeEditedPaths(baseline, [file]);
       fs.rmSync(createdDir, { recursive: true });
       fs.writeFileSync(target, "outside secret", "utf8");
       fs.symlinkSync(outside, createdDir, "dir");
 
-      const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+      const { reflected, unsupported } = await reconcileWorkingTree(baseline);
       expect(reflected).toEqual([]);
       expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
       expect(fs.readFileSync(target, "utf8")).toBe("outside secret");
@@ -575,66 +650,33 @@ describe("reconcileWorkingTree", () => {
     }
   );
 
-  it("does not report structured-only baseline entries as deletions", async () => {
-    const dir = gitRepo();
-    const outside = tmpDir();
-    const file = path.join(outside, "structured.txt");
-    fs.writeFileSync(file, "created", "utf8");
+  it.skipIf(process.platform === "win32")(
+    "does not follow a baseline file replaced by a symlink during direct resnapshot",
+    async () => {
+      const dir = gitRepo();
+      const outside = tmpDir();
+      const ignoreFile = path.join(dir, ".gitignore");
+      const file = path.join(dir, "hidden.txt");
+      const target = path.join(outside, "target.txt");
+      fs.writeFileSync(ignoreFile, "", "utf8");
+      fs.writeFileSync(file, "inside", "utf8");
+      fs.writeFileSync(target, "outside secret", "utf8");
+      execFileSync("git", ["-C", dir, "add", ".gitignore"]);
 
-    const baseline = await snapshotWorkingTree([dir]);
-    applyDiffBlockToSnapshot(baseline, file, null, "created");
-    expect(baseline.get(file)?.candidate).toBe(false);
+      const baseline = await snapshotWorkingTree([dir]);
+      fs.rmSync(file);
+      fs.symlinkSync(target, file);
+      fs.writeFileSync(ignoreFile, "hidden.txt\n", "utf8");
 
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
-    expect(reflected).toEqual([]);
-    expect(unsupported).toEqual([]);
+      const { reflected, unsupported } = await reconcileWorkingTree(baseline);
+      expect(reflected).toEqual([{ path: ignoreFile, oldText: "", newText: "hidden.txt\n" }]);
+      expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
+      expect(fs.readFileSync(target, "utf8")).toBe("outside secret");
 
-    fs.rmSync(dir, { recursive: true, force: true });
-    fs.rmSync(outside, { recursive: true, force: true });
-  });
-
-  it("does not follow a tracked symlink to a directory", async () => {
-    const dir = gitRepo();
-    const outside = tmpDir();
-    fs.writeFileSync(path.join(outside, "secret.txt"), "nope", "utf8");
-    // Symlink into the repo that points at an external directory.
-    fs.symlinkSync(outside, path.join(dir, "linkdir"));
-    execFileSync("git", ["-C", dir, "add", "-A"]);
-
-    const baseline = await snapshotWorkingTree([dir]);
-    // The symlink itself is not a regular file snapshot; external contents
-    // must not be walked via symlink-following.
-    expect([...baseline.keys()].some((p) => p.includes("secret.txt"))).toBe(false);
-    expect(baseline.has(path.join(dir, "linkdir"))).toBe(false);
-
-    fs.rmSync(dir, { recursive: true, force: true });
-    fs.rmSync(outside, { recursive: true, force: true });
-  });
-
-  it("does not follow a baseline file replaced by a symlink during direct resnapshot", async () => {
-    const dir = gitRepo();
-    const outside = tmpDir();
-    const ignoreFile = path.join(dir, ".gitignore");
-    const file = path.join(dir, "hidden.txt");
-    const target = path.join(outside, "target.txt");
-    fs.writeFileSync(ignoreFile, "", "utf8");
-    fs.writeFileSync(file, "inside", "utf8");
-    fs.writeFileSync(target, "outside secret", "utf8");
-    execFileSync("git", ["-C", dir, "add", ".gitignore"]);
-
-    const baseline = await snapshotWorkingTree([dir]);
-    fs.rmSync(file);
-    fs.symlinkSync(target, file);
-    fs.writeFileSync(ignoreFile, "hidden.txt\n", "utf8");
-
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
-    expect(reflected).toEqual([{ path: ignoreFile, oldText: "", newText: "hidden.txt\n" }]);
-    expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
-    expect(fs.readFileSync(target, "utf8")).toBe("outside secret");
-
-    fs.rmSync(dir, { recursive: true, force: true });
-    fs.rmSync(outside, { recursive: true, force: true });
-  });
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  );
 
   it("recurses into a checked-out submodule without applying parent ignore rules", async () => {
     const root = tmpDir();
@@ -671,14 +713,14 @@ describe("reconcileWorkingTree", () => {
     const inside = path.join(parent, "vendor", "inside.txt");
     const created = path.join(parent, "vendor", "new.txt");
     const baseline = await snapshotWorkingTree([parent]);
-    expect(baseline.has(inside)).toBe(true);
+    expect(emittedPaths(baseline)).toContain(inside);
 
     // Parent ignore rules do not cross the nested repository boundary. Changing
     // the parent rule must not make the submodule creation look newly exposed.
     fs.writeFileSync(parentIgnore, "*.log\n", "utf8");
     fs.writeFileSync(inside, "sub-after", "utf8");
     fs.writeFileSync(created, "sub-created", "utf8");
-    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [parent]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline);
     expect(unsupported).toEqual([]);
     expect(reflected).toHaveLength(3);
     expect(reflected).toEqual(expect.arrayContaining([

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -9,6 +9,7 @@ import {
   buildReconcileEditUpdate,
   isValidUtf8,
   reconcileWorkingTree,
+  replaceOccurrence,
   snapshotWorkingTree
 } from "../src/agy/edit/reconcile.js";
 import { diffBlocks } from "../src/agy/edit/revert.js";
@@ -107,6 +108,33 @@ describe("reconcileWorkingTree", () => {
     expect(reflected).toEqual([{ path: file, oldText: "before\nNEW\nafter", newText: "before\nSHELL\nafter" }]);
 
     fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("replaces the StartLine-targeted occurrence when a snippet repeats", () => {
+    const text = "x\nOLD\ny\nOLD\nz";
+    // First occurrence (default) — line 2.
+    expect(replaceOccurrence(text, "OLD", "NEW")).toBe("x\nNEW\ny\nOLD\nz");
+    // Second occurrence via StartLine 4.
+    expect(replaceOccurrence(text, "OLD", "NEW", 4)).toBe("x\nOLD\ny\nNEW\nz");
+    // applyDiffBlockToSnapshot carries the same line disambiguation.
+    const snap = new Map([
+      ["/r/a.txt", { sha1: "x", size: text.length, text }]
+    ]);
+    applyDiffBlockToSnapshot(snap, "/r/a.txt", "OLD", "NEW", 4);
+    expect(snap.get("/r/a.txt")?.text).toBe("x\nOLD\ny\nNEW\nz");
+  });
+
+  it("round-trips StartLine through diffBlocks when present on the content block", () => {
+    const update = {
+      sessionUpdate: "tool_call",
+      toolCallId: "t1",
+      kind: "edit",
+      status: "completed",
+      content: [{ type: "diff", path: "/r/a.txt", oldText: "OLD", newText: "NEW", line: 4 }]
+    };
+    expect(diffBlocks(update as never)).toEqual([
+      { path: "/r/a.txt", oldText: "OLD", newText: "NEW", line: 4 }
+    ]);
   });
 
   it("ignores gitignored files", async () => {

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -1,0 +1,176 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  MAX_TEXT_BYTES,
+  buildReconcileEditUpdate,
+  reconcileWorkingTree,
+  snapshotWorkingTree
+} from "../src/agy/edit/reconcile.js";
+import { diffBlocks } from "../src/agy/edit/revert.js";
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-reconcile-"));
+}
+
+function gitRepo(): string {
+  const dir = tmpDir();
+  execFileSync("git", ["-C", dir, "init", "-q"]);
+  execFileSync("git", ["-C", dir, "config", "user.email", "t@t"]);
+  execFileSync("git", ["-C", dir, "config", "user.name", "t"]);
+  return dir;
+}
+
+describe("reconcileWorkingTree", () => {
+  it("reflects a modified tracked file with the pre-edit content as oldText", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(file, "after", "utf8");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir], []);
+    expect(unsupported).toEqual([]);
+    expect(reflected).toEqual([{ path: file, oldText: "before", newText: "after" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reflects a newly created untracked file with oldText null", async () => {
+    const dir = gitRepo();
+    const baseline = await snapshotWorkingTree([dir]);
+    const file = path.join(dir, "new.txt");
+    fs.writeFileSync(file, "created", "utf8");
+
+    const { reflected } = await reconcileWorkingTree(baseline, [dir], []);
+    expect(reflected).toEqual([{ path: file, oldText: null, newText: "created" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("skips a path already reflected by a recognized edit", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(file, "after", "utf8");
+
+    const { reflected } = await reconcileWorkingTree(baseline, [dir], [file]);
+    expect(reflected).toEqual([]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("ignores gitignored files", async () => {
+    const dir = gitRepo();
+    fs.writeFileSync(path.join(dir, ".gitignore"), "ignored.txt\n", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(path.join(dir, "ignored.txt"), "secret", "utf8");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir], []);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reports a binary change as unsupported instead of diffing it", async () => {
+    const dir = gitRepo();
+    const baseline = await snapshotWorkingTree([dir]);
+    const file = path.join(dir, "blob.bin");
+    fs.writeFileSync(file, Buffer.from([0x00, 0x01, 0x02, 0x00]));
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir], []);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([{ path: file, reason: "binary" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reports an oversized change as unsupported", async () => {
+    const dir = gitRepo();
+    const baseline = await snapshotWorkingTree([dir]);
+    const file = path.join(dir, "big.txt");
+    fs.writeFileSync(file, "a".repeat(MAX_TEXT_BYTES + 1), "utf8");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir], []);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([{ path: file, reason: "oversized" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reports a deleted file as unsupported", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.rmSync(file);
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir], []);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("leaves unchanged files alone", async () => {
+    const dir = gitRepo();
+    fs.writeFileSync(path.join(dir, "a.txt"), "same", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir], []);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("works for a non-git root via the recursive-walk fallback", async () => {
+    const dir = tmpDir();
+    fs.mkdirSync(path.join(dir, "node_modules"));
+    fs.writeFileSync(path.join(dir, "node_modules", "dep.js"), "vendor", "utf8");
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(path.join(dir, "src.txt"), "hello", "utf8");
+    // A change under node_modules must be skipped by the walk.
+    fs.writeFileSync(path.join(dir, "node_modules", "dep.js"), "changed", "utf8");
+
+    const { reflected } = await reconcileWorkingTree(baseline, [dir], []);
+    expect(reflected).toEqual([{ path: path.join(dir, "src.txt"), oldText: null, newText: "hello" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("buildReconcileEditUpdate", () => {
+  it("produces a completed edit tool_call whose diff round-trips through diffBlocks", () => {
+    const edit = { path: "/repo/src/a.txt", oldText: "old", newText: "new" };
+    const update = buildReconcileEditUpdate(edit, 0, "/repo");
+
+    expect(update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "agy-fs-reconcile-0",
+      kind: "edit",
+      status: "completed",
+      title: "Edit src/a.txt"
+    });
+    expect(diffBlocks(update)).toEqual([{ path: "/repo/src/a.txt", oldText: "old", newText: "new" }]);
+  });
+
+  it("names a create (oldText null) write_to_file", () => {
+    const update = buildReconcileEditUpdate({ path: "/repo/new.txt", oldText: null, newText: "x" }, 1, "/repo");
+    expect(update).toMatchObject({ toolCallId: "agy-fs-reconcile-1", name: "write_to_file" });
+  });
+});

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -206,6 +206,29 @@ describe("reconcileWorkingTree", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("still reflects an unrelated creation when ignore rules also change", async () => {
+    const dir = gitRepo();
+    const ignoreFile = path.join(dir, ".gitignore");
+    const createdFile = path.join(dir, "src", "new.ts");
+    fs.writeFileSync(ignoreFile, "", "utf8");
+    execFileSync("git", ["-C", dir, "add", ".gitignore"]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(ignoreFile, "dist/\n", "utf8");
+    fs.mkdirSync(path.dirname(createdFile), { recursive: true });
+    fs.writeFileSync(createdFile, "export {};\n", "utf8");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    expect(reflected).toHaveLength(2);
+    expect(reflected).toEqual(expect.arrayContaining([
+      { path: ignoreFile, oldText: "", newText: "dist/\n" },
+      { path: createdFile, oldText: null, newText: "export {};\n" }
+    ]));
+    expect(unsupported).toEqual([]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("does not report a baseline file as deleted when a new ignore rule hides it", async () => {
     const dir = gitRepo();
     const ignoreFile = path.join(dir, ".gitignore");
@@ -377,6 +400,31 @@ describe("reconcileWorkingTree", () => {
     // must not be walked via symlink-following.
     expect([...baseline.keys()].some((p) => p.includes("secret.txt"))).toBe(false);
     expect(baseline.has(path.join(dir, "linkdir"))).toBe(false);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  it("does not follow a baseline file replaced by a symlink during direct resnapshot", async () => {
+    const dir = gitRepo();
+    const outside = tmpDir();
+    const ignoreFile = path.join(dir, ".gitignore");
+    const file = path.join(dir, "hidden.txt");
+    const target = path.join(outside, "target.txt");
+    fs.writeFileSync(ignoreFile, "", "utf8");
+    fs.writeFileSync(file, "inside", "utf8");
+    fs.writeFileSync(target, "outside secret", "utf8");
+    execFileSync("git", ["-C", dir, "add", ".gitignore"]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.rmSync(file);
+    fs.symlinkSync(target, file);
+    fs.writeFileSync(ignoreFile, "hidden.txt\n", "utf8");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    expect(reflected).toEqual([{ path: ignoreFile, oldText: "", newText: "hidden.txt\n" }]);
+    expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
+    expect(fs.readFileSync(target, "utf8")).toBe("outside secret");
 
     fs.rmSync(dir, { recursive: true, force: true });
     fs.rmSync(outside, { recursive: true, force: true });

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -5,10 +5,10 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   MAX_TEXT_BYTES,
+  applyDiffBlockToSnapshot,
   buildReconcileEditUpdate,
   isValidUtf8,
   reconcileWorkingTree,
-  refreshSnapshotPath,
   snapshotWorkingTree
 } from "../src/agy/edit/reconcile.js";
 import { diffBlocks } from "../src/agy/edit/revert.js";
@@ -62,8 +62,8 @@ describe("reconcileWorkingTree", () => {
 
     const baseline = await snapshotWorkingTree([dir]);
     fs.writeFileSync(file, "after-structured", "utf8");
-    // Simulate a recognized edit landing: advance baseline to post-edit content.
-    await refreshSnapshotPath(baseline, file);
+    // Advance from the structured diff content (not a disk reread).
+    applyDiffBlockToSnapshot(baseline, file, "before", "after-structured");
 
     const { reflected } = await reconcileWorkingTree(baseline, [dir]);
     expect(reflected).toEqual([]);
@@ -78,15 +78,33 @@ describe("reconcileWorkingTree", () => {
     execFileSync("git", ["-C", dir, "add", "."]);
 
     const baseline = await snapshotWorkingTree([dir]);
-    // Structured edit lands first.
-    fs.writeFileSync(file, "mid", "utf8");
-    await refreshSnapshotPath(baseline, file);
-    // Then a shell / unrecognized edit further changes the same file.
+    // Structured edit mid, then a shell edit to final — both may be on disk
+    // before the structured tool-call is observed. Baseline must advance from
+    // the diff content, not a disk reread (which would see "final").
     fs.writeFileSync(file, "final", "utf8");
+    applyDiffBlockToSnapshot(baseline, file, "before", "mid");
 
     const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
     expect(unsupported).toEqual([]);
     expect(reflected).toEqual([{ path: file, oldText: "mid", newText: "final" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("applies partial replace snippets to the baseline without reading disk", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "a.txt");
+    fs.writeFileSync(file, "before\nOLD\nafter", "utf8");
+    execFileSync("git", ["-C", dir, "add", "."]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    // Disk already has a later shell edit; structured replace was OLD→NEW.
+    fs.writeFileSync(file, "before\nSHELL\nafter", "utf8");
+    applyDiffBlockToSnapshot(baseline, file, "OLD", "NEW");
+    expect(baseline.get(file)?.text).toBe("before\nNEW\nafter");
+
+    const { reflected } = await reconcileWorkingTree(baseline, [dir]);
+    expect(reflected).toEqual([{ path: file, oldText: "before\nNEW\nafter", newText: "before\nSHELL\nafter" }]);
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -225,6 +243,24 @@ describe("reconcileWorkingTree", () => {
     expect(reflected).toEqual([{ path: path.join(dir, "src.txt"), oldText: null, newText: "hello" }]);
 
     fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not follow a tracked symlink to a directory", async () => {
+    const dir = gitRepo();
+    const outside = tmpDir();
+    fs.writeFileSync(path.join(outside, "secret.txt"), "nope", "utf8");
+    // Symlink into the repo that points at an external directory.
+    fs.symlinkSync(outside, path.join(dir, "linkdir"));
+    execFileSync("git", ["-C", dir, "add", "-A"]);
+
+    const baseline = await snapshotWorkingTree([dir]);
+    // The symlink itself is not a regular file snapshot; external contents
+    // must not be walked via symlink-following.
+    expect([...baseline.keys()].some((p) => p.includes("secret.txt"))).toBe(false);
+    expect(baseline.has(path.join(dir, "linkdir"))).toBe(false);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
   });
 
   it("recurses into a checked-out git submodule", async () => {

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   MAX_TEXT_BYTES,
   applyDiffBlockToSnapshot,
+  applyDiffBlocksToSnapshot,
   buildReconcileEditUpdate,
   isValidUtf8,
   reconcileWorkingTree,
@@ -122,6 +123,21 @@ describe("reconcileWorkingTree", () => {
     ]);
     applyDiffBlockToSnapshot(snap, "/r/a.txt", "OLD", "NEW", 4);
     expect(snap.get("/r/a.txt")?.text).toBe("x\nOLD\ny\nNEW\nz");
+  });
+
+  it("applies multi-replace StartLines against the original text, not intermediate state", () => {
+    // Line 2 is a 3-line block; replacing it with one line shifts later lines up.
+    // Chunk 2's StartLine 6 is relative to the *original* file.
+    const original = "keep\nAAA\nBBB\nCCC\nmid\nOLD\nend";
+    // lines: 1 keep, 2 AAA, 3 BBB, 4 CCC, 5 mid, 6 OLD, 7 end
+    const snap = new Map([
+      ["/r/a.txt", { sha1: "x", size: original.length, text: original }]
+    ]);
+    applyDiffBlocksToSnapshot(snap, "/r/a.txt", [
+      { oldText: "AAA\nBBB\nCCC", newText: "X", line: 2 },
+      { oldText: "OLD", newText: "NEW", line: 6 }
+    ]);
+    expect(snap.get("/r/a.txt")?.text).toBe("keep\nX\nmid\nNEW\nend");
   });
 
   it("round-trips StartLine through diffBlocks when present on the content block", () => {
@@ -361,5 +377,15 @@ describe("buildReconcileEditUpdate", () => {
     expect(turn1).toMatchObject({ toolCallId: "agy-fs-reconcile-1-0" });
     // Same index in different turns must not collide.
     expect((turn0 as { toolCallId: string }).toolCallId).not.toBe((turn1 as { toolCallId: string }).toolCallId);
+  });
+
+  it("keeps tool-call IDs unique when turn tokens are UUIDs (session reload safe)", () => {
+    const edit = { path: "/repo/a.txt", oldText: null, newText: "x" };
+    const a = buildReconcileEditUpdate(edit, 0, "/repo", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    const b = buildReconcileEditUpdate(edit, 0, "/repo", "ffffffff-0000-1111-2222-333333333333");
+    expect((a as { toolCallId: string }).toolCallId).toBe(
+      "agy-fs-reconcile-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-0"
+    );
+    expect((a as { toolCallId: string }).toolCallId).not.toBe((b as { toolCallId: string }).toolCallId);
   });
 });

--- a/tests/edit-reconcile.test.ts
+++ b/tests/edit-reconcile.test.ts
@@ -416,6 +416,165 @@ describe("reconcileWorkingTree", () => {
     }
   );
 
+  it.skipIf(process.platform === "win32")(
+    "deduplicates files shared by overlapping aliased roots",
+    async () => {
+      const dir = gitRepo();
+      const subdir = path.join(dir, "subdir");
+      const aliasParent = tmpDir();
+      const alias = path.join(aliasParent, "alias");
+      fs.mkdirSync(subdir);
+      fs.symlinkSync(subdir, alias, "dir");
+      const file = path.join(subdir, "a.txt");
+      const aliasedFile = path.join(alias, "a.txt");
+      fs.writeFileSync(file, "before", "utf8");
+      execFileSync("git", ["-C", dir, "add", "."]);
+
+      const baseline = await snapshotWorkingTree([alias, dir]);
+      expect([...baseline.keys()].filter((p) => p.endsWith("a.txt"))).toEqual([aliasedFile]);
+      fs.writeFileSync(file, "after", "utf8");
+
+      const { reflected, unsupported } = await reconcileWorkingTree(baseline, [alias, dir]);
+      expect(unsupported).toEqual([]);
+      expect(reflected).toEqual([{ path: aliasedFile, oldText: "before", newText: "after" }]);
+
+      fs.rmSync(aliasParent, { recursive: true, force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "aligns structured creations with the retained alias spelling",
+    async () => {
+      const dir = gitRepo();
+      const subdir = path.join(dir, "subdir");
+      const aliasParent = tmpDir();
+      const alias = path.join(aliasParent, "alias");
+      fs.mkdirSync(subdir);
+      fs.symlinkSync(subdir, alias, "dir");
+      const file = path.join(subdir, "new.txt");
+      const aliasedFile = path.join(alias, "new.txt");
+      const baseline = await snapshotWorkingTree([alias, dir]);
+      fs.writeFileSync(file, "structured", "utf8");
+      applyDiffBlockToSnapshot(baseline, file, null, "structured");
+
+      expect(await reconcileWorkingTree(baseline, [alias, dir])).toEqual({ reflected: [], unsupported: [] });
+
+      fs.writeFileSync(file, "later", "utf8");
+      const { reflected, unsupported } = await reconcileWorkingTree(baseline, [alias, dir]);
+      expect(unsupported).toEqual([]);
+      expect(reflected).toEqual([{ path: aliasedFile, oldText: "structured", newText: "later" }]);
+
+      fs.rmSync(aliasParent, { recursive: true, force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  );
+
+  it("reports deletion of an in-root file created by a structured edit", async () => {
+    const dir = gitRepo();
+    const createdDir = path.join(dir, "created");
+    const file = path.join(createdDir, "structured.txt");
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.mkdirSync(createdDir);
+    fs.writeFileSync(file, "created", "utf8");
+    applyDiffBlockToSnapshot(baseline, file, null, "created");
+    expect(baseline.get(file)?.candidate).toBe(false);
+    fs.rmSync(createdDir, { recursive: true });
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not report a surviving ignored structured creation as deleted", async () => {
+    const dir = gitRepo();
+    const file = path.join(dir, "ignored.txt");
+    fs.writeFileSync(path.join(dir, ".gitignore"), "ignored.txt\n", "utf8");
+    execFileSync("git", ["-C", dir, "add", ".gitignore"]);
+    const baseline = await snapshotWorkingTree([dir]);
+    fs.writeFileSync(file, "created", "utf8");
+    applyDiffBlockToSnapshot(baseline, file, null, "created");
+
+    const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+    expect(reflected).toEqual([]);
+    expect(unsupported).toEqual([]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "uses structured physical identity after an in-root symlink to outside is removed",
+    async () => {
+      const dir = gitRepo();
+      const outside = tmpDir();
+      const link = path.join(dir, "link");
+      const file = path.join(link, "outside.txt");
+      fs.symlinkSync(outside, link, "dir");
+      const baseline = await snapshotWorkingTree([dir]);
+      fs.writeFileSync(file, "created", "utf8");
+      applyDiffBlockToSnapshot(baseline, file, null, "created");
+      fs.rmSync(file);
+      fs.rmSync(link);
+
+      expect(await reconcileWorkingTree(baseline, [dir])).toEqual({ reflected: [], unsupported: [] });
+
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "reports an in-root structured file replaced by an outside symlink as deleted",
+    async () => {
+      const dir = gitRepo();
+      const outside = tmpDir();
+      const file = path.join(dir, "structured.txt");
+      const target = path.join(outside, "target.txt");
+      const baseline = await snapshotWorkingTree([dir]);
+      fs.writeFileSync(file, "created", "utf8");
+      fs.writeFileSync(target, "outside", "utf8");
+      applyDiffBlockToSnapshot(baseline, file, null, "created");
+      fs.rmSync(file);
+      fs.symlinkSync(target, file);
+
+      const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+      expect(reflected).toEqual([]);
+      expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
+      expect(fs.readFileSync(target, "utf8")).toBe("outside");
+
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "does not read through a replaced parent directory symlink",
+    async () => {
+      const dir = gitRepo();
+      const outside = tmpDir();
+      const createdDir = path.join(dir, "created");
+      const file = path.join(createdDir, "structured.txt");
+      const target = path.join(outside, "structured.txt");
+      const baseline = await snapshotWorkingTree([dir]);
+      fs.mkdirSync(createdDir);
+      fs.writeFileSync(file, "created", "utf8");
+      applyDiffBlockToSnapshot(baseline, file, null, "created");
+      fs.rmSync(createdDir, { recursive: true });
+      fs.writeFileSync(target, "outside secret", "utf8");
+      fs.symlinkSync(outside, createdDir, "dir");
+
+      const { reflected, unsupported } = await reconcileWorkingTree(baseline, [dir]);
+      expect(reflected).toEqual([]);
+      expect(unsupported).toEqual([{ path: file, reason: "deleted" }]);
+      expect(fs.readFileSync(target, "utf8")).toBe("outside secret");
+
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  );
+
   it("does not report structured-only baseline entries as deletions", async () => {
     const dir = gitRepo();
     const outside = tmpDir();

--- a/tests/edit-revert.test.ts
+++ b/tests/edit-revert.test.ts
@@ -22,9 +22,10 @@ describe("revertEditToolCall", () => {
     const file = path.join(dir, "a.txt");
     fs.writeFileSync(file, "new content", "utf8");
 
-    revertEditToolCall(diffToolCall([{ path: file, oldText: "old content", newText: "new content" }]));
+    const restored = revertEditToolCall(diffToolCall([{ path: file, oldText: "old content", newText: "new content" }]));
 
     expect(fs.readFileSync(file, "utf8")).toBe("old content");
+    expect(restored).toEqual([{ path: file, oldText: "old content", newText: "new content" }]);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
@@ -33,9 +34,10 @@ describe("revertEditToolCall", () => {
     const file = path.join(dir, "a.txt");
     fs.writeFileSync(file, "before\nNEW\nafter", "utf8");
 
-    revertEditToolCall(diffToolCall([{ path: file, oldText: "OLD", newText: "NEW" }]));
+    const restored = revertEditToolCall(diffToolCall([{ path: file, oldText: "OLD", newText: "NEW" }]));
 
     expect(fs.readFileSync(file, "utf8")).toBe("before\nOLD\nafter");
+    expect(restored).toEqual([{ path: file, oldText: "OLD", newText: "NEW" }]);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
@@ -44,9 +46,26 @@ describe("revertEditToolCall", () => {
     const file = path.join(dir, "new.txt");
     fs.writeFileSync(file, "created", "utf8");
 
-    revertEditToolCall(diffToolCall([{ path: file, oldText: null, newText: "created" }]));
+    const restored = revertEditToolCall(diffToolCall([{ path: file, oldText: null, newText: "created" }]));
 
     expect(fs.existsSync(file)).toBe(false);
+    expect(restored).toEqual([{ path: file, oldText: null, newText: "created" }]);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("restores only the blocks that still match when several target one file", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-revert-"));
+    const file = path.join(dir, "a.txt");
+    // Block two's newText is gone from disk, so only block one may be restored.
+    fs.writeFileSync(file, "one TWO", "utf8");
+
+    const restored = revertEditToolCall(diffToolCall([
+      { path: file, oldText: "ONE", newText: "one" },
+      { path: file, oldText: "two", newText: "diverged" }
+    ]));
+
+    expect(fs.readFileSync(file, "utf8")).toBe("ONE TWO");
+    expect(restored).toEqual([{ path: file, oldText: "ONE", newText: "one" }]);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
@@ -55,9 +74,10 @@ describe("revertEditToolCall", () => {
     const file = path.join(dir, "a.txt");
     fs.writeFileSync(file, "something else entirely", "utf8");
 
-    revertEditToolCall(diffToolCall([{ path: file, oldText: "old", newText: "new" }]));
+    const restored = revertEditToolCall(diffToolCall([{ path: file, oldText: "old", newText: "new" }]));
 
     expect(fs.readFileSync(file, "utf8")).toBe("something else entirely");
+    expect(restored).toEqual([]);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
@@ -65,7 +85,7 @@ describe("revertEditToolCall", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-revert-"));
     const file = path.join(dir, "gone.txt");
 
-    expect(() => revertEditToolCall(diffToolCall([{ path: file, oldText: "old", newText: "new" }]))).not.toThrow();
+    expect(revertEditToolCall(diffToolCall([{ path: file, oldText: "old", newText: "new" }]))).toEqual([]);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Description

Edits agy made outside a recognized structured-edit tool-call (shell commands via `run_command`, or edit payloads the translator does not decode) previously reached disk with no corresponding ACP diff update or client `fs/*` write-through. As a result Zed's Changes panel and Git showed files agy modified while the ACP bridge emitted nothing for them.

This adds a working-tree reconciler that runs around each turn. Its snapshot models exactly one thing: **the content the client has already been told each file holds**. Two invariants keep it out of the business of reimplementing agy's edit semantics or Git's ignore semantics:

1. **Content only enters the snapshot by reading disk.** When a recognized edit is reported, `src/agy/cli.ts` calls `observeEditedPaths` for its paths while disk still holds the reported content (before any write-through revert/replay, and again after a rejected edit is reverted — attributed by the reverse of the restored blocks, so only the restoration itself is treated as known). Nothing derives recorded content by replaying a diff block onto a remembered body, because a matcher cannot reliably reproduce what agy wrote and a wrong guess emits a duplicate or destructive synthetic edit. The reported blocks are used only to decide whether the bytes on disk were in fact reported: a whole-file write must equal disk, and a targeted replacement must reproduce disk exactly when applied to the recorded content. Anything else fails closed, so a change that reached the file before the tool-call was polled is still reported instead of absorbed.
2. **Files are keyed by physical identity (`fs.realpath`), and every path comparison is between strings produced by the same root spelling.** Aliased and overlapping workspace roots collapse to one entry instead of producing two ACP edits for one physical change, and no lexical `startsWith` ever compares a symlinked spelling against a canonical one.

### `src/agy/edit/reconcile.ts`

- `snapshotWorkingTree(roots)` resolves roots to `{ display, canonical }` (deduplicated by real path, first configured spelling retained), then enumerates files via `git ls-files --cached --others --exclude-standard` (tracked + untracked, honoring `.gitignore`, recursing into checked-out submodules as their own repository), with a bounded recursive-walk fallback for non-git roots. Records `{ path, canonicalPath, sha1, size, text }` per file; `text` is `null` for binary (NUL byte or invalid UTF-8) or oversized (>1 MiB, hashed as a stream) files. It also records `excluded`: the paths the listing deliberately skipped (gitignored entries, symlinks, the non-git skip list), so a file that only becomes visible when agy edits an ignore rule is reported as `previously-excluded` instead of invented as a creation whose pre-turn content was never captured.
- `observeEditedPaths(snapshot, paths)` re-reads the given paths from disk and records them as reported. Paths outside the configured roots are ignored.
- `reconcileWorkingTree(snapshot)` re-lists, aligns by canonical path, and returns `reflected` (added/modified text files) and `unsupported` (binary/oversized/deleted/previously-excluded). A baseline entry missing from the new listing is verified directly on disk against its recorded identity, so a newly ignored file is compared rather than misreported as deleted, and a path whose identity moved (a component replaced by a symlink) is reported as deleted without reading through it.
- `buildReconcileEditUpdate(...)` synthesizes a completed `kind:"edit"` `tool_call` `SessionUpdate` whose diff round-trips through the existing `diffBlocks`. IDs carry a per-turn UUID token so they stay unique across turns and session reloads.

### `src/agy/cli.ts` turn lifecycle

Both the interactive and print-mode paths snapshot the pre-edit tree at turn start, observe reported edits as they land, and at turn end reflect each remaining change via `onUpdate` plus the existing `routeEditThroughClient` write-through. Emitting the synthetic `session/update` needs no client filesystem capability, so it happens for every client (v1 and v2); the write-through is layered on only when a bridge is available. Changes that can't be represented as a text diff are reported through a bounded `[agy-acp] WARN` line rather than being silently dropped.

### Known limitations

- Attribution fails closed, so an unrecognized change that lands next to a targeted replacement before the tool-call is polled produces one extra synthetic edit alongside the structured one. Its `newText` is the true disk content, so the client still converges on disk.
- For a whole-file write, an unrecognized change to the same path earlier in the same turn is subsumed by the reported body (which equals disk), so it is not emitted separately.
- Deletions and binary/oversized edits are reported, not applied — the ACP fs write-through bridge only writes text. Propagating deletions would need a delete path in `edit/bridge.ts` (follow-up).
- A file that was gitignored at turn start is reported as `previously-excluded` rather than diffed, since its pre-turn content was never captured.

## Related Issues

Fixes #76

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass (303 passed)
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes (`tests/edit-reconcile.test.ts`, 48 tests; print-mode and rejected-edit regressions in `tests/cli.test.ts`)
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed



