### PR TITLE
Support queued follow-ups and steer-by-cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ pre-1.0 caveat that minor versions may include breaking changes. Starting with
 `1.0.0-alpha.0`, package pre-releases track ACP v2 draft work; the wire protocol
 for draft v2 may still change before ACP v2 stabilizes.
 
+## [0.4.2] - 2026-08-04
+
+Queued follow-up prompts and steer-by-cancel during active turns, background-task-aware turn completion, and stricter zero-prompt-injection content encoding.
+
+### Added
+
+- Opt-in extension semantics for overlapping `session/prompt` requests via `_meta["agy-acp/turnIntent"]`: `"queue"` stores the follow-up in a per-session FIFO and runs it after the active turn reaches idle; `"steer"` cancels the active turn, waits for the backend and conversation writes to settle, and runs the replacement. Prompts without an intent keep standard ACP overlap behavior and are rejected. (#50, #84)
+- Targeted cancellation of queued v2 prompts: the queue acceptance response returns `_meta["agy-acp/queuedPromptId"]`, which `session/cancel` accepts to cancel that item specifically. (#84)
+- Keep print-mode and interactive turns open while agy background tasks finish, draining their output instead of injecting synthetic follow-up prompts. (#68)
+
+### Changed
+
+- Forward only client-originated content to agy — text, URIs, resource bodies, and the native `@path` image transport — without adapter framing prose or omission notices, in both prompt encoding and display text.
+- Replay historical raw prompts verbatim, preserving leading and trailing whitespace; only fully-enveloped legacy tagged prompts are unwrapped into resource blocks. (#84)
+
+### Fixed
+
+- Cancellation races across queued, steered, and in-preparation turns: every turn claim is cancellable from admission, client-bound deliveries are bounded by the turn's cancellation, session teardown cannot be blocked by stalled client transports, and targeted queued cancels no longer fall back to session-wide aborts. (#84)
+
 ## [0.4.1] - 2026-07-31
 
 Support for the programmatic tool call `name` field in ACP v2, a bridge for `manage_task` permission requests, and clean formatting for upstream 402 quota limit errors.

--- a/README.md
+++ b/README.md
@@ -76,39 +76,6 @@ Zed / ACP client
 - **v1:** `session/load` replays history; `session/resume` reattaches without replay.
   **v2:** only `session/resume` — pass `replayFrom: { "type": "start" }` to replay.
 
-### Queued follow-ups and steering
-
-`agy-acp` supports an opt-in extension for overlapping `session/prompt` requests:
-
-```json
-{
-  "_meta": { "agy-acp/turnIntent": "queue" }
-}
-```
-
-`queue` stores the prompt in a per-session FIFO and runs it after the active
-turn reaches idle. Use `"steer"` instead to cancel the active turn, wait for
-its process and conversation writes to settle, and then run the new prompt.
-Steering is cancellation followed by a replacement turn, not modification of
-an in-flight model request. Prompts without `turnIntent` retain standard ACP
-overlap behavior and are rejected.
-
-Queued v1 prompts resolve with `stopReason: "cancelled"` when cancelled or when
-their session closes/deletes. Queued v2 prompts emit `state_update` with
-`state: "idle"` and `stopReason: "cancelled"`.
-
-A queued v2 acceptance response carries a cancellation handle:
-
-```json
-{
-  "_meta": { "agy-acp/queuedPromptId": "q-..." }
-}
-```
-
-Pass the same value as `_meta` on `session/cancel` to cancel that queued item
-specifically; a plain `session/cancel` still cancels the active turn (and any
-steer reservation) without touching the queue.
-
 Wire format decoding was cross-referenced with
 [shubzkothekar/antigravity-acp](https://github.com/shubzkothekar/antigravity-acp) (MIT);
 decoding code is our own.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ Zed / ACP client
 - **v1:** `session/load` replays history; `session/resume` reattaches without replay.
   **v2:** only `session/resume` — pass `replayFrom: { "type": "start" }` to replay.
 
+### Queued follow-ups and steering
+
+`agy-acp` supports an opt-in extension for overlapping `session/prompt` requests:
+
+```json
+{
+  "_meta": { "agy-acp/turnIntent": "queue" }
+}
+```
+
+`queue` stores the prompt in a per-session FIFO and runs it after the active
+turn reaches idle. Use `"steer"` instead to cancel the active turn, wait for
+its process and conversation writes to settle, and then run the new prompt.
+Steering is cancellation followed by a replacement turn, not modification of
+an in-flight model request. Prompts without `turnIntent` retain standard ACP
+overlap behavior and are rejected.
+
+Queued v1 prompts resolve with `stopReason: "cancelled"` when cancelled or when
+their session closes/deletes. Queued v2 prompts emit `state_update` with
+`state: "idle"` and `stopReason: "cancelled"`.
+
 Wire format decoding was cross-referenced with
 [shubzkothekar/antigravity-acp](https://github.com/shubzkothekar/antigravity-acp) (MIT);
 decoding code is our own.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ Queued v1 prompts resolve with `stopReason: "cancelled"` when cancelled or when
 their session closes/deletes. Queued v2 prompts emit `state_update` with
 `state: "idle"` and `stopReason: "cancelled"`.
 
+A queued v2 acceptance response carries a cancellation handle:
+
+```json
+{
+  "_meta": { "agy-acp/queuedPromptId": "q-..." }
+}
+```
+
+Pass the same value as `_meta` on `session/cancel` to cancel that queued item
+specifically; a plain `session/cancel` still cancels the active turn (and any
+steer reservation) without touching the queue.
+
 Wire format decoding was cross-referenced with
 [shubzkothekar/antigravity-acp](https://github.com/shubzkothekar/antigravity-acp) (MIT);
 decoding code is our own.

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -390,8 +390,8 @@ export class AcpAgent {
     return handlePromptV2(params, client, this.promptV2Deps());
   }
 
-  cancel(params: { sessionId: string }): Promise<void> {
-    return handleCancel(params.sessionId, this.#sessions);
+  cancel(params: { sessionId: string; _meta?: Record<string, unknown> | null }): Promise<void> {
+    return handleCancel(params.sessionId, this.#sessions, params._meta);
   }
 
   async closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {

--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -1,5 +1,10 @@
 // ACP Content: map prompt ContentBlock[] (text / image / resource) onto agy input.
 // Docs: https://agentclientprotocol.com/protocol/v1/content
+//
+// Only encodes blocks from the ACP client's session/prompt payload — never invents
+// conversational turns. Minimal structural framing is used so non-text blocks can
+// be represented as a single agy prompt string (images → @path; text resources
+// keep a short "Resource <uri>:" label around client-supplied body text).
 
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";

--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -1,10 +1,10 @@
 // ACP Content: map prompt ContentBlock[] (text / image / resource) onto agy input.
 // Docs: https://agentclientprotocol.com/protocol/v1/content
 //
-// Only encodes blocks from the ACP client's session/prompt payload — never invents
-// conversational turns. Minimal structural framing is used so non-text blocks can
-// be represented as a single agy prompt string (images → @path; text resources
-// keep a short "Resource <uri>:" label around client-supplied body text).
+// Zero prompt injection: every substring forwarded to agy must come from the ACP
+// client's session/prompt content (or be agy's native attachment transport for
+// client-provided image bytes). Never invent conversational labels, instructions,
+// follow-ups ("continue"), or framing prose around client data.
 
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
@@ -14,11 +14,22 @@ import type { ContentBlock } from "@agentclientprotocol/sdk";
 
 const ATTACHMENTS_DIR = ".agy-acp/attachments";
 
+/**
+ * Encode client ContentBlocks into a single agy prompt string.
+ *
+ * - text → block.text as-is
+ * - image / image resource → write bytes, reference with agy `@path` transport
+ * - resource_link (non-image) → uri only (client-supplied)
+ * - embedded text resource → resource.text only (client-supplied body)
+ * - non-image blobs → omitted (no invented "blob omitted" copy)
+ *
+ * Parts are joined with newlines; empty parts are dropped.
+ */
 export async function contentBlocksToPrompt(blocks: ContentBlock[], cwd: string): Promise<string> {
   const parts: string[] = [];
   for (const block of blocks) {
     if (block.type === "text") {
-      parts.push(block.text);
+      if (block.text.length > 0) parts.push(block.text);
       continue;
     }
 
@@ -35,31 +46,34 @@ export async function contentBlocksToPrompt(blocks: ContentBlock[], cwd: string)
     if (block.type === "resource_link") {
       if (isImageMimeType(block.mimeType) && block.uri) {
         parts.push(agyAttachmentReference(filePathFromUri(block.uri)));
-      } else {
-        parts.push(`Referenced resource: ${block.uri}`);
+      } else if (block.uri) {
+        // Client-supplied URI only — no adapter prose.
+        parts.push(block.uri);
       }
       continue;
     }
 
     if (block.type === "resource") {
-      parts.push(await resourceBlockToPrompt(block, cwd));
+      const encoded = await resourceBlockToPrompt(block, cwd);
+      if (encoded.length > 0) parts.push(encoded);
     }
   }
   return parts.join("\n");
 }
 
+/** Flatten client content to plain text for display/logging — no invented copy. */
 export function contentBlocksToText(blocks: ContentBlock[]): string {
   const parts: string[] = [];
   for (const block of blocks) {
     if (block.type === "text") {
-      parts.push(block.text);
+      if (block.text.length > 0) parts.push(block.text);
     } else if (block.type === "resource_link") {
-      parts.push(`Referenced resource: ${block.uri}`);
+      if (block.uri) parts.push(block.uri);
     } else if (block.type === "resource") {
-      parts.push(resourceBlockToText(block));
-    } else if (block.type === "image") {
-      parts.push(`[image: ${block.mimeType}]`);
+      const text = resourceBlockClientText(block);
+      if (text.length > 0) parts.push(text);
     }
+    // image blocks have no client text payload for display
   }
   return parts.join("\n");
 }
@@ -77,17 +91,22 @@ async function resourceBlockToPrompt(
     );
     return agyAttachmentReference(filePath);
   }
-  return resourceBlockToText(block);
+  return resourceBlockClientText(block);
 }
 
-function resourceBlockToText(block: Extract<ContentBlock, { type: "resource" }>): string {
+/** Client-authored body only; never wrap with URI labels or omission notices. */
+function resourceBlockClientText(block: Extract<ContentBlock, { type: "resource" }>): string {
   const resource = block.resource;
-  if ("text" in resource) {
-    return `Resource ${resource.uri}:\n${resource.text}`;
+  if ("text" in resource && typeof resource.text === "string") {
+    return resource.text;
   }
-  return `Resource ${resource.uri}: [${resource.mimeType ?? "application/octet-stream"} blob omitted]`;
+  return "";
 }
 
+/**
+ * agy native file-attachment transport for client-provided image bytes.
+ * `@` + absolute path is how agy attaches files — not conversational prose.
+ */
 function agyAttachmentReference(filePath: string): string {
   return `@${path.resolve(filePath)}`;
 }

--- a/src/acp/session/cancel.ts
+++ b/src/acp/session/cancel.ts
@@ -2,6 +2,7 @@
 // Docs: https://agentclientprotocol.com/protocol/v1/prompt-turn#cancellation
 
 import type { SessionState } from "./types.js";
+import { turnsOf } from "./turn-scheduler.js";
 import * as v2 from "@agentclientprotocol/sdk/experimental/v2";
 
 function cancelQueuedV2Prompt(
@@ -59,6 +60,8 @@ export async function handleCancel(
     }
   }
 
-  session.promptAbort?.abort();
+  // Aborts the running turn *and* any steer holding a reservation — a steer
+  // waiting for the previous turn to stop is still the user's turn to cancel.
+  turnsOf(session).abortAll();
   await session.agy.cancel();
 }

--- a/src/acp/session/cancel.ts
+++ b/src/acp/session/cancel.ts
@@ -2,9 +2,61 @@
 // Docs: https://agentclientprotocol.com/protocol/v1/prompt-turn#cancellation
 
 import type { SessionState } from "./types.js";
+import * as v2 from "@agentclientprotocol/sdk/experimental/v2";
 
-export async function handleCancel(sessionId: string, sessions: Map<string, SessionState>): Promise<void> {
+export async function cancelQueuedPrompts(session: SessionState): Promise<void> {
+  if (!Array.isArray(session.promptQueue)) return;
+  const items = session.promptQueue.splice(0, session.promptQueue.length);
+  for (const item of items) {
+    if (item.version === "v1") {
+      item.resolve({ stopReason: "cancelled" });
+    } else {
+      await item.client.notify(v2.methods.client.session.update, {
+        sessionId: item.params.sessionId,
+        update: {
+          sessionUpdate: "state_update",
+          state: "idle",
+          stopReason: "cancelled"
+        }
+      }).catch(() => {});
+      item.controller.abort();
+    }
+  }
+}
+
+export async function handleCancel(
+  sessionId: string,
+  sessions: Map<string, SessionState>,
+  meta?: Record<string, unknown> | null
+): Promise<void> {
   const session = sessions.get(sessionId);
-  session?.promptAbort?.abort();
-  await session?.agy.cancel();
+  if (!session) return;
+
+  const queuedPromptId = typeof meta?.["agy-acp/queuedPromptId"] === "string"
+    ? meta["agy-acp/queuedPromptId"]
+    : undefined;
+
+  if (queuedPromptId) {
+    const idx = session.promptQueue.findIndex((q) => q.id === queuedPromptId);
+    if (idx >= 0) {
+      const [removed] = session.promptQueue.splice(idx, 1);
+      if (removed.version === "v1") {
+        removed.resolve({ stopReason: "cancelled" });
+      } else {
+        await removed.client.notify(v2.methods.client.session.update, {
+          sessionId: removed.params.sessionId,
+          update: {
+            sessionUpdate: "state_update",
+            state: "idle",
+            stopReason: "cancelled"
+          }
+        }).catch(() => {});
+        removed.controller.abort();
+      }
+      return;
+    }
+  }
+
+  session.promptAbort?.abort();
+  await session.agy.cancel();
 }

--- a/src/acp/session/cancel.ts
+++ b/src/acp/session/cancel.ts
@@ -4,22 +4,32 @@
 import type { SessionState } from "./types.js";
 import * as v2 from "@agentclientprotocol/sdk/experimental/v2";
 
-export async function cancelQueuedPrompts(session: SessionState): Promise<void> {
+function cancelQueuedV2Prompt(
+  item: Extract<SessionState["promptQueue"][number], { version: "v2" }>
+): void {
+  item.controller.abort();
+  try {
+    void item.client.notify(v2.methods.client.session.update, {
+      sessionId: item.params.sessionId,
+      update: {
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: "cancelled"
+      }
+    }).catch(() => {});
+  } catch {
+    // Cancellation notifications are best effort during teardown.
+  }
+}
+
+export function cancelQueuedPrompts(session: SessionState): void {
   if (!Array.isArray(session.promptQueue)) return;
   const items = session.promptQueue.splice(0, session.promptQueue.length);
   for (const item of items) {
     if (item.version === "v1") {
       item.resolve({ stopReason: "cancelled" });
     } else {
-      await item.client.notify(v2.methods.client.session.update, {
-        sessionId: item.params.sessionId,
-        update: {
-          sessionUpdate: "state_update",
-          state: "idle",
-          stopReason: "cancelled"
-        }
-      }).catch(() => {});
-      item.controller.abort();
+      cancelQueuedV2Prompt(item);
     }
   }
 }
@@ -43,15 +53,7 @@ export async function handleCancel(
       if (removed.version === "v1") {
         removed.resolve({ stopReason: "cancelled" });
       } else {
-        await removed.client.notify(v2.methods.client.session.update, {
-          sessionId: removed.params.sessionId,
-          update: {
-            sessionUpdate: "state_update",
-            state: "idle",
-            stopReason: "cancelled"
-          }
-        }).catch(() => {});
-        removed.controller.abort();
+        cancelQueuedV2Prompt(removed);
       }
       return;
     }

--- a/src/acp/session/cancel.ts
+++ b/src/acp/session/cancel.ts
@@ -28,6 +28,7 @@ export function cancelQueuedPrompts(session: SessionState): void {
   const items = session.promptQueue.splice(0, session.promptQueue.length);
   for (const item of items) {
     if (item.version === "v1") {
+      item.detachQueueCancel?.();
       item.resolve({ stopReason: "cancelled" });
     } else {
       cancelQueuedV2Prompt(item);
@@ -52,6 +53,7 @@ export async function handleCancel(
     if (idx >= 0) {
       const [removed] = session.promptQueue.splice(idx, 1);
       if (removed.version === "v1") {
+        removed.detachQueueCancel?.();
         removed.resolve({ stopReason: "cancelled" });
       } else {
         cancelQueuedV2Prompt(removed);

--- a/src/acp/session/cancel.ts
+++ b/src/acp/session/cancel.ts
@@ -58,6 +58,14 @@ export async function handleCancel(
       }
       return;
     }
+    // The item may already have left the FIFO and claimed the turn slot: abort
+    // exactly that claim — never unrelated turns or steer reservations. A
+    // stale id matches nothing and must not fall back to a global abort.
+    const claimed = turnsOf(session).activeClaim;
+    if (claimed?.tag === queuedPromptId) {
+      claimed.abort();
+    }
+    return;
   }
 
   // Aborts the running turn *and* any steer holding a reservation — a steer

--- a/src/acp/session/close.ts
+++ b/src/acp/session/close.ts
@@ -6,6 +6,7 @@ import type { SessionDeleteTarget } from "./delete.js";
 
 import type { SessionState } from "./types.js";
 import { cancelQueuedPrompts } from "./cancel.js";
+import { wakePromptIdleWaiters } from "./prompt.js";
 
 export async function handleCloseSession(
   params: CloseSessionRequest,
@@ -15,6 +16,8 @@ export async function handleCloseSession(
   activeSessions.delete(params.sessionId);
   if (session) {
     (session as SessionState).closed = true;
+    // Unblock any steer waiter before teardown so it observes `closed`.
+    wakePromptIdleWaiters(session as SessionState);
     await cancelQueuedPrompts(session as SessionState);
     session.promptAbort?.abort();
     await session.agy.close();

--- a/src/acp/session/close.ts
+++ b/src/acp/session/close.ts
@@ -14,6 +14,7 @@ export async function handleCloseSession(
   const session = activeSessions.get(params.sessionId);
   activeSessions.delete(params.sessionId);
   if (session) {
+    (session as SessionState).closed = true;
     await cancelQueuedPrompts(session as SessionState);
     session.promptAbort?.abort();
     await session.agy.close();

--- a/src/acp/session/close.ts
+++ b/src/acp/session/close.ts
@@ -6,7 +6,7 @@ import type { SessionDeleteTarget } from "./delete.js";
 
 import type { SessionState } from "./types.js";
 import { cancelQueuedPrompts } from "./cancel.js";
-import { wakePromptIdleWaiters } from "./prompt.js";
+import { turnsOf } from "./turn-scheduler.js";
 
 export async function handleCloseSession(
   params: CloseSessionRequest,
@@ -16,9 +16,9 @@ export async function handleCloseSession(
   activeSessions.delete(params.sessionId);
   if (session) {
     (session as SessionState).closed = true;
-    // Unblock any steer waiter before teardown so it observes `closed`.
-    wakePromptIdleWaiters(session as SessionState);
-    session.promptAbort?.abort();
+    // Abort running turns and steer reservations before touching the backend,
+    // so a stalled client transport cannot delay teardown.
+    turnsOf(session as SessionState).close();
     cancelQueuedPrompts(session as SessionState);
     await session.agy.close();
   }

--- a/src/acp/session/close.ts
+++ b/src/acp/session/close.ts
@@ -18,8 +18,8 @@ export async function handleCloseSession(
     (session as SessionState).closed = true;
     // Unblock any steer waiter before teardown so it observes `closed`.
     wakePromptIdleWaiters(session as SessionState);
-    await cancelQueuedPrompts(session as SessionState);
     session.promptAbort?.abort();
+    cancelQueuedPrompts(session as SessionState);
     await session.agy.close();
   }
   return {};

--- a/src/acp/session/close.ts
+++ b/src/acp/session/close.ts
@@ -4,13 +4,19 @@
 import type { CloseSessionRequest, CloseSessionResponse } from "@agentclientprotocol/sdk";
 import type { SessionDeleteTarget } from "./delete.js";
 
+import type { SessionState } from "./types.js";
+import { cancelQueuedPrompts } from "./cancel.js";
+
 export async function handleCloseSession(
   params: CloseSessionRequest,
   activeSessions: Map<string, SessionDeleteTarget>
 ): Promise<CloseSessionResponse> {
   const session = activeSessions.get(params.sessionId);
   activeSessions.delete(params.sessionId);
-  session?.promptAbort?.abort();
-  await session?.agy.close();
+  if (session) {
+    await cancelQueuedPrompts(session as SessionState);
+    session.promptAbort?.abort();
+    await session.agy.close();
+  }
   return {};
 }

--- a/src/acp/session/delete.ts
+++ b/src/acp/session/delete.ts
@@ -3,6 +3,8 @@
 
 import type { DeleteSessionRequest, DeleteSessionResponse } from "@agentclientprotocol/sdk";
 import type { SessionStore } from "./store.js";
+import type { SessionState } from "./types.js";
+import { cancelQueuedPrompts } from "./cancel.js";
 
 export interface SessionDeleteTarget {
   promptAbort?: AbortController | null;
@@ -22,6 +24,9 @@ export async function handleDeleteSession(
 ): Promise<DeleteSessionResponse> {
   const session = activeSessions.get(params.sessionId);
   activeSessions.delete(params.sessionId);
+  if (session) {
+    await cancelQueuedPrompts(session as SessionState);
+  }
   session?.promptAbort?.abort();
   await session?.agy.close();
   await store.delete(params.sessionId);

--- a/src/acp/session/delete.ts
+++ b/src/acp/session/delete.ts
@@ -25,6 +25,7 @@ export async function handleDeleteSession(
   const session = activeSessions.get(params.sessionId);
   activeSessions.delete(params.sessionId);
   if (session) {
+    (session as SessionState).closed = true;
     await cancelQueuedPrompts(session as SessionState);
   }
   session?.promptAbort?.abort();

--- a/src/acp/session/delete.ts
+++ b/src/acp/session/delete.ts
@@ -5,10 +5,10 @@ import type { DeleteSessionRequest, DeleteSessionResponse } from "@agentclientpr
 import type { SessionStore } from "./store.js";
 import type { SessionState } from "./types.js";
 import { cancelQueuedPrompts } from "./cancel.js";
-import { wakePromptIdleWaiters } from "./prompt.js";
+import { turnsOf, type TurnScheduler } from "./turn-scheduler.js";
 
 export interface SessionDeleteTarget {
-  promptAbort?: AbortController | null;
+  turns?: TurnScheduler;
   agy: { close(): Promise<void> };
 }
 
@@ -27,9 +27,8 @@ export async function handleDeleteSession(
   activeSessions.delete(params.sessionId);
   if (session) {
     (session as SessionState).closed = true;
-    // Unblock any steer waiter before teardown so it observes `closed`.
-    wakePromptIdleWaiters(session as SessionState);
-    session.promptAbort?.abort();
+    // Abort running turns and steer reservations before touching the backend.
+    turnsOf(session as SessionState).close();
     cancelQueuedPrompts(session as SessionState);
   }
   await session?.agy.close();

--- a/src/acp/session/delete.ts
+++ b/src/acp/session/delete.ts
@@ -29,9 +29,9 @@ export async function handleDeleteSession(
     (session as SessionState).closed = true;
     // Unblock any steer waiter before teardown so it observes `closed`.
     wakePromptIdleWaiters(session as SessionState);
-    await cancelQueuedPrompts(session as SessionState);
+    session.promptAbort?.abort();
+    cancelQueuedPrompts(session as SessionState);
   }
-  session?.promptAbort?.abort();
   await session?.agy.close();
   await store.delete(params.sessionId);
   return {};

--- a/src/acp/session/delete.ts
+++ b/src/acp/session/delete.ts
@@ -5,6 +5,7 @@ import type { DeleteSessionRequest, DeleteSessionResponse } from "@agentclientpr
 import type { SessionStore } from "./store.js";
 import type { SessionState } from "./types.js";
 import { cancelQueuedPrompts } from "./cancel.js";
+import { wakePromptIdleWaiters } from "./prompt.js";
 
 export interface SessionDeleteTarget {
   promptAbort?: AbortController | null;
@@ -26,6 +27,8 @@ export async function handleDeleteSession(
   activeSessions.delete(params.sessionId);
   if (session) {
     (session as SessionState).closed = true;
+    // Unblock any steer waiter before teardown so it observes `closed`.
+    wakePromptIdleWaiters(session as SessionState);
     await cancelQueuedPrompts(session as SessionState);
   }
   session?.promptAbort?.abort();

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -28,7 +28,7 @@ import {
 import { MODEL_CONFIG_ID } from "./config-options.js";
 import { MODE_CONFIG_ID } from "./modes.js";
 import { requestPermissionV1, requestPermissionV2 } from "./request-permission.js";
-import type { SessionState } from "./types.js";
+import type { QueuedPromptV1, QueuedPromptV2, SessionState, TurnIntent } from "./types.js";
 import { createTerminalOutputTracker, createToolCallContentTracker, expandSessionUpdateToV2, sessionUpdateToV1 } from "./update-wire.js";
 
 export interface PromptTurnDeps {
@@ -49,6 +49,46 @@ export interface PromptV2Deps extends PromptTurnDeps {
   notifyConfigOptionUpdateV2(client: V2AgentContext, sessionId: string, session: SessionState): Promise<void>;
   clientElicitationV2?(client: V2AgentContext): ClientElicitationCapability | undefined;
   clientToolCallNameV2?(client: V2AgentContext): ClientToolCallNameCapability | undefined;
+}
+
+export function parseTurnIntent(params: unknown): TurnIntent | undefined {
+  if (!params || typeof params !== "object") return undefined;
+  const meta = (params as Record<string, unknown>)._meta;
+  if (!meta || typeof meta !== "object") return undefined;
+  const intent = (meta as Record<string, unknown>)["agy-acp/turnIntent"];
+  if (intent === "queue" || intent === "steer") return intent;
+  return undefined;
+}
+
+export function notifyIdleAndDrainQueue(session: SessionState): void {
+  const notify = session.promptIdleNotify;
+  session.promptIdleNotify = undefined;
+  if (notify) {
+    notify();
+    return;
+  }
+
+  if (!session.activePrompt && session.promptQueue.length > 0) {
+    const next = session.promptQueue.shift()!;
+    if (next.version === "v1") {
+      if (next.signal?.aborted) {
+        next.resolve({ stopReason: "cancelled" });
+        notifyIdleAndDrainQueue(session);
+        return;
+      }
+      void executeQueuedV1Turn(next);
+    } else {
+      if (next.controller.signal.aborted) {
+        void next.client.notify(v2.methods.client.session.update, {
+          sessionId: next.params.sessionId,
+          update: { sessionUpdate: "state_update", state: "idle", stopReason: "cancelled" }
+        }).catch(() => {});
+        notifyIdleAndDrainQueue(session);
+        return;
+      }
+      void executeQueuedV2Turn(next);
+    }
+  }
 }
 
 /**
@@ -113,7 +153,49 @@ export async function handlePromptV1(
 ): Promise<V1PromptResponse> {
   const session = deps.requireSession(params.sessionId);
   if (session.activePrompt) {
-    throw new Error(`Session already has an active prompt: ${params.sessionId}`);
+    const intent = parseTurnIntent(params);
+    if (intent === "queue") {
+      return new Promise<V1PromptResponse>((resolve, reject) => {
+        const queuedId = `q-${randomUUID()}`;
+        const queued: QueuedPromptV1 = {
+          id: queuedId,
+          version: "v1",
+          params,
+          client,
+          signal,
+          deps,
+          resolve,
+          reject
+        };
+        session.promptQueue.push(queued);
+        if (signal) {
+          const onAbort = () => {
+            const idx = session.promptQueue.findIndex((q) => q.id === queuedId);
+            if (idx >= 0) {
+              session.promptQueue.splice(idx, 1);
+              resolve({ stopReason: "cancelled" });
+            }
+          };
+          signal.addEventListener("abort", onAbort, { once: true });
+        }
+      });
+    }
+
+    if (intent === "steer") {
+      session.promptAbort?.abort();
+      await session.agy.cancel();
+      if (session.activePrompt) {
+        await new Promise<void>((resolve) => {
+          const prevNotify = session.promptIdleNotify;
+          session.promptIdleNotify = () => {
+            prevNotify?.();
+            resolve();
+          };
+        });
+      }
+    } else {
+      throw new Error(`Session already has an active prompt: ${params.sessionId}`);
+    }
   }
 
   const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
@@ -186,6 +268,77 @@ export async function handlePromptV1(
   } finally {
     signal?.removeEventListener("abort", cancelPrompt);
     session.activePrompt = false;
+    notifyIdleAndDrainQueue(session);
+  }
+}
+
+async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
+  const { params, client, signal, deps, resolve, reject } = item;
+  const session = deps.requireSession(params.sessionId);
+  session.activePrompt = true;
+
+  try {
+    const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
+
+    const handled = await applyCuratedSlashCommand(
+      params.sessionId,
+      prompt,
+      {
+        modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
+        configChanged: async () => {
+          await deps.notifyConfigOptionUpdateV1(
+            client,
+            params.sessionId,
+            deps.requireSession(params.sessionId)
+          );
+        }
+      },
+      deps
+    );
+    if (handled) {
+      resolve({ stopReason: signal?.aborted ? "cancelled" : "end_turn" });
+      return;
+    }
+
+    const cancelPrompt = () => {
+      session.agy.cancel().catch(() => {});
+    };
+    signal?.addEventListener("abort", cancelPrompt, { once: true });
+
+    try {
+      const tracker = createTerminalOutputTracker();
+      const clientToolCallName = deps.clientToolCallNameV1?.(client);
+      const outcome = await session.agy.prompt(prompt, async (update) => {
+        await client.notify(v1.methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: sessionUpdateToV1(update, tracker, { clientToolCallName })
+        });
+      }, async (toolCall, { toolName, questionIndex }) => {
+        const elicitationCap = deps.clientElicitationV1?.(client);
+        return requestPermissionV1(
+          client,
+          params.sessionId,
+          toolCall,
+          toolName,
+          signal,
+          questionIndex,
+          elicitationCap,
+          clientToolCallName
+        );
+      }, deps.clientFileSystemV1(client, params.sessionId), deps.clientElicitationV1?.(client));
+      await deps.persistSession(params.sessionId, session);
+      resolve({
+        stopReason: outcome.stopReason === "cancelled" || signal?.aborted ? "cancelled" : "end_turn"
+      });
+    } finally {
+      signal?.removeEventListener("abort", cancelPrompt);
+    }
+  } catch (error) {
+    await deps.persistSession(params.sessionId, session).catch(() => {});
+    reject(error as Error);
+  } finally {
+    session.activePrompt = false;
+    notifyIdleAndDrainQueue(session);
   }
 }
 
@@ -203,7 +356,59 @@ export async function handlePromptV2(
 ): Promise<V2PromptResponse> {
   const session = deps.requireSession(params.sessionId);
   if (session.activePrompt) {
-    throw new Error(`Session already has an active prompt: ${params.sessionId}`);
+    const intent = parseTurnIntent(params);
+    if (intent === "queue") {
+      const promptText = await contentBlocksToPrompt(params.prompt as v1.ContentBlock[], session.cwd);
+      const parsedSlash = parseSlashCommand(promptText);
+      const slashResult = parsedSlash ? interpretSlashCommand(parsedSlash) : null;
+      const userMessageId =
+        slashResult && slashResult.kind !== "pass"
+          ? `slash-${randomUUID()}`
+          : `user-${randomUUID()}`;
+
+      await client.notify(v2.methods.client.session.update, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "user_message",
+          messageId: userMessageId,
+          content: params.prompt as v2.ContentBlock[]
+        }
+      });
+
+      const controller = new AbortController();
+      const queuedId = `q-${randomUUID()}`;
+      const queued: QueuedPromptV2 = {
+        id: queuedId,
+        version: "v2",
+        params,
+        client,
+        promptText,
+        userMessageId,
+        controller,
+        deps
+      };
+      session.promptQueue.push(queued);
+      if (!session.activePrompt) {
+        notifyIdleAndDrainQueue(session);
+      }
+      return {};
+    }
+
+    if (intent === "steer") {
+      session.promptAbort?.abort();
+      await session.agy.cancel();
+      if (session.activePrompt) {
+        await new Promise<void>((resolve) => {
+          const prevNotify = session.promptIdleNotify;
+          session.promptIdleNotify = () => {
+            prevNotify?.();
+            resolve();
+          };
+        });
+      }
+    } else {
+      throw new Error(`Session already has an active prompt: ${params.sessionId}`);
+    }
   }
 
   // Content block shapes are compatible at runtime; v1/v2 TS types diverge on open enums.
@@ -228,9 +433,123 @@ export async function handlePromptV2(
         session.promptAbort = undefined;
       }
       session.activePrompt = false;
+      notifyIdleAndDrainQueue(session);
     });
 
   return {};
+}
+
+async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
+  const { params, client, promptText, userMessageId, controller, deps } = item;
+  const session = deps.requireSession(params.sessionId);
+  session.activePrompt = true;
+  session.promptAbort = controller;
+
+  const notify = async (update: v2.SessionUpdate) => {
+    await client.notify(v2.methods.client.session.update, {
+      sessionId: params.sessionId,
+      update
+    });
+  };
+
+  const signal = controller.signal;
+  try {
+    signal.throwIfAborted();
+
+    // user_message was already sent at enqueue time.
+    await notify({ sessionUpdate: "state_update", state: "running" });
+
+    const slashHandled = await applyCuratedSlashCommand(
+      params.sessionId,
+      promptText,
+      {
+        configChanged: async () => {
+          await deps.notifyConfigOptionUpdateV2(client, params.sessionId, deps.requireSession(params.sessionId));
+        }
+      },
+      deps
+    );
+    if (slashHandled) {
+      await notify({
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: signal.aborted ? "cancelled" : "end_turn"
+      });
+      return;
+    }
+
+    const cancelPrompt = () => {
+      session.agy.cancel().catch(() => {});
+    };
+    signal.addEventListener("abort", cancelPrompt, { once: true });
+
+    try {
+      const terminalTracker = createTerminalOutputTracker();
+      const toolContentTracker = createToolCallContentTracker();
+      const clientToolCallName = deps.clientToolCallNameV2?.(client);
+      const outcome = await (async () => {
+        try {
+          return await session.agy.prompt(promptText, async (update) => {
+            for (const v2Update of expandSessionUpdateToV2(update, terminalTracker, toolContentTracker, { clientToolCallName })) {
+              await notify(v2Update);
+            }
+          }, async (toolCall, { toolName, questionIndex }) => {
+            const elicitationCap = deps.clientElicitationV2?.(client);
+            return requestPermissionV2(
+              client,
+              params.sessionId,
+              toolCall,
+              toolName,
+              signal,
+              questionIndex,
+              elicitationCap,
+              clientToolCallName
+            );
+          }, undefined, deps.clientElicitationV2?.(client));
+        } finally {
+          const userStepIdxs = session.agy.lastPromptUserStepIdxs;
+          if (userStepIdxs.length > 1) {
+            throw new Error(`Expected at most one user step for a prompt, observed: ${userStepIdxs.join(", ")}`);
+          }
+          if (userStepIdxs.length === 1) {
+            session.v2UserMessageIdsByStep[String(userStepIdxs[0])] = userMessageId;
+          }
+        }
+      })();
+      await deps.persistSession(params.sessionId, session);
+
+      const stopReason =
+        outcome.stopReason === "cancelled" || signal.aborted ? "cancelled" : "end_turn";
+      await notify({
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason
+      });
+    } finally {
+      signal.removeEventListener("abort", cancelPrompt);
+    }
+  } catch (error) {
+    await deps.persistSession(params.sessionId, session).catch(() => {});
+    if (signal.aborted) {
+      await notify({
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: "cancelled"
+      });
+      return;
+    }
+    await notify({
+      sessionUpdate: "state_update",
+      state: "idle",
+      stopReason: "end_turn"
+    });
+  } finally {
+    if (session.promptAbort === controller) {
+      session.promptAbort = undefined;
+    }
+    session.activePrompt = false;
+    notifyIdleAndDrainQueue(session);
+  }
 }
 
 async function runV2PromptTurn(

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -60,6 +60,11 @@ export function parseTurnIntent(params: unknown): TurnIntent | undefined {
   return undefined;
 }
 
+/** True when a turn is running or a steer has reserved the next turn. */
+export function sessionTurnBusy(session: SessionState): boolean {
+  return session.activePrompt || (session.steerClaims ?? 0) > 0;
+}
+
 export function notifyIdleAndDrainQueue(session: SessionState): void {
   const notify = session.promptIdleNotify;
   session.promptIdleNotify = undefined;
@@ -80,7 +85,9 @@ export function notifyIdleAndDrainQueue(session: SessionState): void {
         notifyIdleAndDrainQueue(session);
         return;
       }
-      void executeQueuedV1Turn(next);
+      void executeQueuedV1Turn(next).catch((error) => {
+        console.error(`[agy-acp] queued v1 turn failed: ${(error as Error).message}`);
+      });
     } else {
       if (next.controller.signal.aborted) {
         void next.client.notify(v2.methods.client.session.update, {
@@ -90,7 +97,9 @@ export function notifyIdleAndDrainQueue(session: SessionState): void {
         notifyIdleAndDrainQueue(session);
         return;
       }
-      void executeQueuedV2Turn(next);
+      void executeQueuedV2Turn(next).catch((error) => {
+        console.error(`[agy-acp] queued v2 turn failed: ${(error as Error).message}`);
+      });
     }
   }
 }
@@ -186,7 +195,7 @@ export async function handlePromptV1(
   deps: PromptV1Deps
 ): Promise<V1PromptResponse> {
   const session = deps.requireSession(params.sessionId);
-  if (session.activePrompt) {
+  if (sessionTurnBusy(session)) {
     const intent = parseTurnIntent(params);
     if (intent === "queue") {
       return new Promise<V1PromptResponse>((resolve, reject) => {
@@ -211,6 +220,7 @@ export async function handlePromptV1(
             }
           };
           signal.addEventListener("abort", onAbort, { once: true });
+          if (signal.aborted) onAbort();
         }
       });
     }
@@ -223,7 +233,7 @@ export async function handlePromptV1(
   // setup failures and slash-only turns — so release + queue drain always run.
   let releaseSteer: (() => void) | undefined;
   try {
-    if (session.activePrompt) {
+    if (sessionTurnBusy(session)) {
       // Reserve before any await so a queued follow-up cannot claim the session.
       releaseSteer = await acquireSteerSlot(session);
       const waitForIdle = session.activePrompt
@@ -329,8 +339,19 @@ async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
   const session = deps.requireSession(params.sessionId);
   session.activePrompt = true;
 
+  const cancelled = () => Boolean(signal?.aborted || session.closed);
+
   try {
+    if (cancelled()) {
+      resolve({ stopReason: "cancelled" });
+      return;
+    }
+
     const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
+    if (cancelled()) {
+      resolve({ stopReason: "cancelled" });
+      return;
+    }
 
     const handled =
       isClientTextSlashPrompt(params.prompt) &&
@@ -350,7 +371,12 @@ async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
         deps
       ));
     if (handled) {
-      resolve({ stopReason: signal?.aborted ? "cancelled" : "end_turn" });
+      resolve({ stopReason: cancelled() ? "cancelled" : "end_turn" });
+      return;
+    }
+
+    if (cancelled()) {
+      resolve({ stopReason: "cancelled" });
       return;
     }
 
@@ -358,6 +384,13 @@ async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
       session.agy.cancel().catch(() => {});
     };
     signal?.addEventListener("abort", cancelPrompt, { once: true });
+    // Listener only fires for future aborts; honor an already-aborted signal.
+    if (signal?.aborted) {
+      signal.removeEventListener("abort", cancelPrompt);
+      cancelPrompt();
+      resolve({ stopReason: "cancelled" });
+      return;
+    }
 
     try {
       const tracker = createTerminalOutputTracker();
@@ -380,15 +413,24 @@ async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
           clientToolCallName
         );
       }, deps.clientFileSystemV1(client, params.sessionId), deps.clientElicitationV1?.(client));
-      await deps.persistSession(params.sessionId, session);
+      if (!session.closed) {
+        await deps.persistSession(params.sessionId, session);
+      }
       resolve({
-        stopReason: outcome.stopReason === "cancelled" || signal?.aborted ? "cancelled" : "end_turn"
+        stopReason:
+          outcome.stopReason === "cancelled" || cancelled() ? "cancelled" : "end_turn"
       });
     } finally {
       signal?.removeEventListener("abort", cancelPrompt);
     }
   } catch (error) {
-    await deps.persistSession(params.sessionId, session).catch(() => {});
+    if (!session.closed && !signal?.aborted) {
+      await deps.persistSession(params.sessionId, session).catch(() => {});
+    }
+    if (cancelled()) {
+      resolve({ stopReason: "cancelled" });
+      return;
+    }
     reject(error as Error);
   } finally {
     session.activePrompt = false;
@@ -409,10 +451,18 @@ export async function handlePromptV2(
   deps: PromptV2Deps
 ): Promise<V2PromptResponse> {
   const session = deps.requireSession(params.sessionId);
-  if (session.activePrompt) {
+  if (sessionTurnBusy(session)) {
     const intent = parseTurnIntent(params);
     if (intent === "queue") {
       const promptText = await contentBlocksToPrompt(params.prompt as v1.ContentBlock[], session.cwd);
+      if (session.closed) {
+        await client.notify(v2.methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "state_update", state: "idle", stopReason: "cancelled" }
+        }).catch(() => {});
+        return {};
+      }
+
       const parsedSlash = isClientTextSlashPrompt(params.prompt as v1.ContentBlock[])
         ? parseSlashCommand(promptText)
         : null;
@@ -431,6 +481,15 @@ export async function handlePromptV2(
         }
       });
 
+      // Cleanup may have drained the queue while user_message was in flight.
+      if (session.closed) {
+        await client.notify(v2.methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "state_update", state: "idle", stopReason: "cancelled" }
+        }).catch(() => {});
+        return {};
+      }
+
       const controller = new AbortController();
       const queuedId = `q-${randomUUID()}`;
       const queued: QueuedPromptV2 = {
@@ -444,7 +503,7 @@ export async function handlePromptV2(
         deps
       };
       session.promptQueue.push(queued);
-      if (!session.activePrompt) {
+      if (!sessionTurnBusy(session)) {
         notifyIdleAndDrainQueue(session);
       }
       return {};
@@ -458,7 +517,7 @@ export async function handlePromptV2(
   // Once the async turn is scheduled, its finally owns release + drain.
   let turnScheduled = false;
   try {
-    if (session.activePrompt) {
+    if (sessionTurnBusy(session)) {
       // Reserve before any await so a queued follow-up cannot claim the session.
       releaseSteer = await acquireSteerSlot(session);
       const waitForIdle = session.activePrompt

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -590,7 +590,7 @@ function enqueueV1(
 async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
   const { params, client, signal, deps, resolve, reject } = item;
   const session = deps.requireSession(params.sessionId);
-  const claim = turnsOf(session).claimIdle("queued", signal);
+  const claim = turnsOf(session).claimIdle("queued", signal, item.id);
 
   await completeTurn(
     session,
@@ -792,7 +792,7 @@ function enqueueV2(
 async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
   const { params, client, controller, deps } = item;
   const session = deps.requireSession(params.sessionId);
-  const claim = turnsOf(session).claimIdle("queued", controller.signal);
+  const claim = turnsOf(session).claimIdle("queued", controller.signal, item.id);
   const emitTerminal = v2TerminalEmitter(client, params.sessionId, session, claim);
 
   // Cancelling this turn must also abort preparation: if user_message

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -569,11 +569,13 @@ async function runSteeredV2Turn(
 
     session.activePrompt = true;
     ownsActivePrompt = true;
+    controller = new AbortController();
+    session.promptAbort = controller;
     const promptText = await contentBlocksToPrompt(
       params.prompt as v1.ContentBlock[],
       session.cwd
     );
-    if (session.closed) {
+    if (controller.signal.aborted || session.closed) {
       notifyV2BestEffort(client, params.sessionId, {
         sessionUpdate: "state_update",
         state: "idle",
@@ -582,8 +584,6 @@ async function runSteeredV2Turn(
       return;
     }
 
-    controller = new AbortController();
-    session.promptAbort = controller;
     await runV2PromptTurn(params, client, session, promptText, controller.signal, deps);
   } finally {
     if (controller && session.promptAbort === controller) {
@@ -703,11 +703,13 @@ export async function handlePromptV2(
   // Claim an idle session before attachment conversion. Once scheduled, the
   // detached turn owns this claim and releases it from its finalizer.
   session.activePrompt = true;
+  const controller = new AbortController();
+  session.promptAbort = controller;
   let turnScheduled = false;
   try {
     // Content block shapes are compatible at runtime; v1/v2 TS types diverge on open enums.
     const promptText = await contentBlocksToPrompt(params.prompt as v1.ContentBlock[], session.cwd);
-    if (session.closed) {
+    if (controller.signal.aborted || session.closed) {
       notifyV2BestEffort(client, params.sessionId, {
         sessionUpdate: "state_update",
         state: "idle",
@@ -715,8 +717,6 @@ export async function handlePromptV2(
       });
       return {};
     }
-    const controller = new AbortController();
-    session.promptAbort = controller;
 
     // Queue the empty acceptance response before any session/update from the turn.
     // Work starts on the next event-loop task (see dual-version-agent example).
@@ -743,6 +743,9 @@ export async function handlePromptV2(
   } finally {
     // Setup failed or closed before the async turn was scheduled.
     if (!turnScheduled) {
+      if (session.promptAbort === controller) {
+        session.promptAbort = undefined;
+      }
       session.activePrompt = false;
       notifyIdleAndDrainQueue(session);
     }

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -267,11 +267,16 @@ export async function handlePromptV1(
   // setup failures and slash-only turns — so release + queue drain always run.
   let releaseSteer: (() => void) | undefined;
   let ownsActivePrompt = false;
-  const cancelled = () => Boolean(signal?.aborted || session.closed);
+  let turnController: AbortController | undefined;
+  const cancelled = () => Boolean(
+    signal?.aborted || turnController?.signal.aborted || session.closed
+  );
   if (!busyAtAdmission) {
     // Claim an idle session before attachment conversion or config awaits.
     session.activePrompt = true;
     ownsActivePrompt = true;
+    turnController = new AbortController();
+    session.promptAbort = turnController;
   }
   try {
     if (busyAtAdmission) {
@@ -299,6 +304,8 @@ export async function handlePromptV1(
       }
       session.activePrompt = true;
       ownsActivePrompt = true;
+      turnController = new AbortController();
+      session.promptAbort = turnController;
     }
 
     const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
@@ -342,9 +349,11 @@ export async function handlePromptV1(
       });
     };
     signal?.addEventListener("abort", cancelPrompt, { once: true });
+    turnController?.signal.addEventListener("abort", cancelPrompt, { once: true });
     // Listener only fires for future aborts; honor an already-aborted signal.
-    if (signal?.aborted) {
-      signal.removeEventListener("abort", cancelPrompt);
+    if (cancelled()) {
+      signal?.removeEventListener("abort", cancelPrompt);
+      turnController?.signal.removeEventListener("abort", cancelPrompt);
       return { stopReason: "cancelled" };
     }
 
@@ -379,14 +388,18 @@ export async function handlePromptV1(
       // Persist even on failure: agy's conversation id/step position may have
       // advanced before it errored out, and that partial progress is worth
       // resuming from on the next prompt.
-      if (!session.closed && !signal?.aborted) {
+      if (!cancelled()) {
         await deps.persistSession(params.sessionId, session).catch(() => {});
       }
       throw error;
     } finally {
       signal?.removeEventListener("abort", cancelPrompt);
+      turnController?.signal.removeEventListener("abort", cancelPrompt);
     }
   } finally {
+    if (turnController && session.promptAbort === turnController) {
+      session.promptAbort = undefined;
+    }
     if (ownsActivePrompt) {
       session.activePrompt = false;
     }
@@ -403,8 +416,12 @@ async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
   const { params, client, signal, deps, resolve, reject } = item;
   const session = deps.requireSession(params.sessionId);
   session.activePrompt = true;
+  const turnController = new AbortController();
+  session.promptAbort = turnController;
 
-  const cancelled = () => Boolean(signal?.aborted || session.closed);
+  const cancelled = () => Boolean(
+    signal?.aborted || turnController.signal.aborted || session.closed
+  );
 
   try {
     if (cancelled()) {
@@ -449,9 +466,11 @@ async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
       session.agy.cancel().catch(() => {});
     };
     signal?.addEventListener("abort", cancelPrompt, { once: true });
+    turnController.signal.addEventListener("abort", cancelPrompt, { once: true });
     // Listener only fires for future aborts; honor an already-aborted signal.
-    if (signal?.aborted) {
-      signal.removeEventListener("abort", cancelPrompt);
+    if (cancelled()) {
+      signal?.removeEventListener("abort", cancelPrompt);
+      turnController.signal.removeEventListener("abort", cancelPrompt);
       cancelPrompt();
       resolve({ stopReason: "cancelled" });
       return;
@@ -487,9 +506,10 @@ async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
       });
     } finally {
       signal?.removeEventListener("abort", cancelPrompt);
+      turnController.signal.removeEventListener("abort", cancelPrompt);
     }
   } catch (error) {
-    if (!session.closed && !signal?.aborted) {
+    if (!cancelled()) {
       await deps.persistSession(params.sessionId, session).catch(() => {});
     }
     if (cancelled()) {
@@ -498,6 +518,9 @@ async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
     }
     reject(error as Error);
   } finally {
+    if (session.promptAbort === turnController) {
+      session.promptAbort = undefined;
+    }
     session.activePrompt = false;
     notifyIdleAndDrainQueue(session);
   }

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -503,6 +503,79 @@ async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
   }
 }
 
+async function runSteeredV2Turn(
+  params: V2PromptRequest,
+  client: V2AgentContext,
+  session: SessionState,
+  steerSlot: Promise<() => void>,
+  deps: PromptV2Deps
+): Promise<void> {
+  const releaseSteer = await steerSlot;
+  let ownsActivePrompt = false;
+  let controller: AbortController | undefined;
+  try {
+    if (session.closed) {
+      notifyV2BestEffort(client, params.sessionId, {
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: "cancelled"
+      });
+      return;
+    }
+
+    const waitForIdle = session.activePrompt
+      ? new Promise<void>((resolve) => {
+          const prevNotify = session.promptIdleNotify;
+          session.promptIdleNotify = () => {
+            prevNotify?.();
+            resolve();
+          };
+        })
+      : undefined;
+    session.promptAbort?.abort();
+    await session.agy.cancel();
+    await waitForIdle;
+    if (session.closed) {
+      notifyV2BestEffort(client, params.sessionId, {
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: "cancelled"
+      });
+      return;
+    }
+
+    session.activePrompt = true;
+    ownsActivePrompt = true;
+    const promptText = await contentBlocksToPrompt(
+      params.prompt as v1.ContentBlock[],
+      session.cwd
+    );
+    if (session.closed) {
+      notifyV2BestEffort(client, params.sessionId, {
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: "cancelled"
+      });
+      return;
+    }
+
+    controller = new AbortController();
+    session.promptAbort = controller;
+    await runV2PromptTurn(params, client, session, promptText, controller.signal, deps);
+  } finally {
+    if (controller && session.promptAbort === controller) {
+      session.promptAbort = undefined;
+    }
+    if (ownsActivePrompt) {
+      session.activePrompt = false;
+    }
+    releaseSteer();
+    if (!session.activePrompt) {
+      notifyIdleAndDrainQueue(session);
+    }
+  }
+}
+
 /**
  * v2 `session/prompt`: respond `{}` immediately on acceptance. Foreground
  * progress and stopReason arrive as `state_update` notifications.
@@ -590,54 +663,25 @@ export async function handlePromptV2(
     if (intent !== "steer") {
       throw new Error(`Session already has an active prompt: ${params.sessionId}`);
     }
+    // Reserve synchronously, acknowledge the RPC, then cancel and replace on
+    // the next task so backend shutdown latency cannot delay v2 acceptance.
+    const steerSlot = acquireSteerSlot(session);
+    const responseQueued = new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    void responseQueued
+      .then(() => runSteeredV2Turn(params, client, session, steerSlot, deps))
+      .catch((error) => {
+        console.error(`[agy-acp] v2 steer turn failed: ${(error as Error).message}`);
+      });
+    return {};
   }
 
-  let releaseSteer: (() => void) | undefined;
-  let ownsActivePrompt = false;
-  // Once the async turn is scheduled, its finally owns release + drain.
+  // Claim an idle session before attachment conversion. Once scheduled, the
+  // detached turn owns this claim and releases it from its finalizer.
+  session.activePrompt = true;
   let turnScheduled = false;
-  if (!busyAtAdmission) {
-    // Claim an idle session before attachment conversion.
-    session.activePrompt = true;
-    ownsActivePrompt = true;
-  }
   try {
-    if (busyAtAdmission) {
-      // Reserve before any await so a queued follow-up cannot claim the session.
-      releaseSteer = await acquireSteerSlot(session);
-      // Teardown may have completed while this steer waited behind another.
-      if (session.closed) {
-        notifyV2BestEffort(client, params.sessionId, {
-          sessionUpdate: "state_update",
-          state: "idle",
-          stopReason: "cancelled"
-        });
-        return {};
-      }
-      const waitForIdle = session.activePrompt
-        ? new Promise<void>((resolve) => {
-            const prevNotify = session.promptIdleNotify;
-            session.promptIdleNotify = () => {
-              prevNotify?.();
-              resolve();
-            };
-          })
-        : undefined;
-      session.promptAbort?.abort();
-      await session.agy.cancel();
-      await waitForIdle;
-      if (session.closed) {
-        notifyV2BestEffort(client, params.sessionId, {
-          sessionUpdate: "state_update",
-          state: "idle",
-          stopReason: "cancelled"
-        });
-        return {};
-      }
-      session.activePrompt = true;
-      ownsActivePrompt = true;
-    }
-
     // Content block shapes are compatible at runtime; v1/v2 TS types diverge on open enums.
     const promptText = await contentBlocksToPrompt(params.prompt as v1.ContentBlock[], session.cwd);
     if (session.closed) {
@@ -657,8 +701,6 @@ export async function handlePromptV2(
       setTimeout(resolve, 0);
     });
 
-    const releaseForTurn = releaseSteer;
-    releaseSteer = undefined;
     turnScheduled = true;
 
     void responseQueued
@@ -671,20 +713,14 @@ export async function handlePromptV2(
           session.promptAbort = undefined;
         }
         session.activePrompt = false;
-        releaseForTurn?.();
         notifyIdleAndDrainQueue(session);
       });
 
     return {};
   } finally {
     // Setup failed or closed before the async turn was scheduled.
-    if (!turnScheduled && releaseSteer) {
-      releaseSteer();
-    }
-    if (!turnScheduled && ownsActivePrompt) {
+    if (!turnScheduled) {
       session.activePrompt = false;
-    }
-    if (!turnScheduled && !session.activePrompt) {
       notifyIdleAndDrainQueue(session);
     }
   }

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -1,5 +1,14 @@
 // ACP session/prompt: user message, agent execution loop, permission requests.
 // Docs: https://agentclientprotocol.com/protocol/v1/prompt-turn
+//
+// Turn ownership (who may talk to agy, and when) lives in `turn-scheduler.ts`.
+// Every accepted request here follows the same shape:
+//
+//   claim the slot (synchronously)  ->  runTurnBody  ->  exactly one terminal
+//
+// `runTurnBody` is shared by all five entry points (v1 foreground, v1 queued,
+// v2 foreground, v2 queued, v2 steer) so a fix lands in one place instead of
+// five. Cancellation unwinds by throwing, so no path can "forget" to re-check.
 
 import { randomUUID } from "node:crypto";
 import * as v1 from "@agentclientprotocol/sdk";
@@ -29,6 +38,14 @@ import { MODEL_CONFIG_ID } from "./config-options.js";
 import { MODE_CONFIG_ID } from "./modes.js";
 import { requestPermissionV1, requestPermissionV2 } from "./request-permission.js";
 import type { QueuedPromptV1, QueuedPromptV2, SessionState, TurnIntent } from "./types.js";
+import {
+  isTurnCancelled,
+  onAbort,
+  raceClaim,
+  TurnCancelled,
+  turnsOf,
+  type TurnClaim
+} from "./turn-scheduler.js";
 import { createTerminalOutputTracker, createToolCallContentTracker, expandSessionUpdateToV2, sessionUpdateToV1 } from "./update-wire.js";
 
 export interface PromptTurnDeps {
@@ -51,6 +68,8 @@ export interface PromptV2Deps extends PromptTurnDeps {
   clientToolCallNameV2?(client: V2AgentContext): ClientToolCallNameCapability | undefined;
 }
 
+type StopReason = "end_turn" | "cancelled";
+
 export function parseTurnIntent(params: unknown): TurnIntent | undefined {
   if (!params || typeof params !== "object") return undefined;
   const meta = (params as Record<string, unknown>)._meta;
@@ -58,27 +77,6 @@ export function parseTurnIntent(params: unknown): TurnIntent | undefined {
   const intent = (meta as Record<string, unknown>)["agy-acp/turnIntent"];
   if (intent === "queue" || intent === "steer") return intent;
   return undefined;
-}
-
-function raceWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
-  return new Promise((resolve, reject) => {
-    if (signal.aborted) {
-      reject(signal.reason);
-      return;
-    }
-    const onAbort = () => reject(signal.reason);
-    signal.addEventListener("abort", onAbort, { once: true });
-    promise.then(
-      (value) => {
-        signal.removeEventListener("abort", onAbort);
-        resolve(value);
-      },
-      (error) => {
-        signal.removeEventListener("abort", onAbort);
-        reject(error);
-      }
-    );
-  });
 }
 
 function notifyV2BestEffort(
@@ -95,76 +93,43 @@ function notifyV2BestEffort(
 
 /** True when a turn is running or a steer has reserved the next turn. */
 export function sessionTurnBusy(session: SessionState): boolean {
-  return session.activePrompt || (session.steerClaims ?? 0) > 0;
-}
-
-export function notifyIdleAndDrainQueue(session: SessionState): void {
-  const notify = session.promptIdleNotify;
-  session.promptIdleNotify = undefined;
-  if (notify) {
-    notify();
-    return;
-  }
-
-  if (session.closed) return;
-  // A steer has reserved the next turn (possibly still waiting on a prior steer).
-  if ((session.steerClaims ?? 0) > 0) return;
-
-  if (!session.activePrompt && session.promptQueue.length > 0) {
-    const next = session.promptQueue.shift()!;
-    if (next.version === "v1") {
-      if (next.signal?.aborted) {
-        next.resolve({ stopReason: "cancelled" });
-        notifyIdleAndDrainQueue(session);
-        return;
-      }
-      void executeQueuedV1Turn(next).catch((error) => {
-        console.error(`[agy-acp] queued v1 turn failed: ${(error as Error).message}`);
-      });
-    } else {
-      if (next.controller.signal.aborted) {
-        void next.client.notify(v2.methods.client.session.update, {
-          sessionId: next.params.sessionId,
-          update: { sessionUpdate: "state_update", state: "idle", stopReason: "cancelled" }
-        }).catch(() => {});
-        notifyIdleAndDrainQueue(session);
-        return;
-      }
-      void executeQueuedV2Turn(next).catch((error) => {
-        console.error(`[agy-acp] queued v2 turn failed: ${(error as Error).message}`);
-      });
-    }
-  }
+  return turnsOf(session).busy();
 }
 
 /**
- * Claim the session for a steer replacement before any await, then serialize
- * against other steers. The returned release must run exactly once (success,
- * cancel, or closed) so the queue can drain again.
+ * Start the next queued prompt if the session is free. Safe to call from any
+ * finalizer; it is a no-op while a turn or steer reservation owns the slot.
  */
-async function acquireSteerSlot(session: SessionState): Promise<() => void> {
-  session.steerClaims = (session.steerClaims ?? 0) + 1;
-  const previousSteer = session.promptSteerInProgress;
-  let release!: () => void;
-  session.promptSteerInProgress = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  if (previousSteer) await previousSteer;
+export function notifyIdleAndDrainQueue(session: SessionState): void {
+  if (session.closed) return;
+  const turns = turnsOf(session);
+  if (turns.busy()) return;
+  if (session.promptQueue.length === 0) return;
 
-  let released = false;
-  return () => {
-    if (released) return;
-    released = true;
-    session.steerClaims = Math.max(0, (session.steerClaims ?? 1) - 1);
-    release();
-  };
-}
-
-/** Wake any steer idle-waiter after marking the session closed. */
-export function wakePromptIdleWaiters(session: SessionState): void {
-  const notify = session.promptIdleNotify;
-  session.promptIdleNotify = undefined;
-  notify?.();
+  const next = session.promptQueue.shift()!;
+  if (next.version === "v1") {
+    if (next.signal?.aborted) {
+      next.resolve({ stopReason: "cancelled" });
+      notifyIdleAndDrainQueue(session);
+      return;
+    }
+    void executeQueuedV1Turn(next).catch((error) => {
+      console.error(`[agy-acp] queued v1 turn failed: ${(error as Error).message}`);
+    });
+  } else {
+    if (next.controller.signal.aborted) {
+      notifyV2BestEffort(next.client, next.params.sessionId, {
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: "cancelled"
+      });
+      notifyIdleAndDrainQueue(session);
+      return;
+    }
+    void executeQueuedV2Turn(next).catch((error) => {
+      console.error(`[agy-acp] queued v2 turn failed: ${(error as Error).message}`);
+    });
+  }
 }
 
 /**
@@ -216,6 +181,298 @@ export async function applyCuratedSlashCommand(
 }
 
 /**
+ * Per-version hooks for the shared turn body. Progress notifications differ
+ * between v1 and v2; the ordering, cancellation, and persistence rules do not.
+ */
+interface TurnAdapter {
+  /** v2 foreground only — queued v2 already published it, v1 has no concept. */
+  announceUserMessage?(promptText: string): Promise<void>;
+  /** v2 only. */
+  announceRunning?(): Promise<void>;
+  forwardUpdates(promptText: string, claim: TurnClaim): Promise<{ stopReason: string }>;
+  applySlash(promptText: string): Promise<boolean>;
+}
+
+/**
+ * The one turn body. Converts content, honors curated slash commands, runs agy,
+ * and persists. Throws `TurnCancelled` the moment the claim is aborted — every
+ * await is guarded, so there is no "recheck the flag afterwards" step to omit.
+ */
+async function runTurnBody(
+  sessionId: string,
+  promptBlocks: v1.ContentBlock[],
+  session: SessionState,
+  claim: TurnClaim,
+  adapter: TurnAdapter,
+  deps: PromptTurnDeps,
+  /** Queued v2 converts at enqueue time; re-converting would rewrite attachments. */
+  preconverted?: string
+): Promise<StopReason> {
+  const guard = <T>(promise: Promise<T>) => raceClaim(promise, claim);
+  const ensureLive = () => {
+    claim.throwIfAborted();
+    if (session.closed) throw new TurnCancelled();
+  };
+
+  ensureLive();
+  const promptText = preconverted ?? await guard(contentBlocksToPrompt(promptBlocks, session.cwd));
+  ensureLive();
+
+  if (adapter.announceUserMessage) {
+    await guard(adapter.announceUserMessage(promptText));
+    ensureLive();
+  }
+  if (adapter.announceRunning) {
+    await guard(adapter.announceRunning());
+    ensureLive();
+  }
+
+  // Only intercept pure client text blocks; a resource or image payload whose
+  // flattened body happens to read `/plan` must be forwarded to agy verbatim.
+  if (isClientTextSlashPrompt(promptBlocks)) {
+    const handled = await guard(adapter.applySlash(promptText));
+    if (handled) {
+      ensureLive();
+      return "end_turn";
+    }
+    ensureLive();
+  }
+
+  // The backend is now the thing to stop, so route aborts to it. `onAbort`
+  // fires immediately if the claim is already aborted.
+  const stopBackend = () => {
+    session.agy.cancel().catch(() => {
+      // The prompt loop surfaces process failures through its own result.
+    });
+  };
+  const detach = onAbort(claim.signal, stopBackend);
+  try {
+    ensureLive();
+    const outcome = await adapter.forwardUpdates(promptText, claim);
+    if (!session.closed) {
+      await deps.persistSession(sessionId, session);
+    }
+    return outcome.stopReason === "cancelled" || claim.aborted || session.closed
+      ? "cancelled"
+      : "end_turn";
+  } catch (error) {
+    // Persist even on failure: agy's conversation id/step position may have
+    // advanced before it errored out, and that partial progress is worth
+    // resuming from on the next prompt.
+    if (!claim.aborted && !session.closed) {
+      await deps.persistSession(sessionId, session).catch(() => {});
+    }
+    throw error;
+  } finally {
+    detach();
+  }
+}
+
+function v1Adapter(
+  params: V1PromptRequest,
+  client: V1AgentContext,
+  session: SessionState,
+  deps: PromptV1Deps
+): TurnAdapter {
+  return {
+    applySlash: (promptText) => applyCuratedSlashCommand(
+      params.sessionId,
+      promptText,
+      {
+        // ACP transition: send both legacy current_mode_update (modes-API clients)
+        // and config_option_update (configOptions clients) on slash mode changes.
+        modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
+        configChanged: async () => {
+          await deps.notifyConfigOptionUpdateV1(
+            client,
+            params.sessionId,
+            deps.requireSession(params.sessionId)
+          );
+        }
+      },
+      deps
+    ),
+    forwardUpdates: async (promptText, claim) => {
+      const tracker = createTerminalOutputTracker();
+      const clientToolCallName = deps.clientToolCallNameV1?.(client);
+      return session.agy.prompt(promptText, async (update) => {
+        await client.notify(v1.methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: sessionUpdateToV1(update, tracker, { clientToolCallName })
+        });
+      }, async (toolCall, { toolName, questionIndex }) => {
+        const elicitationCap = deps.clientElicitationV1?.(client);
+        return requestPermissionV1(
+          client,
+          params.sessionId,
+          toolCall,
+          toolName,
+          claim.signal,
+          questionIndex,
+          elicitationCap,
+          clientToolCallName
+        );
+      }, deps.clientFileSystemV1(client, params.sessionId), deps.clientElicitationV1?.(client));
+    }
+  };
+}
+
+function v2Adapter(
+  params: V2PromptRequest,
+  client: V2AgentContext,
+  session: SessionState,
+  deps: PromptV2Deps,
+  options: { userMessageId?: string; announceUserMessage: boolean }
+): TurnAdapter {
+  const notify = async (update: v2.SessionUpdate) => {
+    await client.notify(v2.methods.client.session.update, {
+      sessionId: params.sessionId,
+      update
+    });
+  };
+  // Assigned when announced (foreground) or supplied by the queue (already
+  // announced at enqueue time); recorded against agy's step index afterwards.
+  let userMessageId = options.userMessageId ?? "";
+
+  const adapter: TurnAdapter = {
+    announceUserMessage: options.announceUserMessage
+      ? async (promptText: string) => {
+          userMessageId = v2UserMessageId(params.prompt as v1.ContentBlock[], promptText);
+          await notify({
+            sessionUpdate: "user_message",
+            messageId: userMessageId,
+            content: params.prompt as v2.ContentBlock[]
+          });
+        }
+      : undefined,
+    announceRunning: () => notify({ sessionUpdate: "state_update", state: "running" }),
+    applySlash: (promptText) => applyCuratedSlashCommand(
+      params.sessionId,
+      promptText,
+      {
+        configChanged: () => deps.notifyConfigOptionUpdateV2(
+          client,
+          params.sessionId,
+          deps.requireSession(params.sessionId)
+        )
+      },
+      deps
+    ),
+    forwardUpdates: async (promptText, claim) => {
+      const terminalTracker = createTerminalOutputTracker();
+      const toolContentTracker = createToolCallContentTracker();
+      const clientToolCallName = deps.clientToolCallNameV2?.(client);
+      try {
+        return await session.agy.prompt(promptText, async (update) => {
+          for (const v2Update of expandSessionUpdateToV2(update, terminalTracker, toolContentTracker, { clientToolCallName })) {
+            await raceClaim(notify(v2Update), claim);
+          }
+        }, async (toolCall, { toolName, questionIndex }) => {
+          const elicitationCap = deps.clientElicitationV2?.(client);
+          return requestPermissionV2(
+            client,
+            params.sessionId,
+            toolCall,
+            toolName,
+            claim.signal,
+            questionIndex,
+            elicitationCap,
+            clientToolCallName
+          );
+        }, undefined, deps.clientElicitationV2?.(client));
+      } finally {
+        const userStepIdxs = session.agy.lastPromptUserStepIdxs;
+        if (userStepIdxs.length > 1) {
+          throw new Error(`Expected at most one user step for a prompt, observed: ${userStepIdxs.join(", ")}`);
+        }
+        if (userStepIdxs.length === 1 && userMessageId) {
+          session.v2UserMessageIdsByStep[String(userStepIdxs[0])] = userMessageId;
+        }
+      }
+    }
+  };
+  return adapter;
+}
+
+/**
+ * Emit a v2 turn's single terminal `idle` update.
+ *
+ * Racing the claim matters: if the session is closed or cancelled while this
+ * notification is in flight on a stalled transport, teardown must not be held
+ * up — and neither must the turn slot, which is only released afterwards.
+ */
+function v2TerminalEmitter(
+  client: V2AgentContext,
+  sessionId: string,
+  session: SessionState,
+  claim: TurnClaim
+): (stopReason: StopReason) => Promise<void> {
+  return async (stopReason) => {
+    const update: v2.SessionUpdate = {
+      sessionUpdate: "state_update",
+      state: "idle",
+      stopReason
+    };
+    if (session.closed || claim.aborted) {
+      notifyV2BestEffort(client, sessionId, update);
+      return;
+    }
+    try {
+      await raceClaim(
+        client.notify(v2.methods.client.session.update, { sessionId, update }),
+        claim
+      );
+    } catch (error) {
+      if (!isTurnCancelled(error)) throw error;
+      notifyV2BestEffort(client, sessionId, update);
+    }
+  };
+}
+
+/** Slash selections get a distinguishable message id, matching v2 clients. */
+function v2UserMessageId(promptBlocks: v1.ContentBlock[], promptText: string): string {
+  const parsedSlash = isClientTextSlashPrompt(promptBlocks) ? parseSlashCommand(promptText) : null;
+  const slashResult = parsedSlash ? interpretSlashCommand(parsedSlash) : null;
+  return slashResult && slashResult.kind !== "pass"
+    ? `slash-${randomUUID()}`
+    : `user-${randomUUID()}`;
+}
+
+/**
+ * Run a claimed turn to completion and report exactly one terminal outcome.
+ * Every accepted request — foreground, queued, steered, or one that fails
+ * during setup — ends here, so a prompt can never vanish without a terminal.
+ */
+async function completeTurn(
+  session: SessionState,
+  claim: TurnClaim,
+  body: () => Promise<StopReason>,
+  report: {
+    terminal(stopReason: StopReason): void | Promise<void>;
+    failure(error: unknown): void | Promise<void>;
+  }
+): Promise<void> {
+  const turns = turnsOf(session);
+  try {
+    let stopReason: StopReason;
+    try {
+      stopReason = await body();
+    } catch (error) {
+      if (isTurnCancelled(error) || claim.aborted || session.closed) {
+        stopReason = "cancelled";
+      } else {
+        await report.failure(error);
+        return;
+      }
+    }
+    await report.terminal(stopReason);
+  } finally {
+    turns.release(claim);
+    notifyIdleAndDrainQueue(session);
+  }
+}
+
+/**
  * v1 `session/prompt`: response carries stopReason after the full turn.
  *
  * Zero prompt injection: only client `params.prompt` content is encoded and
@@ -228,375 +485,123 @@ export async function handlePromptV1(
   deps: PromptV1Deps
 ): Promise<V1PromptResponse> {
   const session = deps.requireSession(params.sessionId);
-  const busyAtAdmission = sessionTurnBusy(session);
-  if (busyAtAdmission) {
+  const turns = turnsOf(session);
+
+  if (turns.busy()) {
     const intent = parseTurnIntent(params);
     if (intent === "queue") {
-      return new Promise<V1PromptResponse>((resolve, reject) => {
-        const queuedId = `q-${randomUUID()}`;
-        const queued: QueuedPromptV1 = {
-          id: queuedId,
-          version: "v1",
-          params,
-          client,
-          signal,
-          deps,
-          resolve,
-          reject
-        };
-        session.promptQueue.push(queued);
-        if (signal) {
-          const onAbort = () => {
-            const idx = session.promptQueue.findIndex((q) => q.id === queuedId);
-            if (idx >= 0) {
-              session.promptQueue.splice(idx, 1);
-              resolve({ stopReason: "cancelled" });
-            }
-          };
-          signal.addEventListener("abort", onAbort, { once: true });
-          if (signal.aborted) onAbort();
-        }
-      });
+      return enqueueV1(params, client, signal, session, deps);
     }
     if (intent !== "steer") {
       throw new Error(`Session already has an active prompt: ${params.sessionId}`);
     }
-  }
-
-  // Own the steer claim (if any) for the full replacement path — including
-  // setup failures and slash-only turns — so release + queue drain always run.
-  let releaseSteer: (() => void) | undefined;
-  let ownsActivePrompt = false;
-  let turnController: AbortController | undefined;
-  const cancelled = () => Boolean(
-    signal?.aborted || turnController?.signal.aborted || session.closed
-  );
-  if (!busyAtAdmission) {
-    // Claim an idle session before attachment conversion or config awaits.
-    session.activePrompt = true;
-    ownsActivePrompt = true;
-    turnController = new AbortController();
-    session.promptAbort = turnController;
-  }
-  try {
-    if (busyAtAdmission) {
-      // Reserve before any await so a queued follow-up cannot claim the session.
-      releaseSteer = await acquireSteerSlot(session);
-      // Teardown may have completed while this steer waited behind another.
-      if (cancelled()) {
-        return { stopReason: "cancelled" };
-      }
-      const waitForIdle = session.activePrompt
-        ? new Promise<void>((resolve) => {
-            const prevNotify = session.promptIdleNotify;
-            session.promptIdleNotify = () => {
-              prevNotify?.();
-              resolve();
-            };
-          })
-        : undefined;
-      session.promptAbort?.abort();
-      await session.agy.cancel();
-      await waitForIdle;
-      // Request may have been cancelled while waiting on the prior turn/steer.
-      if (cancelled()) {
-        return { stopReason: "cancelled" };
-      }
-      session.activePrompt = true;
-      ownsActivePrompt = true;
-      turnController = new AbortController();
-      session.promptAbort = turnController;
-    }
-
-    const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
-    if (cancelled()) {
-      return { stopReason: "cancelled" };
-    }
-
-    // Curated slash commands → config options; do not spawn agy for those.
-    // Only intercept pure client text blocks (not resource/image payloads whose
-    // flattened body happens to look like `/plan`).
-    const handled =
-      isClientTextSlashPrompt(params.prompt) &&
-      (await applyCuratedSlashCommand(
-        params.sessionId,
-        prompt,
-        {
-          // ACP transition: send both legacy current_mode_update (modes-API clients)
-          // and config_option_update (configOptions clients) on slash-command mode changes.
-          modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
-          configChanged: async () => {
-            await deps.notifyConfigOptionUpdateV1(
-              client,
-              params.sessionId,
-              deps.requireSession(params.sessionId)
-            );
-          }
-        },
-        deps
-      ));
-    if (handled) {
-      return { stopReason: cancelled() ? "cancelled" : "end_turn" };
-    }
-
-    if (cancelled()) {
-      return { stopReason: "cancelled" };
-    }
-
-    const cancelPrompt = () => {
-      session.agy.cancel().catch(() => {
-        // The prompt loop will surface process failures through its own result.
-      });
-    };
-    signal?.addEventListener("abort", cancelPrompt, { once: true });
-    turnController?.signal.addEventListener("abort", cancelPrompt, { once: true });
-    // Listener only fires for future aborts; honor an already-aborted signal.
-    if (cancelled()) {
-      signal?.removeEventListener("abort", cancelPrompt);
-      turnController?.signal.removeEventListener("abort", cancelPrompt);
-      return { stopReason: "cancelled" };
-    }
-
-    try {
-      const tracker = createTerminalOutputTracker();
-      const clientToolCallName = deps.clientToolCallNameV1?.(client);
-      const outcome = await session.agy.prompt(prompt, async (update) => {
-        await client.notify(v1.methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: sessionUpdateToV1(update, tracker, { clientToolCallName })
-        });
-      }, async (toolCall, { toolName, questionIndex }) => {
-        const elicitationCap = deps.clientElicitationV1?.(client);
-        return requestPermissionV1(
-          client,
+    // Reserve synchronously: the claim (and its abort controller) must exist
+    // before the first await so a cancel during the wait is never dropped.
+    const claim = turns.reserveSteer(signal);
+    let response: V1PromptResponse = { stopReason: "cancelled" };
+    await completeTurn(
+      session,
+      claim,
+      async () => {
+        await turns.promote(claim, () => session.agy.cancel());
+        return runTurnBody(
           params.sessionId,
-          toolCall,
-          toolName,
-          signal,
-          questionIndex,
-          elicitationCap,
-          clientToolCallName
+          params.prompt,
+          session,
+          claim,
+          v1Adapter(params, client, session, deps),
+          deps
         );
-      }, deps.clientFileSystemV1(client, params.sessionId), deps.clientElicitationV1?.(client));
-      if (!session.closed) {
-        await deps.persistSession(params.sessionId, session);
+      },
+      {
+        terminal: (stopReason) => {
+          response = { stopReason };
+        },
+        failure: (error) => {
+          throw error;
+        }
       }
-      return {
-        stopReason: outcome.stopReason === "cancelled" || cancelled() ? "cancelled" : "end_turn"
-      };
-    } catch (error) {
-      // Persist even on failure: agy's conversation id/step position may have
-      // advanced before it errored out, and that partial progress is worth
-      // resuming from on the next prompt.
-      if (!cancelled()) {
-        await deps.persistSession(params.sessionId, session).catch(() => {});
-      }
-      throw error;
-    } finally {
-      signal?.removeEventListener("abort", cancelPrompt);
-      turnController?.signal.removeEventListener("abort", cancelPrompt);
-    }
-  } finally {
-    if (turnController && session.promptAbort === turnController) {
-      session.promptAbort = undefined;
-    }
-    if (ownsActivePrompt) {
-      session.activePrompt = false;
-    }
-    releaseSteer?.();
-    // Slash-only, closed, setup-error, and agy paths all release the same
-    // admission claim here, after which queued work may proceed.
-    if (!session.activePrompt) {
-      notifyIdleAndDrainQueue(session);
-    }
+    );
+    return response;
   }
+
+  const claim = turns.claimIdle("foreground", signal);
+  let response: V1PromptResponse = { stopReason: "cancelled" };
+  await completeTurn(
+    session,
+    claim,
+    () => runTurnBody(
+      params.sessionId,
+      params.prompt,
+      session,
+      claim,
+      v1Adapter(params, client, session, deps),
+      deps
+    ),
+    {
+      terminal: (stopReason) => {
+        response = { stopReason };
+      },
+      failure: (error) => {
+        throw error;
+      }
+    }
+  );
+  return response;
+}
+
+function enqueueV1(
+  params: V1PromptRequest,
+  client: V1AgentContext,
+  signal: AbortSignal | undefined,
+  session: SessionState,
+  deps: PromptV1Deps
+): Promise<V1PromptResponse> {
+  return new Promise<V1PromptResponse>((resolve, reject) => {
+    const queuedId = `q-${randomUUID()}`;
+    session.promptQueue.push({
+      id: queuedId,
+      version: "v1",
+      params,
+      client,
+      signal,
+      deps,
+      resolve,
+      reject
+    } satisfies QueuedPromptV1);
+    if (signal) {
+      onAbort(signal, () => {
+        const idx = session.promptQueue.findIndex((q) => q.id === queuedId);
+        if (idx >= 0) {
+          session.promptQueue.splice(idx, 1);
+          resolve({ stopReason: "cancelled" });
+        }
+      });
+    }
+  });
 }
 
 async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
   const { params, client, signal, deps, resolve, reject } = item;
   const session = deps.requireSession(params.sessionId);
-  session.activePrompt = true;
-  const turnController = new AbortController();
-  session.promptAbort = turnController;
+  const claim = turnsOf(session).claimIdle("queued", signal);
 
-  const cancelled = () => Boolean(
-    signal?.aborted || turnController.signal.aborted || session.closed
+  await completeTurn(
+    session,
+    claim,
+    () => runTurnBody(
+      params.sessionId,
+      params.prompt,
+      session,
+      claim,
+      v1Adapter(params, client, session, deps),
+      deps
+    ),
+    {
+      terminal: (stopReason) => resolve({ stopReason }),
+      failure: (error) => reject(error as Error)
+    }
   );
-
-  try {
-    if (cancelled()) {
-      resolve({ stopReason: "cancelled" });
-      return;
-    }
-
-    const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
-    if (cancelled()) {
-      resolve({ stopReason: "cancelled" });
-      return;
-    }
-
-    const handled =
-      isClientTextSlashPrompt(params.prompt) &&
-      (await applyCuratedSlashCommand(
-        params.sessionId,
-        prompt,
-        {
-          modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
-          configChanged: async () => {
-            await deps.notifyConfigOptionUpdateV1(
-              client,
-              params.sessionId,
-              deps.requireSession(params.sessionId)
-            );
-          }
-        },
-        deps
-      ));
-    if (handled) {
-      resolve({ stopReason: cancelled() ? "cancelled" : "end_turn" });
-      return;
-    }
-
-    if (cancelled()) {
-      resolve({ stopReason: "cancelled" });
-      return;
-    }
-
-    const cancelPrompt = () => {
-      session.agy.cancel().catch(() => {});
-    };
-    signal?.addEventListener("abort", cancelPrompt, { once: true });
-    turnController.signal.addEventListener("abort", cancelPrompt, { once: true });
-    // Listener only fires for future aborts; honor an already-aborted signal.
-    if (cancelled()) {
-      signal?.removeEventListener("abort", cancelPrompt);
-      turnController.signal.removeEventListener("abort", cancelPrompt);
-      cancelPrompt();
-      resolve({ stopReason: "cancelled" });
-      return;
-    }
-
-    try {
-      const tracker = createTerminalOutputTracker();
-      const clientToolCallName = deps.clientToolCallNameV1?.(client);
-      const outcome = await session.agy.prompt(prompt, async (update) => {
-        await client.notify(v1.methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: sessionUpdateToV1(update, tracker, { clientToolCallName })
-        });
-      }, async (toolCall, { toolName, questionIndex }) => {
-        const elicitationCap = deps.clientElicitationV1?.(client);
-        return requestPermissionV1(
-          client,
-          params.sessionId,
-          toolCall,
-          toolName,
-          signal,
-          questionIndex,
-          elicitationCap,
-          clientToolCallName
-        );
-      }, deps.clientFileSystemV1(client, params.sessionId), deps.clientElicitationV1?.(client));
-      if (!session.closed) {
-        await deps.persistSession(params.sessionId, session);
-      }
-      resolve({
-        stopReason:
-          outcome.stopReason === "cancelled" || cancelled() ? "cancelled" : "end_turn"
-      });
-    } finally {
-      signal?.removeEventListener("abort", cancelPrompt);
-      turnController.signal.removeEventListener("abort", cancelPrompt);
-    }
-  } catch (error) {
-    if (!cancelled()) {
-      await deps.persistSession(params.sessionId, session).catch(() => {});
-    }
-    if (cancelled()) {
-      resolve({ stopReason: "cancelled" });
-      return;
-    }
-    reject(error as Error);
-  } finally {
-    if (session.promptAbort === turnController) {
-      session.promptAbort = undefined;
-    }
-    session.activePrompt = false;
-    notifyIdleAndDrainQueue(session);
-  }
-}
-
-async function runSteeredV2Turn(
-  params: V2PromptRequest,
-  client: V2AgentContext,
-  session: SessionState,
-  steerSlot: Promise<() => void>,
-  deps: PromptV2Deps
-): Promise<void> {
-  const releaseSteer = await steerSlot;
-  let ownsActivePrompt = false;
-  let controller: AbortController | undefined;
-  try {
-    if (session.closed) {
-      notifyV2BestEffort(client, params.sessionId, {
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason: "cancelled"
-      });
-      return;
-    }
-
-    const waitForIdle = session.activePrompt
-      ? new Promise<void>((resolve) => {
-          const prevNotify = session.promptIdleNotify;
-          session.promptIdleNotify = () => {
-            prevNotify?.();
-            resolve();
-          };
-        })
-      : undefined;
-    session.promptAbort?.abort();
-    await session.agy.cancel();
-    await waitForIdle;
-    if (session.closed) {
-      notifyV2BestEffort(client, params.sessionId, {
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason: "cancelled"
-      });
-      return;
-    }
-
-    session.activePrompt = true;
-    ownsActivePrompt = true;
-    controller = new AbortController();
-    session.promptAbort = controller;
-    const promptText = await contentBlocksToPrompt(
-      params.prompt as v1.ContentBlock[],
-      session.cwd
-    );
-    if (controller.signal.aborted || session.closed) {
-      notifyV2BestEffort(client, params.sessionId, {
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason: "cancelled"
-      });
-      return;
-    }
-
-    await runV2PromptTurn(params, client, session, promptText, controller.signal, deps);
-  } finally {
-    if (controller && session.promptAbort === controller) {
-      session.promptAbort = undefined;
-    }
-    if (ownsActivePrompt) {
-      session.activePrompt = false;
-    }
-    releaseSteer();
-    if (!session.activePrompt) {
-      notifyIdleAndDrainQueue(session);
-    }
-  }
 }
 
 /**
@@ -612,463 +617,199 @@ export async function handlePromptV2(
   deps: PromptV2Deps
 ): Promise<V2PromptResponse> {
   const session = deps.requireSession(params.sessionId);
-  const busyAtAdmission = sessionTurnBusy(session);
-  if (busyAtAdmission) {
+  const turns = turnsOf(session);
+
+  if (turns.busy()) {
     const intent = parseTurnIntent(params);
     if (intent === "queue") {
-      const controller = new AbortController();
-      const queuedId = `q-${randomUUID()}`;
-      const queued: QueuedPromptV2 = {
-        id: queuedId,
-        version: "v2",
-        params,
-        client,
-        ready: Promise.resolve(),
-        controller,
-        deps
-      };
-      // Enter FIFO before conversion or client transport awaits can reorder
-      // concurrently admitted queue requests.
-      session.promptQueue.push(queued);
-      const responseQueued = new Promise<void>((resolve) => {
-        setTimeout(resolve, 0);
-      });
-      const previousPreparation = session.promptQueuePreparation ?? Promise.resolve();
-      queued.ready = raceWithAbort(
-        previousPreparation.catch(() => {}).then(() => responseQueued).then(async () => {
-          const promptText = await contentBlocksToPrompt(
-            params.prompt as v1.ContentBlock[],
-            session.cwd
-          );
-          controller.signal.throwIfAborted();
-          const parsedSlash = isClientTextSlashPrompt(params.prompt as v1.ContentBlock[])
-            ? parseSlashCommand(promptText)
-            : null;
-          const slashResult = parsedSlash ? interpretSlashCommand(parsedSlash) : null;
-          const userMessageId =
-            slashResult && slashResult.kind !== "pass"
-              ? `slash-${randomUUID()}`
-              : `user-${randomUUID()}`;
-
-          await client.notify(v2.methods.client.session.update, {
-            sessionId: params.sessionId,
-            update: {
-              sessionUpdate: "user_message",
-              messageId: userMessageId,
-              content: params.prompt as v2.ContentBlock[]
-            }
-          });
-          controller.signal.throwIfAborted();
-          queued.promptText = promptText;
-          queued.userMessageId = userMessageId;
-        }),
-        controller.signal
-      );
-      session.promptQueuePreparation = queued.ready.then(() => {}, () => {});
-      void queued.ready.catch(() => {
-        const idx = session.promptQueue.findIndex((item) => item.id === queuedId);
-        if (idx < 0) return; // The FIFO executor owns terminal reporting.
-        session.promptQueue.splice(idx, 1);
-        if (!controller.signal.aborted && !session.closed) {
-          notifyV2BestEffort(client, params.sessionId, {
-            sessionUpdate: "state_update",
-            state: "idle",
-            stopReason: "end_turn"
-          });
-        }
-        if (!sessionTurnBusy(session)) notifyIdleAndDrainQueue(session);
-      });
-      if (!sessionTurnBusy(session)) {
-        notifyIdleAndDrainQueue(session);
-      }
+      enqueueV2(params, client, session, deps);
       return {};
     }
     if (intent !== "steer") {
       throw new Error(`Session already has an active prompt: ${params.sessionId}`);
     }
-    // Reserve synchronously, acknowledge the RPC, then cancel and replace on
-    // the next task so backend shutdown latency cannot delay v2 acceptance.
-    const steerSlot = acquireSteerSlot(session);
-    const responseQueued = new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    void responseQueued
-      .then(() => runSteeredV2Turn(params, client, session, steerSlot, deps))
+    // Reserve synchronously, acknowledge the RPC, then displace the active turn
+    // on the next task so backend shutdown latency cannot delay acceptance.
+    const claim = turns.reserveSteer();
+    void nextTask()
+      .then(() => runV2Turn(params, client, session, claim, deps, {
+        announceUserMessage: true,
+        displaceActive: true
+      }))
       .catch((error) => {
         console.error(`[agy-acp] v2 steer turn failed: ${(error as Error).message}`);
       });
     return {};
   }
 
-  // Claim an idle session before attachment conversion. Once scheduled, the
-  // detached turn owns this claim and releases it from its finalizer.
-  session.activePrompt = true;
-  const controller = new AbortController();
-  session.promptAbort = controller;
-  let turnScheduled = false;
-  try {
-    // Content block shapes are compatible at runtime; v1/v2 TS types diverge on open enums.
-    const promptText = await contentBlocksToPrompt(params.prompt as v1.ContentBlock[], session.cwd);
-    if (controller.signal.aborted || session.closed) {
-      notifyV2BestEffort(client, params.sessionId, {
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason: "cancelled"
-      });
-      return {};
-    }
-
-    // Queue the empty acceptance response before any session/update from the turn.
-    // Work starts on the next event-loop task (see dual-version-agent example).
-    const responseQueued = new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
+  const claim = turns.claimIdle("foreground");
+  void nextTask()
+    .then(() => runV2Turn(params, client, session, claim, deps, {
+      announceUserMessage: true,
+      displaceActive: false
+    }))
+    .catch((error) => {
+      console.error(`[agy-acp] v2 prompt turn failed: ${(error as Error).message}`);
     });
+  return {};
+}
 
-    turnScheduled = true;
+/** Queue the RPC response ahead of any session/update the turn emits. */
+function nextTask(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
 
-    void responseQueued
-      .then(() => runV2PromptTurn(params, client, session, promptText, controller.signal, deps))
-      .catch((error) => {
-        console.error(`[agy-acp] v2 prompt turn failed: ${(error as Error).message}`);
-      })
-      .finally(() => {
-        if (session.promptAbort === controller) {
-          session.promptAbort = undefined;
-        }
-        session.activePrompt = false;
-        notifyIdleAndDrainQueue(session);
-      });
-
-    return {};
-  } finally {
-    // Setup failed or closed before the async turn was scheduled.
-    if (!turnScheduled) {
-      if (session.promptAbort === controller) {
-        session.promptAbort = undefined;
-      }
-      session.activePrompt = false;
-      notifyIdleAndDrainQueue(session);
-    }
+async function runV2Turn(
+  params: V2PromptRequest,
+  client: V2AgentContext,
+  session: SessionState,
+  claim: TurnClaim,
+  deps: PromptV2Deps,
+  options: {
+    announceUserMessage: boolean;
+    displaceActive: boolean;
+    userMessageId?: string;
+    promptBlocks?: v1.ContentBlock[];
   }
+): Promise<void> {
+  const adapter = v2Adapter(params, client, session, deps, {
+    announceUserMessage: options.announceUserMessage,
+    userMessageId: options.userMessageId
+  });
+  const turns = turnsOf(session);
+  const emitTerminal = v2TerminalEmitter(client, params.sessionId, session, claim);
+
+  await completeTurn(
+    session,
+    claim,
+    async () => {
+      if (options.displaceActive) {
+        await turns.promote(claim, () => session.agy.cancel());
+      }
+      return runTurnBody(
+        params.sessionId,
+        options.promptBlocks ?? (params.prompt as v1.ContentBlock[]),
+        session,
+        claim,
+        adapter,
+        deps
+      );
+    },
+    {
+      terminal: emitTerminal,
+      failure: async (error) => {
+        console.error(`[agy-acp] v2 turn failed: ${(error as Error).message}`);
+        // The RPC already returned `{}`; a setup or backend failure must still
+        // land the client back in `idle` rather than leaving it in `running`.
+        await emitTerminal("end_turn").catch(() => {});
+      }
+    }
+  );
+}
+
+function enqueueV2(
+  params: V2PromptRequest,
+  client: V2AgentContext,
+  session: SessionState,
+  deps: PromptV2Deps
+): void {
+  const controller = new AbortController();
+  const queuedId = `q-${randomUUID()}`;
+  const queued: QueuedPromptV2 = {
+    id: queuedId,
+    version: "v2",
+    params,
+    client,
+    ready: Promise.resolve(),
+    controller,
+    deps
+  };
+  // Enter FIFO before conversion or client transport awaits can reorder
+  // concurrently admitted queue requests.
+  session.promptQueue.push(queued);
+
+  const previousPreparation = session.promptQueuePreparation ?? Promise.resolve();
+  queued.ready = previousPreparation
+    .catch(() => {})
+    .then(() => nextTask())
+    .then(async () => {
+      controller.signal.throwIfAborted();
+      const promptText = await contentBlocksToPrompt(
+        params.prompt as v1.ContentBlock[],
+        session.cwd
+      );
+      controller.signal.throwIfAborted();
+      const userMessageId = v2UserMessageId(params.prompt as v1.ContentBlock[], promptText);
+
+      await client.notify(v2.methods.client.session.update, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "user_message",
+          messageId: userMessageId,
+          content: params.prompt as v2.ContentBlock[]
+        }
+      });
+      controller.signal.throwIfAborted();
+      if (session.closed) throw new TurnCancelled();
+      queued.promptText = promptText;
+      queued.userMessageId = userMessageId;
+    });
+  session.promptQueuePreparation = queued.ready.then(() => {}, () => {});
+
+  void queued.ready.catch(() => {
+    const idx = session.promptQueue.findIndex((item) => item.id === queuedId);
+    if (idx < 0) return; // The FIFO executor owns terminal reporting.
+    session.promptQueue.splice(idx, 1);
+    notifyV2BestEffort(client, params.sessionId, {
+      sessionUpdate: "state_update",
+      state: "idle",
+      stopReason: controller.signal.aborted || session.closed ? "cancelled" : "end_turn"
+    });
+    notifyIdleAndDrainQueue(session);
+  });
+
+  notifyIdleAndDrainQueue(session);
 }
 
 async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
   const { params, client, controller, deps } = item;
   const session = deps.requireSession(params.sessionId);
-  session.activePrompt = true;
-  session.promptAbort = controller;
-  const signal = controller.signal;
+  const claim = turnsOf(session).claimIdle("queued", controller.signal);
+  const emitTerminal = v2TerminalEmitter(client, params.sessionId, session, claim);
 
-  const notify = async (update: v2.SessionUpdate) => {
-    await raceWithAbort(
-      client.notify(v2.methods.client.session.update, {
-        sessionId: params.sessionId,
-        update
-      }),
-      signal
-    );
-  };
-
-  try {
-    signal.throwIfAborted();
-    await item.ready;
-    signal.throwIfAborted();
-    const { promptText, userMessageId } = item;
-    if (promptText === undefined || userMessageId === undefined) {
-      throw new Error("Queued v2 prompt preparation completed without content");
-    }
-
-    // user_message was already sent at enqueue time.
-    await notify({ sessionUpdate: "state_update", state: "running" });
-    // Cleanup may have aborted while the notification was in flight.
-    signal.throwIfAborted();
-    if (session.closed) {
-      notifyV2BestEffort(client, params.sessionId, {
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason: "cancelled"
-      });
-      return;
-    }
-
-    const slashHandled =
-      isClientTextSlashPrompt(params.prompt as v1.ContentBlock[]) &&
-      (await applyCuratedSlashCommand(
-        params.sessionId,
-        promptText,
-        {
-          configChanged: () => raceWithAbort(
-            deps.notifyConfigOptionUpdateV2(
-              client,
-              params.sessionId,
-              deps.requireSession(params.sessionId)
-            ),
-            signal
-          )
-        },
-        deps
-      ));
-    if (slashHandled) {
-      await notify({
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason: signal.aborted ? "cancelled" : "end_turn"
-      });
-      return;
-    }
-
-    signal.throwIfAborted();
-    if (session.closed) {
-      notifyV2BestEffort(client, params.sessionId, {
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason: "cancelled"
-      });
-      return;
-    }
-
-    const cancelPrompt = () => {
-      session.agy.cancel().catch(() => {});
-    };
-    signal.addEventListener("abort", cancelPrompt, { once: true });
-    // Listener only fires for future aborts; honor an already-aborted signal.
-    if (signal.aborted) {
-      cancelPrompt();
-      signal.throwIfAborted();
-    }
-
-    try {
-      const terminalTracker = createTerminalOutputTracker();
-      const toolContentTracker = createToolCallContentTracker();
-      const clientToolCallName = deps.clientToolCallNameV2?.(client);
-      const outcome = await (async () => {
-        try {
-          return await session.agy.prompt(promptText, async (update) => {
-            for (const v2Update of expandSessionUpdateToV2(update, terminalTracker, toolContentTracker, { clientToolCallName })) {
-              await notify(v2Update);
-            }
-          }, async (toolCall, { toolName, questionIndex }) => {
-            const elicitationCap = deps.clientElicitationV2?.(client);
-            return requestPermissionV2(
-              client,
-              params.sessionId,
-              toolCall,
-              toolName,
-              signal,
-              questionIndex,
-              elicitationCap,
-              clientToolCallName
-            );
-          }, undefined, deps.clientElicitationV2?.(client));
-        } finally {
-          const userStepIdxs = session.agy.lastPromptUserStepIdxs;
-          if (userStepIdxs.length > 1) {
-            throw new Error(`Expected at most one user step for a prompt, observed: ${userStepIdxs.join(", ")}`);
-          }
-          if (userStepIdxs.length === 1) {
-            session.v2UserMessageIdsByStep[String(userStepIdxs[0])] = userMessageId;
-          }
-        }
-      })();
-      if (!session.closed) {
-        await deps.persistSession(params.sessionId, session);
+  await completeTurn(
+    session,
+    claim,
+    async () => {
+      // Preparation (content conversion + user_message) ran at enqueue time.
+      await raceClaim(item.ready, claim);
+      claim.throwIfAborted();
+      const { promptText, userMessageId } = item;
+      if (promptText === undefined || userMessageId === undefined) {
+        throw new Error("Queued v2 prompt preparation completed without content");
       }
-
-      const stopReason =
-        outcome.stopReason === "cancelled" || signal.aborted || session.closed ? "cancelled" : "end_turn";
-      await notify({
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason
+      const adapter = v2Adapter(params, client, session, deps, {
+        announceUserMessage: false,
+        userMessageId
       });
-    } finally {
-      signal.removeEventListener("abort", cancelPrompt);
-    }
-  } catch (error) {
-    if (!session.closed && !signal.aborted) {
-      await deps.persistSession(params.sessionId, session).catch(() => {});
-    }
-    if (signal.aborted || session.closed) {
-      notifyV2BestEffort(client, params.sessionId, {
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason: "cancelled"
-      });
-      return;
-    }
-    await notify({
-      sessionUpdate: "state_update",
-      state: "idle",
-      stopReason: "end_turn"
-    });
-  } finally {
-    if (session.promptAbort === controller) {
-      session.promptAbort = undefined;
-    }
-    session.activePrompt = false;
-    notifyIdleAndDrainQueue(session);
-  }
-}
-
-async function runV2PromptTurn(
-  params: V2PromptRequest,
-  client: V2AgentContext,
-  session: SessionState,
-  promptText: string,
-  signal: AbortSignal,
-  deps: PromptV2Deps
-): Promise<void> {
-  const notify = async (update: v2.SessionUpdate) => {
-    await raceWithAbort(
-      client.notify(v2.methods.client.session.update, {
-        sessionId: params.sessionId,
-        update
-      }),
-      signal
-    );
-  };
-
-  // Only treat pure client text as a slash-menu selection (not resource bodies).
-  const clientSlash = isClientTextSlashPrompt(params.prompt as v1.ContentBlock[]);
-  const parsedSlash = clientSlash ? parseSlashCommand(promptText) : null;
-  const slashResult = parsedSlash ? interpretSlashCommand(parsedSlash) : null;
-  const userMessageId =
-    slashResult && slashResult.kind !== "pass"
-      ? `slash-${randomUUID()}`
-      : `user-${randomUUID()}`;
-  try {
-    signal.throwIfAborted();
-
-    // User message acknowledgment — source of truth for agent-owned messageId.
-    await notify({
-      sessionUpdate: "user_message",
-      messageId: userMessageId,
-      content: params.prompt as v2.ContentBlock[]
-    });
-
-    signal.throwIfAborted();
-    await notify({ sessionUpdate: "state_update", state: "running" });
-    signal.throwIfAborted();
-    if (session.closed) {
-      notifyV2BestEffort(client, params.sessionId, {
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason: "cancelled"
-      });
-      return;
-    }
-
-    // Curated slash commands → config options (no agy spawn).
-    const slashHandled =
-      clientSlash &&
-      (await applyCuratedSlashCommand(
+      return runTurnBody(
         params.sessionId,
-        promptText,
-        {
-          configChanged: () => raceWithAbort(
-            deps.notifyConfigOptionUpdateV2(
-              client,
-              params.sessionId,
-              deps.requireSession(params.sessionId)
-            ),
-            signal
-          )
-        },
-        deps
-      ));
-    if (slashHandled) {
-      await notify({
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason: signal.aborted ? "cancelled" : "end_turn"
-      });
-      return;
-    }
-
-    signal.throwIfAborted();
-    if (session.closed) {
-      notifyV2BestEffort(client, params.sessionId, {
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason: "cancelled"
-      });
-      return;
-    }
-
-    const cancelPrompt = () => {
-      session.agy.cancel().catch(() => {});
-    };
-    signal.addEventListener("abort", cancelPrompt, { once: true });
-    if (signal.aborted) {
-      cancelPrompt();
-      signal.throwIfAborted();
-    }
-
-    try {
-      const terminalTracker = createTerminalOutputTracker();
-      const toolContentTracker = createToolCallContentTracker();
-      const clientToolCallName = deps.clientToolCallNameV2?.(client);
-      const outcome = await (async () => {
-        try {
-          return await session.agy.prompt(promptText, async (update) => {
-            for (const v2Update of expandSessionUpdateToV2(update, terminalTracker, toolContentTracker, { clientToolCallName })) {
-              await notify(v2Update);
-            }
-          }, async (toolCall, { toolName, questionIndex }) => {
-            const elicitationCap = deps.clientElicitationV2?.(client);
-            return requestPermissionV2(
-              client,
-              params.sessionId,
-              toolCall,
-              toolName,
-              signal,
-              questionIndex,
-              elicitationCap,
-              clientToolCallName
-            );
-          }, undefined, deps.clientElicitationV2?.(client));
-        } finally {
-          const userStepIdxs = session.agy.lastPromptUserStepIdxs;
-          if (userStepIdxs.length > 1) {
-            throw new Error(`Expected at most one user step for a prompt, observed: ${userStepIdxs.join(", ")}`);
-          }
-          if (userStepIdxs.length === 1) {
-            session.v2UserMessageIdsByStep[String(userStepIdxs[0])] = userMessageId;
-          }
-        }
-      })();
-      if (!session.closed) {
-        await deps.persistSession(params.sessionId, session);
+        params.prompt as v1.ContentBlock[],
+        session,
+        claim,
+        adapter,
+        deps,
+        promptText
+      );
+    },
+    {
+      terminal: emitTerminal,
+      failure: async (error) => {
+        console.error(`[agy-acp] queued v2 turn failed: ${(error as Error).message}`);
+        await emitTerminal("end_turn").catch(() => {});
       }
-
-      const stopReason =
-        outcome.stopReason === "cancelled" || signal.aborted || session.closed ? "cancelled" : "end_turn";
-      await notify({
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason
-      });
-    } finally {
-      signal.removeEventListener("abort", cancelPrompt);
     }
-  } catch (error) {
-    if (!session.closed && !signal.aborted) {
-      await deps.persistSession(params.sessionId, session).catch(() => {});
-    }
-    if (signal.aborted || session.closed) {
-      notifyV2BestEffort(client, params.sessionId, {
-        sessionUpdate: "state_update",
-        state: "idle",
-        stopReason: "cancelled"
-      });
-      return;
-    }
-    // Surface a failed turn as idle so the client is not left in `running`.
-    await notify({
-      sessionUpdate: "state_update",
-      state: "idle",
-      stopReason: "end_turn"
-    });
-    throw error;
-  }
+  );
 }

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -186,7 +186,6 @@ export async function handlePromptV1(
   deps: PromptV1Deps
 ): Promise<V1PromptResponse> {
   const session = deps.requireSession(params.sessionId);
-  let releaseSteer: (() => void) | undefined;
   if (session.activePrompt) {
     const intent = parseTurnIntent(params);
     if (intent === "queue") {
@@ -215,8 +214,16 @@ export async function handlePromptV1(
         }
       });
     }
+    if (intent !== "steer") {
+      throw new Error(`Session already has an active prompt: ${params.sessionId}`);
+    }
+  }
 
-    if (intent === "steer") {
+  // Own the steer claim (if any) for the full replacement path — including
+  // setup failures and slash-only turns — so release + queue drain always run.
+  let releaseSteer: (() => void) | undefined;
+  try {
+    if (session.activePrompt) {
       // Reserve before any await so a queued follow-up cannot claim the session.
       releaseSteer = await acquireSteerSlot(session);
       const waitForIdle = session.activePrompt
@@ -232,88 +239,88 @@ export async function handlePromptV1(
       await session.agy.cancel();
       await waitForIdle;
       if (session.closed) {
-        releaseSteer();
-        releaseSteer = undefined;
         return { stopReason: "cancelled" };
       }
-    } else {
-      throw new Error(`Session already has an active prompt: ${params.sessionId}`);
     }
-  }
 
-  const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
+    const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
 
-  // Curated slash commands → config options; do not spawn agy for those.
-  // Only intercept pure client text blocks (not resource/image payloads whose
-  // flattened body happens to look like `/plan`).
-  const handled =
-    isClientTextSlashPrompt(params.prompt) &&
-    (await applyCuratedSlashCommand(
-      params.sessionId,
-      prompt,
-      {
-        // ACP transition: send both legacy current_mode_update (modes-API clients)
-        // and config_option_update (configOptions clients) on slash-command mode changes.
-        modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
-        configChanged: async () => {
-          await deps.notifyConfigOptionUpdateV1(
-            client,
-            params.sessionId,
-            deps.requireSession(params.sessionId)
-          );
-        }
-      },
-      deps
-    ));
-  if (handled) {
-    releaseSteer?.();
-    return { stopReason: signal?.aborted ? "cancelled" : "end_turn" };
-  }
-
-  session.activePrompt = true;
-  const cancelPrompt = () => {
-    session.agy.cancel().catch(() => {
-      // The prompt loop will surface process failures through its own result.
-    });
-  };
-  signal?.addEventListener("abort", cancelPrompt, { once: true });
-
-  try {
-    const tracker = createTerminalOutputTracker();
-    const clientToolCallName = deps.clientToolCallNameV1?.(client);
-    const outcome = await session.agy.prompt(prompt, async (update) => {
-      await client.notify(v1.methods.client.session.update, {
-        sessionId: params.sessionId,
-        update: sessionUpdateToV1(update, tracker, { clientToolCallName })
-      });
-    }, async (toolCall, { toolName, questionIndex }) => {
-      const elicitationCap = deps.clientElicitationV1?.(client);
-      return requestPermissionV1(
-        client,
+    // Curated slash commands → config options; do not spawn agy for those.
+    // Only intercept pure client text blocks (not resource/image payloads whose
+    // flattened body happens to look like `/plan`).
+    const handled =
+      isClientTextSlashPrompt(params.prompt) &&
+      (await applyCuratedSlashCommand(
         params.sessionId,
-        toolCall,
-        toolName,
-        signal,
-        questionIndex,
-        elicitationCap,
-        clientToolCallName
-      );
-    }, deps.clientFileSystemV1(client, params.sessionId), deps.clientElicitationV1?.(client));
-    await deps.persistSession(params.sessionId, session);
-    return {
-      stopReason: outcome.stopReason === "cancelled" || signal?.aborted ? "cancelled" : "end_turn"
+        prompt,
+        {
+          // ACP transition: send both legacy current_mode_update (modes-API clients)
+          // and config_option_update (configOptions clients) on slash-command mode changes.
+          modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
+          configChanged: async () => {
+            await deps.notifyConfigOptionUpdateV1(
+              client,
+              params.sessionId,
+              deps.requireSession(params.sessionId)
+            );
+          }
+        },
+        deps
+      ));
+    if (handled) {
+      return { stopReason: signal?.aborted ? "cancelled" : "end_turn" };
+    }
+
+    session.activePrompt = true;
+    const cancelPrompt = () => {
+      session.agy.cancel().catch(() => {
+        // The prompt loop will surface process failures through its own result.
+      });
     };
-  } catch (error) {
-    // Persist even on failure: agy's conversation id/step position may have
-    // advanced before it errored out, and that partial progress is worth
-    // resuming from on the next prompt.
-    await deps.persistSession(params.sessionId, session).catch(() => {});
-    throw error;
+    signal?.addEventListener("abort", cancelPrompt, { once: true });
+
+    try {
+      const tracker = createTerminalOutputTracker();
+      const clientToolCallName = deps.clientToolCallNameV1?.(client);
+      const outcome = await session.agy.prompt(prompt, async (update) => {
+        await client.notify(v1.methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: sessionUpdateToV1(update, tracker, { clientToolCallName })
+        });
+      }, async (toolCall, { toolName, questionIndex }) => {
+        const elicitationCap = deps.clientElicitationV1?.(client);
+        return requestPermissionV1(
+          client,
+          params.sessionId,
+          toolCall,
+          toolName,
+          signal,
+          questionIndex,
+          elicitationCap,
+          clientToolCallName
+        );
+      }, deps.clientFileSystemV1(client, params.sessionId), deps.clientElicitationV1?.(client));
+      await deps.persistSession(params.sessionId, session);
+      return {
+        stopReason: outcome.stopReason === "cancelled" || signal?.aborted ? "cancelled" : "end_turn"
+      };
+    } catch (error) {
+      // Persist even on failure: agy's conversation id/step position may have
+      // advanced before it errored out, and that partial progress is worth
+      // resuming from on the next prompt.
+      await deps.persistSession(params.sessionId, session).catch(() => {});
+      throw error;
+    } finally {
+      signal?.removeEventListener("abort", cancelPrompt);
+      session.activePrompt = false;
+    }
   } finally {
-    signal?.removeEventListener("abort", cancelPrompt);
-    session.activePrompt = false;
     releaseSteer?.();
-    notifyIdleAndDrainQueue(session);
+    // Slash-only / closed / setup-error paths never set activePrompt; agy turns
+    // clear it in the inner finally. Either way the queue may now proceed.
+    if (!session.activePrompt) {
+      notifyIdleAndDrainQueue(session);
+    }
   }
 }
 
@@ -402,7 +409,6 @@ export async function handlePromptV2(
   deps: PromptV2Deps
 ): Promise<V2PromptResponse> {
   const session = deps.requireSession(params.sessionId);
-  let releaseSteer: (() => void) | undefined;
   if (session.activePrompt) {
     const intent = parseTurnIntent(params);
     if (intent === "queue") {
@@ -443,8 +449,16 @@ export async function handlePromptV2(
       }
       return {};
     }
+    if (intent !== "steer") {
+      throw new Error(`Session already has an active prompt: ${params.sessionId}`);
+    }
+  }
 
-    if (intent === "steer") {
+  let releaseSteer: (() => void) | undefined;
+  // Once the async turn is scheduled, its finally owns release + drain.
+  let turnScheduled = false;
+  try {
+    if (session.activePrompt) {
       // Reserve before any await so a queued follow-up cannot claim the session.
       releaseSteer = await acquireSteerSlot(session);
       const waitForIdle = session.activePrompt
@@ -460,46 +474,54 @@ export async function handlePromptV2(
       await session.agy.cancel();
       await waitForIdle;
       if (session.closed) {
-        releaseSteer();
-        releaseSteer = undefined;
         await client.notify(v2.methods.client.session.update, {
           sessionId: params.sessionId,
           update: { sessionUpdate: "state_update", state: "idle", stopReason: "cancelled" }
         }).catch(() => {});
         return {};
       }
-    } else {
-      throw new Error(`Session already has an active prompt: ${params.sessionId}`);
     }
-  }
 
-  // Content block shapes are compatible at runtime; v1/v2 TS types diverge on open enums.
-  const promptText = await contentBlocksToPrompt(params.prompt as v1.ContentBlock[], session.cwd);
-  session.activePrompt = true;
-  const controller = new AbortController();
-  session.promptAbort = controller;
+    // Content block shapes are compatible at runtime; v1/v2 TS types diverge on open enums.
+    const promptText = await contentBlocksToPrompt(params.prompt as v1.ContentBlock[], session.cwd);
+    session.activePrompt = true;
+    const controller = new AbortController();
+    session.promptAbort = controller;
 
-  // Queue the empty acceptance response before any session/update from the turn.
-  // Work starts on the next event-loop task (see dual-version-agent example).
-  const responseQueued = new Promise<void>((resolve) => {
-    setTimeout(resolve, 0);
-  });
-
-  void responseQueued
-    .then(() => runV2PromptTurn(params, client, session, promptText, controller.signal, deps))
-    .catch((error) => {
-      console.error(`[agy-acp] v2 prompt turn failed: ${(error as Error).message}`);
-    })
-    .finally(() => {
-      if (session.promptAbort === controller) {
-        session.promptAbort = undefined;
-      }
-      session.activePrompt = false;
-      releaseSteer?.();
-      notifyIdleAndDrainQueue(session);
+    // Queue the empty acceptance response before any session/update from the turn.
+    // Work starts on the next event-loop task (see dual-version-agent example).
+    const responseQueued = new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
     });
 
-  return {};
+    const releaseForTurn = releaseSteer;
+    releaseSteer = undefined;
+    turnScheduled = true;
+
+    void responseQueued
+      .then(() => runV2PromptTurn(params, client, session, promptText, controller.signal, deps))
+      .catch((error) => {
+        console.error(`[agy-acp] v2 prompt turn failed: ${(error as Error).message}`);
+      })
+      .finally(() => {
+        if (session.promptAbort === controller) {
+          session.promptAbort = undefined;
+        }
+        session.activePrompt = false;
+        releaseForTurn?.();
+        notifyIdleAndDrainQueue(session);
+      });
+
+    return {};
+  } finally {
+    // Setup failed or closed before the async turn was scheduled.
+    if (!turnScheduled && releaseSteer) {
+      releaseSteer();
+      if (!session.activePrompt) {
+        notifyIdleAndDrainQueue(session);
+      }
+    }
+  }
 }
 
 async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
@@ -521,6 +543,16 @@ async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
 
     // user_message was already sent at enqueue time.
     await notify({ sessionUpdate: "state_update", state: "running" });
+    // Cleanup may have aborted while the notification was in flight.
+    signal.throwIfAborted();
+    if (session.closed) {
+      await notify({
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: "cancelled"
+      });
+      return;
+    }
 
     const slashHandled =
       isClientTextSlashPrompt(params.prompt as v1.ContentBlock[]) &&
@@ -543,10 +575,25 @@ async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
       return;
     }
 
+    signal.throwIfAborted();
+    if (session.closed) {
+      await notify({
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: "cancelled"
+      });
+      return;
+    }
+
     const cancelPrompt = () => {
       session.agy.cancel().catch(() => {});
     };
     signal.addEventListener("abort", cancelPrompt, { once: true });
+    // Listener only fires for future aborts; honor an already-aborted signal.
+    if (signal.aborted) {
+      cancelPrompt();
+      signal.throwIfAborted();
+    }
 
     try {
       const terminalTracker = createTerminalOutputTracker();
@@ -581,10 +628,12 @@ async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
           }
         }
       })();
-      await deps.persistSession(params.sessionId, session);
+      if (!session.closed) {
+        await deps.persistSession(params.sessionId, session);
+      }
 
       const stopReason =
-        outcome.stopReason === "cancelled" || signal.aborted ? "cancelled" : "end_turn";
+        outcome.stopReason === "cancelled" || signal.aborted || session.closed ? "cancelled" : "end_turn";
       await notify({
         sessionUpdate: "state_update",
         state: "idle",
@@ -594,8 +643,10 @@ async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
       signal.removeEventListener("abort", cancelPrompt);
     }
   } catch (error) {
-    await deps.persistSession(params.sessionId, session).catch(() => {});
-    if (signal.aborted) {
+    if (!session.closed && !signal.aborted) {
+      await deps.persistSession(params.sessionId, session).catch(() => {});
+    }
+    if (signal.aborted || session.closed) {
       await notify({
         sessionUpdate: "state_update",
         state: "idle",
@@ -652,6 +703,15 @@ async function runV2PromptTurn(
 
     signal.throwIfAborted();
     await notify({ sessionUpdate: "state_update", state: "running" });
+    signal.throwIfAborted();
+    if (session.closed) {
+      await notify({
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: "cancelled"
+      });
+      return;
+    }
 
     // Curated slash commands → config options (no agy spawn).
     const slashHandled =
@@ -675,10 +735,24 @@ async function runV2PromptTurn(
       return;
     }
 
+    signal.throwIfAborted();
+    if (session.closed) {
+      await notify({
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: "cancelled"
+      });
+      return;
+    }
+
     const cancelPrompt = () => {
       session.agy.cancel().catch(() => {});
     };
     signal.addEventListener("abort", cancelPrompt, { once: true });
+    if (signal.aborted) {
+      cancelPrompt();
+      signal.throwIfAborted();
+    }
 
     try {
       const terminalTracker = createTerminalOutputTracker();
@@ -713,10 +787,12 @@ async function runV2PromptTurn(
           }
         }
       })();
-      await deps.persistSession(params.sessionId, session);
+      if (!session.closed) {
+        await deps.persistSession(params.sessionId, session);
+      }
 
       const stopReason =
-        outcome.stopReason === "cancelled" || signal.aborted ? "cancelled" : "end_turn";
+        outcome.stopReason === "cancelled" || signal.aborted || session.closed ? "cancelled" : "end_turn";
       await notify({
         sessionUpdate: "state_update",
         state: "idle",
@@ -726,8 +802,10 @@ async function runV2PromptTurn(
       signal.removeEventListener("abort", cancelPrompt);
     }
   } catch (error) {
-    await deps.persistSession(params.sessionId, session).catch(() => {});
-    if (signal.aborted) {
+    if (!session.closed && !signal.aborted) {
+      await deps.persistSession(params.sessionId, session).catch(() => {});
+    }
+    if (signal.aborted || session.closed) {
       await notify({
         sessionUpdate: "state_update",
         state: "idle",

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -42,6 +42,7 @@ import {
   isTurnCancelled,
   onAbort,
   raceClaim,
+  raceSignal,
   TurnCancelled,
   turnsOf,
   type TurnClaim
@@ -296,10 +297,15 @@ function v1Adapter(
       const tracker = createTerminalOutputTracker();
       const clientToolCallName = deps.clientToolCallNameV1?.(client);
       return session.agy.prompt(promptText, async (update) => {
-        await client.notify(v1.methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: sessionUpdateToV1(update, tracker, { clientToolCallName })
-        });
+        // I4: agy's print-mode poll loop awaits this callback, so a wedged v1
+        // transport would otherwise pin the turn even after the backend dies.
+        await raceClaim(
+          client.notify(v1.methods.client.session.update, {
+            sessionId: params.sessionId,
+            update: sessionUpdateToV1(update, tracker, { clientToolCallName })
+          }),
+          claim
+        );
       }, async (toolCall, { toolName, questionIndex }) => {
         const elicitationCap = deps.clientElicitationV1?.(client);
         return requestPermissionV1(
@@ -743,14 +749,20 @@ function enqueueV2(
       controller.signal.throwIfAborted();
       const userMessageId = v2UserMessageId(params.prompt as v1.ContentBlock[], promptText);
 
-      await client.notify(v2.methods.client.session.update, {
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "user_message",
-          messageId: userMessageId,
-          content: params.prompt as v2.ContentBlock[]
-        }
-      });
+      // I4: this delivery is serialized across the FIFO, so a wedged transport
+      // would otherwise jam every later queued prompt; cancelling the item
+      // must unwedge the chain.
+      await raceSignal(
+        client.notify(v2.methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "user_message",
+            messageId: userMessageId,
+            content: params.prompt as v2.ContentBlock[]
+          }
+        }),
+        controller.signal
+      );
       controller.signal.throwIfAborted();
       if (session.closed) throw new TurnCancelled();
       queued.promptText = promptText;

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -109,6 +109,7 @@ export function notifyIdleAndDrainQueue(session: SessionState): void {
 
   const next = session.promptQueue.shift()!;
   if (next.version === "v1") {
+    next.detachQueueCancel?.();
     if (next.signal?.aborted) {
       next.resolve({ stopReason: "cancelled" });
       notifyIdleAndDrainQueue(session);
@@ -565,7 +566,7 @@ function enqueueV1(
 ): Promise<V1PromptResponse> {
   return new Promise<V1PromptResponse>((resolve, reject) => {
     const queuedId = `q-${randomUUID()}`;
-    session.promptQueue.push({
+    const item: QueuedPromptV1 = {
       id: queuedId,
       version: "v1",
       params,
@@ -574,15 +575,22 @@ function enqueueV1(
       deps,
       resolve,
       reject
-    } satisfies QueuedPromptV1);
+    };
+    session.promptQueue.push(item);
     if (signal) {
-      onAbort(signal, () => {
+      // The listener's job ends when the item leaves the FIFO by any path —
+      // afterwards the turn's claim owns cancellation. Detaching keeps a
+      // long-lived request signal from pinning the session.
+      let detach: () => void = () => {};
+      detach = onAbort(signal, () => {
+        detach();
         const idx = session.promptQueue.findIndex((q) => q.id === queuedId);
         if (idx >= 0) {
           session.promptQueue.splice(idx, 1);
           resolve({ stopReason: "cancelled" });
         }
       });
+      item.detachQueueCancel = detach;
     }
   });
 }

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -69,6 +69,8 @@ export function notifyIdleAndDrainQueue(session: SessionState): void {
   }
 
   if (session.closed) return;
+  // A steer has reserved the next turn (possibly still waiting on a prior steer).
+  if ((session.steerClaims ?? 0) > 0) return;
 
   if (!session.activePrompt && session.promptQueue.length > 0) {
     const next = session.promptQueue.shift()!;
@@ -91,6 +93,36 @@ export function notifyIdleAndDrainQueue(session: SessionState): void {
       void executeQueuedV2Turn(next);
     }
   }
+}
+
+/**
+ * Claim the session for a steer replacement before any await, then serialize
+ * against other steers. The returned release must run exactly once (success,
+ * cancel, or closed) so the queue can drain again.
+ */
+async function acquireSteerSlot(session: SessionState): Promise<() => void> {
+  session.steerClaims = (session.steerClaims ?? 0) + 1;
+  const previousSteer = session.promptSteerInProgress;
+  let release!: () => void;
+  session.promptSteerInProgress = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  if (previousSteer) await previousSteer;
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    session.steerClaims = Math.max(0, (session.steerClaims ?? 1) - 1);
+    release();
+  };
+}
+
+/** Wake any steer idle-waiter after marking the session closed. */
+export function wakePromptIdleWaiters(session: SessionState): void {
+  const notify = session.promptIdleNotify;
+  session.promptIdleNotify = undefined;
+  notify?.();
 }
 
 /**
@@ -185,13 +217,8 @@ export async function handlePromptV1(
     }
 
     if (intent === "steer") {
-      const previousSteer = session.promptSteerInProgress;
-      if (previousSteer) await previousSteer;
-      let release!: () => void;
-      session.promptSteerInProgress = new Promise<void>((resolve) => {
-        release = resolve;
-      });
-      releaseSteer = release;
+      // Reserve before any await so a queued follow-up cannot claim the session.
+      releaseSteer = await acquireSteerSlot(session);
       const waitForIdle = session.activePrompt
         ? new Promise<void>((resolve) => {
             const prevNotify = session.promptIdleNotify;
@@ -206,6 +233,7 @@ export async function handlePromptV1(
       await waitForIdle;
       if (session.closed) {
         releaseSteer();
+        releaseSteer = undefined;
         return { stopReason: "cancelled" };
       }
     } else {
@@ -417,13 +445,8 @@ export async function handlePromptV2(
     }
 
     if (intent === "steer") {
-      const previousSteer = session.promptSteerInProgress;
-      if (previousSteer) await previousSteer;
-      let release!: () => void;
-      session.promptSteerInProgress = new Promise<void>((resolve) => {
-        release = resolve;
-      });
-      releaseSteer = release;
+      // Reserve before any await so a queued follow-up cannot claim the session.
+      releaseSteer = await acquireSteerSlot(session);
       const waitForIdle = session.activePrompt
         ? new Promise<void>((resolve) => {
             const prevNotify = session.promptIdleNotify;
@@ -438,6 +461,7 @@ export async function handlePromptV2(
       await waitForIdle;
       if (session.closed) {
         releaseSteer();
+        releaseSteer = undefined;
         await client.notify(v2.methods.client.session.update, {
           sessionId: params.sessionId,
           update: { sessionUpdate: "state_update", state: "idle", stopReason: "cancelled" }

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -68,6 +68,8 @@ export function notifyIdleAndDrainQueue(session: SessionState): void {
     return;
   }
 
+  if (session.closed) return;
+
   if (!session.activePrompt && session.promptQueue.length > 0) {
     const next = session.promptQueue.shift()!;
     if (next.version === "v1") {
@@ -152,6 +154,7 @@ export async function handlePromptV1(
   deps: PromptV1Deps
 ): Promise<V1PromptResponse> {
   const session = deps.requireSession(params.sessionId);
+  let releaseSteer: (() => void) | undefined;
   if (session.activePrompt) {
     const intent = parseTurnIntent(params);
     if (intent === "queue") {
@@ -182,16 +185,28 @@ export async function handlePromptV1(
     }
 
     if (intent === "steer") {
+      const previousSteer = session.promptSteerInProgress;
+      if (previousSteer) await previousSteer;
+      let release!: () => void;
+      session.promptSteerInProgress = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      releaseSteer = release;
+      const waitForIdle = session.activePrompt
+        ? new Promise<void>((resolve) => {
+            const prevNotify = session.promptIdleNotify;
+            session.promptIdleNotify = () => {
+              prevNotify?.();
+              resolve();
+            };
+          })
+        : undefined;
       session.promptAbort?.abort();
       await session.agy.cancel();
-      if (session.activePrompt) {
-        await new Promise<void>((resolve) => {
-          const prevNotify = session.promptIdleNotify;
-          session.promptIdleNotify = () => {
-            prevNotify?.();
-            resolve();
-          };
-        });
+      await waitForIdle;
+      if (session.closed) {
+        releaseSteer();
+        return { stopReason: "cancelled" };
       }
     } else {
       throw new Error(`Session already has an active prompt: ${params.sessionId}`);
@@ -223,6 +238,7 @@ export async function handlePromptV1(
       deps
     ));
   if (handled) {
+    releaseSteer?.();
     return { stopReason: signal?.aborted ? "cancelled" : "end_turn" };
   }
 
@@ -268,6 +284,7 @@ export async function handlePromptV1(
   } finally {
     signal?.removeEventListener("abort", cancelPrompt);
     session.activePrompt = false;
+    releaseSteer?.();
     notifyIdleAndDrainQueue(session);
   }
 }
@@ -280,21 +297,23 @@ async function executeQueuedV1Turn(item: QueuedPromptV1): Promise<void> {
   try {
     const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
 
-    const handled = await applyCuratedSlashCommand(
-      params.sessionId,
-      prompt,
-      {
-        modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
-        configChanged: async () => {
-          await deps.notifyConfigOptionUpdateV1(
-            client,
-            params.sessionId,
-            deps.requireSession(params.sessionId)
-          );
-        }
-      },
-      deps
-    );
+    const handled =
+      isClientTextSlashPrompt(params.prompt) &&
+      (await applyCuratedSlashCommand(
+        params.sessionId,
+        prompt,
+        {
+          modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
+          configChanged: async () => {
+            await deps.notifyConfigOptionUpdateV1(
+              client,
+              params.sessionId,
+              deps.requireSession(params.sessionId)
+            );
+          }
+        },
+        deps
+      ));
     if (handled) {
       resolve({ stopReason: signal?.aborted ? "cancelled" : "end_turn" });
       return;
@@ -355,11 +374,14 @@ export async function handlePromptV2(
   deps: PromptV2Deps
 ): Promise<V2PromptResponse> {
   const session = deps.requireSession(params.sessionId);
+  let releaseSteer: (() => void) | undefined;
   if (session.activePrompt) {
     const intent = parseTurnIntent(params);
     if (intent === "queue") {
       const promptText = await contentBlocksToPrompt(params.prompt as v1.ContentBlock[], session.cwd);
-      const parsedSlash = parseSlashCommand(promptText);
+      const parsedSlash = isClientTextSlashPrompt(params.prompt as v1.ContentBlock[])
+        ? parseSlashCommand(promptText)
+        : null;
       const slashResult = parsedSlash ? interpretSlashCommand(parsedSlash) : null;
       const userMessageId =
         slashResult && slashResult.kind !== "pass"
@@ -395,16 +417,32 @@ export async function handlePromptV2(
     }
 
     if (intent === "steer") {
+      const previousSteer = session.promptSteerInProgress;
+      if (previousSteer) await previousSteer;
+      let release!: () => void;
+      session.promptSteerInProgress = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      releaseSteer = release;
+      const waitForIdle = session.activePrompt
+        ? new Promise<void>((resolve) => {
+            const prevNotify = session.promptIdleNotify;
+            session.promptIdleNotify = () => {
+              prevNotify?.();
+              resolve();
+            };
+          })
+        : undefined;
       session.promptAbort?.abort();
       await session.agy.cancel();
-      if (session.activePrompt) {
-        await new Promise<void>((resolve) => {
-          const prevNotify = session.promptIdleNotify;
-          session.promptIdleNotify = () => {
-            prevNotify?.();
-            resolve();
-          };
-        });
+      await waitForIdle;
+      if (session.closed) {
+        releaseSteer();
+        await client.notify(v2.methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "state_update", state: "idle", stopReason: "cancelled" }
+        }).catch(() => {});
+        return {};
       }
     } else {
       throw new Error(`Session already has an active prompt: ${params.sessionId}`);
@@ -433,6 +471,7 @@ export async function handlePromptV2(
         session.promptAbort = undefined;
       }
       session.activePrompt = false;
+      releaseSteer?.();
       notifyIdleAndDrainQueue(session);
     });
 
@@ -459,16 +498,18 @@ async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
     // user_message was already sent at enqueue time.
     await notify({ sessionUpdate: "state_update", state: "running" });
 
-    const slashHandled = await applyCuratedSlashCommand(
-      params.sessionId,
-      promptText,
-      {
-        configChanged: async () => {
-          await deps.notifyConfigOptionUpdateV2(client, params.sessionId, deps.requireSession(params.sessionId));
-        }
-      },
-      deps
-    );
+    const slashHandled =
+      isClientTextSlashPrompt(params.prompt as v1.ContentBlock[]) &&
+      (await applyCuratedSlashCommand(
+        params.sessionId,
+        promptText,
+        {
+          configChanged: async () => {
+            await deps.notifyConfigOptionUpdateV2(client, params.sessionId, deps.requireSession(params.sessionId));
+          }
+        },
+        deps
+      ));
     if (slashHandled) {
       await notify({
         sessionUpdate: "state_update",

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -19,7 +19,12 @@ import type { ClientToolCallNameCapability } from "../initialize.js";
 import type { SessionModeId } from "../../agy/cli.js";
 import { contentBlocksToPrompt } from "../content/index.js";
 import type { ClientFileSystem } from "../../agy/edit/bridge.js";
-import { interpretSlashCommand, parseSlashCommand, resolveModelValue } from "../slash-commands/index.js";
+import {
+  interpretSlashCommand,
+  isClientTextSlashPrompt,
+  parseSlashCommand,
+  resolveModelValue
+} from "../slash-commands/index.js";
 import { MODEL_CONFIG_ID } from "./config-options.js";
 import { MODE_CONFIG_ID } from "./modes.js";
 import { requestPermissionV1, requestPermissionV2 } from "./request-permission.js";
@@ -114,23 +119,27 @@ export async function handlePromptV1(
   const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
 
   // Curated slash commands → config options; do not spawn agy for those.
-  const handled = await applyCuratedSlashCommand(
-    params.sessionId,
-    prompt,
-    {
-      // ACP transition: send both legacy current_mode_update (modes-API clients)
-      // and config_option_update (configOptions clients) on slash-command mode changes.
-      modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
-      configChanged: async () => {
-        await deps.notifyConfigOptionUpdateV1(
-          client,
-          params.sessionId,
-          deps.requireSession(params.sessionId)
-        );
-      }
-    },
-    deps
-  );
+  // Only intercept pure client text blocks (not resource/image payloads whose
+  // flattened body happens to look like `/plan`).
+  const handled =
+    isClientTextSlashPrompt(params.prompt) &&
+    (await applyCuratedSlashCommand(
+      params.sessionId,
+      prompt,
+      {
+        // ACP transition: send both legacy current_mode_update (modes-API clients)
+        // and config_option_update (configOptions clients) on slash-command mode changes.
+        modeChanged: (mode) => deps.notifyCurrentModeUpdate(client, params.sessionId, mode),
+        configChanged: async () => {
+          await deps.notifyConfigOptionUpdateV1(
+            client,
+            params.sessionId,
+            deps.requireSession(params.sessionId)
+          );
+        }
+      },
+      deps
+    ));
   if (handled) {
     return { stopReason: signal?.aborted ? "cancelled" : "end_turn" };
   }
@@ -239,7 +248,9 @@ async function runV2PromptTurn(
     });
   };
 
-  const parsedSlash = parseSlashCommand(promptText);
+  // Only treat pure client text as a slash-menu selection (not resource bodies).
+  const clientSlash = isClientTextSlashPrompt(params.prompt as v1.ContentBlock[]);
+  const parsedSlash = clientSlash ? parseSlashCommand(promptText) : null;
   const slashResult = parsedSlash ? interpretSlashCommand(parsedSlash) : null;
   const userMessageId =
     slashResult && slashResult.kind !== "pass"
@@ -259,16 +270,18 @@ async function runV2PromptTurn(
     await notify({ sessionUpdate: "state_update", state: "running" });
 
     // Curated slash commands → config options (no agy spawn).
-    const slashHandled = await applyCuratedSlashCommand(
-      params.sessionId,
-      promptText,
-      {
-        configChanged: async () => {
-          await deps.notifyConfigOptionUpdateV2(client, params.sessionId, deps.requireSession(params.sessionId));
-        }
-      },
-      deps
-    );
+    const slashHandled =
+      clientSlash &&
+      (await applyCuratedSlashCommand(
+        params.sessionId,
+        promptText,
+        {
+          configChanged: async () => {
+            await deps.notifyConfigOptionUpdateV2(client, params.sessionId, deps.requireSession(params.sessionId));
+          }
+        },
+        deps
+      ));
     if (slashHandled) {
       await notify({
         sessionUpdate: "state_update",

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -60,6 +60,39 @@ export function parseTurnIntent(params: unknown): TurnIntent | undefined {
   return undefined;
 }
 
+function raceWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+function notifyV2BestEffort(
+  client: V2AgentContext,
+  sessionId: string,
+  update: v2.SessionUpdate
+): void {
+  try {
+    void client.notify(v2.methods.client.session.update, { sessionId, update }).catch(() => {});
+  } catch {
+    // Teardown must not wait for or fail on a disconnected client transport.
+  }
+}
+
 /** True when a turn is running or a steer has reserved the next turn. */
 export function sessionTurnBusy(session: SessionState): boolean {
   return session.activePrompt || (session.steerClaims ?? 0) > 0;
@@ -195,7 +228,8 @@ export async function handlePromptV1(
   deps: PromptV1Deps
 ): Promise<V1PromptResponse> {
   const session = deps.requireSession(params.sessionId);
-  if (sessionTurnBusy(session)) {
+  const busyAtAdmission = sessionTurnBusy(session);
+  if (busyAtAdmission) {
     const intent = parseTurnIntent(params);
     if (intent === "queue") {
       return new Promise<V1PromptResponse>((resolve, reject) => {
@@ -232,11 +266,21 @@ export async function handlePromptV1(
   // Own the steer claim (if any) for the full replacement path — including
   // setup failures and slash-only turns — so release + queue drain always run.
   let releaseSteer: (() => void) | undefined;
+  let ownsActivePrompt = false;
   const cancelled = () => Boolean(signal?.aborted || session.closed);
+  if (!busyAtAdmission) {
+    // Claim an idle session before attachment conversion or config awaits.
+    session.activePrompt = true;
+    ownsActivePrompt = true;
+  }
   try {
-    if (sessionTurnBusy(session)) {
+    if (busyAtAdmission) {
       // Reserve before any await so a queued follow-up cannot claim the session.
       releaseSteer = await acquireSteerSlot(session);
+      // Teardown may have completed while this steer waited behind another.
+      if (cancelled()) {
+        return { stopReason: "cancelled" };
+      }
       const waitForIdle = session.activePrompt
         ? new Promise<void>((resolve) => {
             const prevNotify = session.promptIdleNotify;
@@ -253,6 +297,8 @@ export async function handlePromptV1(
       if (cancelled()) {
         return { stopReason: "cancelled" };
       }
+      session.activePrompt = true;
+      ownsActivePrompt = true;
     }
 
     const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
@@ -290,7 +336,6 @@ export async function handlePromptV1(
       return { stopReason: "cancelled" };
     }
 
-    session.activePrompt = true;
     const cancelPrompt = () => {
       session.agy.cancel().catch(() => {
         // The prompt loop will surface process failures through its own result.
@@ -300,7 +345,6 @@ export async function handlePromptV1(
     // Listener only fires for future aborts; honor an already-aborted signal.
     if (signal?.aborted) {
       signal.removeEventListener("abort", cancelPrompt);
-      session.activePrompt = false;
       return { stopReason: "cancelled" };
     }
 
@@ -341,12 +385,14 @@ export async function handlePromptV1(
       throw error;
     } finally {
       signal?.removeEventListener("abort", cancelPrompt);
-      session.activePrompt = false;
     }
   } finally {
+    if (ownsActivePrompt) {
+      session.activePrompt = false;
+    }
     releaseSteer?.();
-    // Slash-only / closed / setup-error paths never set activePrompt; agy turns
-    // clear it in the inner finally. Either way the queue may now proceed.
+    // Slash-only, closed, setup-error, and agy paths all release the same
+    // admission claim here, after which queued work may proceed.
     if (!session.activePrompt) {
       notifyIdleAndDrainQueue(session);
     }
@@ -470,45 +516,10 @@ export async function handlePromptV2(
   deps: PromptV2Deps
 ): Promise<V2PromptResponse> {
   const session = deps.requireSession(params.sessionId);
-  if (sessionTurnBusy(session)) {
+  const busyAtAdmission = sessionTurnBusy(session);
+  if (busyAtAdmission) {
     const intent = parseTurnIntent(params);
     if (intent === "queue") {
-      const promptText = await contentBlocksToPrompt(params.prompt as v1.ContentBlock[], session.cwd);
-      if (session.closed) {
-        await client.notify(v2.methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: { sessionUpdate: "state_update", state: "idle", stopReason: "cancelled" }
-        }).catch(() => {});
-        return {};
-      }
-
-      const parsedSlash = isClientTextSlashPrompt(params.prompt as v1.ContentBlock[])
-        ? parseSlashCommand(promptText)
-        : null;
-      const slashResult = parsedSlash ? interpretSlashCommand(parsedSlash) : null;
-      const userMessageId =
-        slashResult && slashResult.kind !== "pass"
-          ? `slash-${randomUUID()}`
-          : `user-${randomUUID()}`;
-
-      await client.notify(v2.methods.client.session.update, {
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "user_message",
-          messageId: userMessageId,
-          content: params.prompt as v2.ContentBlock[]
-        }
-      });
-
-      // Cleanup may have drained the queue while user_message was in flight.
-      if (session.closed) {
-        await client.notify(v2.methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: { sessionUpdate: "state_update", state: "idle", stopReason: "cancelled" }
-        }).catch(() => {});
-        return {};
-      }
-
       const controller = new AbortController();
       const queuedId = `q-${randomUUID()}`;
       const queued: QueuedPromptV2 = {
@@ -516,12 +527,61 @@ export async function handlePromptV2(
         version: "v2",
         params,
         client,
-        promptText,
-        userMessageId,
+        ready: Promise.resolve(),
         controller,
         deps
       };
+      // Enter FIFO before conversion or client transport awaits can reorder
+      // concurrently admitted queue requests.
       session.promptQueue.push(queued);
+      const responseQueued = new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      const previousPreparation = session.promptQueuePreparation ?? Promise.resolve();
+      queued.ready = raceWithAbort(
+        previousPreparation.catch(() => {}).then(() => responseQueued).then(async () => {
+          const promptText = await contentBlocksToPrompt(
+            params.prompt as v1.ContentBlock[],
+            session.cwd
+          );
+          controller.signal.throwIfAborted();
+          const parsedSlash = isClientTextSlashPrompt(params.prompt as v1.ContentBlock[])
+            ? parseSlashCommand(promptText)
+            : null;
+          const slashResult = parsedSlash ? interpretSlashCommand(parsedSlash) : null;
+          const userMessageId =
+            slashResult && slashResult.kind !== "pass"
+              ? `slash-${randomUUID()}`
+              : `user-${randomUUID()}`;
+
+          await client.notify(v2.methods.client.session.update, {
+            sessionId: params.sessionId,
+            update: {
+              sessionUpdate: "user_message",
+              messageId: userMessageId,
+              content: params.prompt as v2.ContentBlock[]
+            }
+          });
+          controller.signal.throwIfAborted();
+          queued.promptText = promptText;
+          queued.userMessageId = userMessageId;
+        }),
+        controller.signal
+      );
+      session.promptQueuePreparation = queued.ready.then(() => {}, () => {});
+      void queued.ready.catch(() => {
+        const idx = session.promptQueue.findIndex((item) => item.id === queuedId);
+        if (idx < 0) return; // The FIFO executor owns terminal reporting.
+        session.promptQueue.splice(idx, 1);
+        if (!controller.signal.aborted && !session.closed) {
+          notifyV2BestEffort(client, params.sessionId, {
+            sessionUpdate: "state_update",
+            state: "idle",
+            stopReason: "end_turn"
+          });
+        }
+        if (!sessionTurnBusy(session)) notifyIdleAndDrainQueue(session);
+      });
       if (!sessionTurnBusy(session)) {
         notifyIdleAndDrainQueue(session);
       }
@@ -533,12 +593,27 @@ export async function handlePromptV2(
   }
 
   let releaseSteer: (() => void) | undefined;
+  let ownsActivePrompt = false;
   // Once the async turn is scheduled, its finally owns release + drain.
   let turnScheduled = false;
+  if (!busyAtAdmission) {
+    // Claim an idle session before attachment conversion.
+    session.activePrompt = true;
+    ownsActivePrompt = true;
+  }
   try {
-    if (sessionTurnBusy(session)) {
+    if (busyAtAdmission) {
       // Reserve before any await so a queued follow-up cannot claim the session.
       releaseSteer = await acquireSteerSlot(session);
+      // Teardown may have completed while this steer waited behind another.
+      if (session.closed) {
+        notifyV2BestEffort(client, params.sessionId, {
+          sessionUpdate: "state_update",
+          state: "idle",
+          stopReason: "cancelled"
+        });
+        return {};
+      }
       const waitForIdle = session.activePrompt
         ? new Promise<void>((resolve) => {
             const prevNotify = session.promptIdleNotify;
@@ -552,17 +627,27 @@ export async function handlePromptV2(
       await session.agy.cancel();
       await waitForIdle;
       if (session.closed) {
-        await client.notify(v2.methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: { sessionUpdate: "state_update", state: "idle", stopReason: "cancelled" }
-        }).catch(() => {});
+        notifyV2BestEffort(client, params.sessionId, {
+          sessionUpdate: "state_update",
+          state: "idle",
+          stopReason: "cancelled"
+        });
         return {};
       }
+      session.activePrompt = true;
+      ownsActivePrompt = true;
     }
 
     // Content block shapes are compatible at runtime; v1/v2 TS types diverge on open enums.
     const promptText = await contentBlocksToPrompt(params.prompt as v1.ContentBlock[], session.cwd);
-    session.activePrompt = true;
+    if (session.closed) {
+      notifyV2BestEffort(client, params.sessionId, {
+        sessionUpdate: "state_update",
+        state: "idle",
+        stopReason: "cancelled"
+      });
+      return {};
+    }
     const controller = new AbortController();
     session.promptAbort = controller;
 
@@ -595,36 +680,48 @@ export async function handlePromptV2(
     // Setup failed or closed before the async turn was scheduled.
     if (!turnScheduled && releaseSteer) {
       releaseSteer();
-      if (!session.activePrompt) {
-        notifyIdleAndDrainQueue(session);
-      }
+    }
+    if (!turnScheduled && ownsActivePrompt) {
+      session.activePrompt = false;
+    }
+    if (!turnScheduled && !session.activePrompt) {
+      notifyIdleAndDrainQueue(session);
     }
   }
 }
 
 async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
-  const { params, client, promptText, userMessageId, controller, deps } = item;
+  const { params, client, controller, deps } = item;
   const session = deps.requireSession(params.sessionId);
   session.activePrompt = true;
   session.promptAbort = controller;
+  const signal = controller.signal;
 
   const notify = async (update: v2.SessionUpdate) => {
-    await client.notify(v2.methods.client.session.update, {
-      sessionId: params.sessionId,
-      update
-    });
+    await raceWithAbort(
+      client.notify(v2.methods.client.session.update, {
+        sessionId: params.sessionId,
+        update
+      }),
+      signal
+    );
   };
 
-  const signal = controller.signal;
   try {
     signal.throwIfAborted();
+    await item.ready;
+    signal.throwIfAborted();
+    const { promptText, userMessageId } = item;
+    if (promptText === undefined || userMessageId === undefined) {
+      throw new Error("Queued v2 prompt preparation completed without content");
+    }
 
     // user_message was already sent at enqueue time.
     await notify({ sessionUpdate: "state_update", state: "running" });
     // Cleanup may have aborted while the notification was in flight.
     signal.throwIfAborted();
     if (session.closed) {
-      await notify({
+      notifyV2BestEffort(client, params.sessionId, {
         sessionUpdate: "state_update",
         state: "idle",
         stopReason: "cancelled"
@@ -638,9 +735,14 @@ async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
         params.sessionId,
         promptText,
         {
-          configChanged: async () => {
-            await deps.notifyConfigOptionUpdateV2(client, params.sessionId, deps.requireSession(params.sessionId));
-          }
+          configChanged: () => raceWithAbort(
+            deps.notifyConfigOptionUpdateV2(
+              client,
+              params.sessionId,
+              deps.requireSession(params.sessionId)
+            ),
+            signal
+          )
         },
         deps
       ));
@@ -655,7 +757,7 @@ async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
 
     signal.throwIfAborted();
     if (session.closed) {
-      await notify({
+      notifyV2BestEffort(client, params.sessionId, {
         sessionUpdate: "state_update",
         state: "idle",
         stopReason: "cancelled"
@@ -725,7 +827,7 @@ async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
       await deps.persistSession(params.sessionId, session).catch(() => {});
     }
     if (signal.aborted || session.closed) {
-      await notify({
+      notifyV2BestEffort(client, params.sessionId, {
         sessionUpdate: "state_update",
         state: "idle",
         stopReason: "cancelled"
@@ -755,10 +857,13 @@ async function runV2PromptTurn(
   deps: PromptV2Deps
 ): Promise<void> {
   const notify = async (update: v2.SessionUpdate) => {
-    await client.notify(v2.methods.client.session.update, {
-      sessionId: params.sessionId,
-      update
-    });
+    await raceWithAbort(
+      client.notify(v2.methods.client.session.update, {
+        sessionId: params.sessionId,
+        update
+      }),
+      signal
+    );
   };
 
   // Only treat pure client text as a slash-menu selection (not resource bodies).
@@ -783,7 +888,7 @@ async function runV2PromptTurn(
     await notify({ sessionUpdate: "state_update", state: "running" });
     signal.throwIfAborted();
     if (session.closed) {
-      await notify({
+      notifyV2BestEffort(client, params.sessionId, {
         sessionUpdate: "state_update",
         state: "idle",
         stopReason: "cancelled"
@@ -798,9 +903,14 @@ async function runV2PromptTurn(
         params.sessionId,
         promptText,
         {
-          configChanged: async () => {
-            await deps.notifyConfigOptionUpdateV2(client, params.sessionId, deps.requireSession(params.sessionId));
-          }
+          configChanged: () => raceWithAbort(
+            deps.notifyConfigOptionUpdateV2(
+              client,
+              params.sessionId,
+              deps.requireSession(params.sessionId)
+            ),
+            signal
+          )
         },
         deps
       ));
@@ -815,7 +925,7 @@ async function runV2PromptTurn(
 
     signal.throwIfAborted();
     if (session.closed) {
-      await notify({
+      notifyV2BestEffort(client, params.sessionId, {
         sessionUpdate: "state_update",
         state: "idle",
         stopReason: "cancelled"
@@ -884,7 +994,7 @@ async function runV2PromptTurn(
       await deps.persistSession(params.sessionId, session).catch(() => {});
     }
     if (signal.aborted || session.closed) {
-      await notify({
+      notifyV2BestEffort(client, params.sessionId, {
         sessionUpdate: "state_update",
         state: "idle",
         stopReason: "cancelled"

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -232,6 +232,7 @@ export async function handlePromptV1(
   // Own the steer claim (if any) for the full replacement path — including
   // setup failures and slash-only turns — so release + queue drain always run.
   let releaseSteer: (() => void) | undefined;
+  const cancelled = () => Boolean(signal?.aborted || session.closed);
   try {
     if (sessionTurnBusy(session)) {
       // Reserve before any await so a queued follow-up cannot claim the session.
@@ -248,12 +249,16 @@ export async function handlePromptV1(
       session.promptAbort?.abort();
       await session.agy.cancel();
       await waitForIdle;
-      if (session.closed) {
+      // Request may have been cancelled while waiting on the prior turn/steer.
+      if (cancelled()) {
         return { stopReason: "cancelled" };
       }
     }
 
     const prompt = await contentBlocksToPrompt(params.prompt, session.cwd);
+    if (cancelled()) {
+      return { stopReason: "cancelled" };
+    }
 
     // Curated slash commands → config options; do not spawn agy for those.
     // Only intercept pure client text blocks (not resource/image payloads whose
@@ -278,7 +283,11 @@ export async function handlePromptV1(
         deps
       ));
     if (handled) {
-      return { stopReason: signal?.aborted ? "cancelled" : "end_turn" };
+      return { stopReason: cancelled() ? "cancelled" : "end_turn" };
+    }
+
+    if (cancelled()) {
+      return { stopReason: "cancelled" };
     }
 
     session.activePrompt = true;
@@ -288,6 +297,12 @@ export async function handlePromptV1(
       });
     };
     signal?.addEventListener("abort", cancelPrompt, { once: true });
+    // Listener only fires for future aborts; honor an already-aborted signal.
+    if (signal?.aborted) {
+      signal.removeEventListener("abort", cancelPrompt);
+      session.activePrompt = false;
+      return { stopReason: "cancelled" };
+    }
 
     try {
       const tracker = createTerminalOutputTracker();
@@ -310,15 +325,19 @@ export async function handlePromptV1(
           clientToolCallName
         );
       }, deps.clientFileSystemV1(client, params.sessionId), deps.clientElicitationV1?.(client));
-      await deps.persistSession(params.sessionId, session);
+      if (!session.closed) {
+        await deps.persistSession(params.sessionId, session);
+      }
       return {
-        stopReason: outcome.stopReason === "cancelled" || signal?.aborted ? "cancelled" : "end_turn"
+        stopReason: outcome.stopReason === "cancelled" || cancelled() ? "cancelled" : "end_turn"
       };
     } catch (error) {
       // Persist even on failure: agy's conversation id/step position may have
       // advanced before it errored out, and that partial progress is worth
       // resuming from on the next prompt.
-      await deps.persistSession(params.sessionId, session).catch(() => {});
+      if (!session.closed && !signal?.aborted) {
+        await deps.persistSession(params.sessionId, session).catch(() => {});
+      }
       throw error;
     } finally {
       signal?.removeEventListener("abort", cancelPrompt);

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -628,8 +628,11 @@ export async function handlePromptV2(
   if (turns.busy()) {
     const intent = parseTurnIntent(params);
     if (intent === "queue") {
-      enqueueV2(params, client, session, deps);
-      return {};
+      const queuedId = enqueueV2(params, client, session, deps);
+      // Surface the cancellation handle: the user_message notification carries
+      // a different id and may arrive late (or wedge), so the acceptance
+      // response is the only reliable place to hand it over.
+      return { _meta: { "agy-acp/queuedPromptId": queuedId } };
     }
     if (intent !== "steer") {
       throw new Error(`Session already has an active prompt: ${params.sessionId}`);
@@ -720,7 +723,7 @@ function enqueueV2(
   client: V2AgentContext,
   session: SessionState,
   deps: PromptV2Deps
-): void {
+): string {
   const controller = new AbortController();
   const queuedId = `q-${randomUUID()}`;
   const queued: QueuedPromptV2 = {
@@ -783,6 +786,7 @@ function enqueueV2(
   });
 
   notifyIdleAndDrainQueue(session);
+  return queuedId;
 }
 
 async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
@@ -791,37 +795,45 @@ async function executeQueuedV2Turn(item: QueuedPromptV2): Promise<void> {
   const claim = turnsOf(session).claimIdle("queued", controller.signal);
   const emitTerminal = v2TerminalEmitter(client, params.sessionId, session, claim);
 
-  await completeTurn(
-    session,
-    claim,
-    async () => {
-      // Preparation (content conversion + user_message) ran at enqueue time.
-      await raceClaim(item.ready, claim);
-      claim.throwIfAborted();
-      const { promptText, userMessageId } = item;
-      if (promptText === undefined || userMessageId === undefined) {
-        throw new Error("Queued v2 prompt preparation completed without content");
+  // Cancelling this turn must also abort preparation: if user_message
+  // delivery is still wedged, the item's `ready` would otherwise stay pinned
+  // in `promptQueuePreparation` and jam every later queued prompt (I4).
+  const propagateCancellation = onAbort(claim.signal, () => controller.abort());
+  try {
+    await completeTurn(
+      session,
+      claim,
+      async () => {
+        // Preparation (content conversion + user_message) ran at enqueue time.
+        await raceClaim(item.ready, claim);
+        claim.throwIfAborted();
+        const { promptText, userMessageId } = item;
+        if (promptText === undefined || userMessageId === undefined) {
+          throw new Error("Queued v2 prompt preparation completed without content");
+        }
+        const adapter = v2Adapter(params, client, session, deps, {
+          announceUserMessage: false,
+          userMessageId
+        });
+        return runTurnBody(
+          params.sessionId,
+          params.prompt as v1.ContentBlock[],
+          session,
+          claim,
+          adapter,
+          deps,
+          promptText
+        );
+      },
+      {
+        terminal: emitTerminal,
+        failure: async (error) => {
+          console.error(`[agy-acp] queued v2 turn failed: ${(error as Error).message}`);
+          await emitTerminal("end_turn").catch(() => {});
+        }
       }
-      const adapter = v2Adapter(params, client, session, deps, {
-        announceUserMessage: false,
-        userMessageId
-      });
-      return runTurnBody(
-        params.sessionId,
-        params.prompt as v1.ContentBlock[],
-        session,
-        claim,
-        adapter,
-        deps,
-        promptText
-      );
-    },
-    {
-      terminal: emitTerminal,
-      failure: async (error) => {
-        console.error(`[agy-acp] queued v2 turn failed: ${(error as Error).message}`);
-        await emitTerminal("end_turn").catch(() => {});
-      }
-    }
-  );
+    );
+  } finally {
+    propagateCancellation();
+  }
 }

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -94,7 +94,12 @@ export async function applyCuratedSlashCommand(
   return true;
 }
 
-/** v1 `session/prompt`: response carries stopReason after the full turn. */
+/**
+ * v1 `session/prompt`: response carries stopReason after the full turn.
+ *
+ * Only the ACP client's `params.prompt` is forwarded to agy (after content-block
+ * encoding). The adapter never synthesizes conversational follow-ups.
+ */
 export async function handlePromptV1(
   params: V1PromptRequest,
   client: V1AgentContext,
@@ -178,6 +183,9 @@ export async function handlePromptV1(
 /**
  * v2 `session/prompt`: respond `{}` immediately on acceptance. Foreground
  * progress and stopReason arrive as `state_update` notifications.
+ *
+ * Only the ACP client's `params.prompt` is forwarded to agy (after content-block
+ * encoding). The adapter never synthesizes conversational follow-ups.
  */
 export async function handlePromptV2(
   params: V2PromptRequest,

--- a/src/acp/session/prompt.ts
+++ b/src/acp/session/prompt.ts
@@ -97,8 +97,8 @@ export async function applyCuratedSlashCommand(
 /**
  * v1 `session/prompt`: response carries stopReason after the full turn.
  *
- * Only the ACP client's `params.prompt` is forwarded to agy (after content-block
- * encoding). The adapter never synthesizes conversational follow-ups.
+ * Zero prompt injection: only client `params.prompt` content is encoded and
+ * forwarded to agy. No adapter-authored labels, instructions, or follow-ups.
  */
 export async function handlePromptV1(
   params: V1PromptRequest,
@@ -184,8 +184,8 @@ export async function handlePromptV1(
  * v2 `session/prompt`: respond `{}` immediately on acceptance. Foreground
  * progress and stopReason arrive as `state_update` notifications.
  *
- * Only the ACP client's `params.prompt` is forwarded to agy (after content-block
- * encoding). The adapter never synthesizes conversational follow-ups.
+ * Zero prompt injection: only client `params.prompt` content is encoded and
+ * forwarded to agy. No adapter-authored labels, instructions, or follow-ups.
  */
 export async function handlePromptV2(
   params: V2PromptRequest,

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -15,6 +15,7 @@ import { applyModelSelection, initialModelSelection, restoredModelSelection } fr
 import type { SessionStore, StoredSession } from "./store.js";
 import type { SessionState } from "./types.js";
 import { cancelQueuedPrompts } from "./cancel.js";
+import { wakePromptIdleWaiters } from "./prompt.js";
 
 export interface SessionBuildDeps {
   env: NodeJS.ProcessEnv;
@@ -72,6 +73,7 @@ export async function registerSession(
   if (replaced && replaced !== session) {
     sessions.delete(sessionId);
     replaced.closed = true;
+    wakePromptIdleWaiters(replaced);
     await cancelQueuedPrompts(replaced);
     replaced.promptAbort?.abort();
     await replaced.agy.close().catch(() => {});
@@ -83,6 +85,7 @@ export async function registerSession(
     const [evictedId, evicted] = candidate;
     sessions.delete(evictedId);
     evicted.closed = true;
+    wakePromptIdleWaiters(evicted);
     await cancelQueuedPrompts(evicted);
     await evicted.agy.close().catch((error) => {
       console.error(

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -71,6 +71,7 @@ export async function registerSession(
   const replaced = sessions.get(sessionId);
   if (replaced && replaced !== session) {
     sessions.delete(sessionId);
+    replaced.closed = true;
     await cancelQueuedPrompts(replaced);
     replaced.promptAbort?.abort();
     await replaced.agy.close().catch(() => {});
@@ -81,6 +82,7 @@ export async function registerSession(
     if (!candidate) break;
     const [evictedId, evicted] = candidate;
     sessions.delete(evictedId);
+    evicted.closed = true;
     await cancelQueuedPrompts(evicted);
     await evicted.agy.close().catch((error) => {
       console.error(

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -15,7 +15,8 @@ import { applyModelSelection, initialModelSelection, restoredModelSelection } fr
 import type { SessionStore, StoredSession } from "./store.js";
 import type { SessionState } from "./types.js";
 import { cancelQueuedPrompts } from "./cancel.js";
-import { sessionTurnBusy, wakePromptIdleWaiters } from "./prompt.js";
+import { sessionTurnBusy } from "./prompt.js";
+import { turnsOf } from "./turn-scheduler.js";
 
 export interface SessionBuildDeps {
   env: NodeJS.ProcessEnv;
@@ -56,7 +57,6 @@ export async function buildSession(
     catalog,
     selectedBaseModel: selection.baseModel,
     selectedReasoningEffort: selection.reasoningEffort,
-    activePrompt: false,
     promptQueue: [],
     v2UserMessageIdsByStep: { ...(stored?.v2UserMessageIdsByStep ?? {}) }
   };
@@ -73,8 +73,7 @@ export async function registerSession(
   if (replaced && replaced !== session) {
     sessions.delete(sessionId);
     replaced.closed = true;
-    wakePromptIdleWaiters(replaced);
-    replaced.promptAbort?.abort();
+    turnsOf(replaced).close();
     cancelQueuedPrompts(replaced);
     await replaced.agy.close().catch(() => {});
   }
@@ -85,8 +84,7 @@ export async function registerSession(
     const [evictedId, evicted] = candidate;
     sessions.delete(evictedId);
     evicted.closed = true;
-    wakePromptIdleWaiters(evicted);
-    evicted.promptAbort?.abort();
+    turnsOf(evicted).close();
     cancelQueuedPrompts(evicted);
     await evicted.agy.close().catch((error) => {
       console.error(

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -15,7 +15,7 @@ import { applyModelSelection, initialModelSelection, restoredModelSelection } fr
 import type { SessionStore, StoredSession } from "./store.js";
 import type { SessionState } from "./types.js";
 import { cancelQueuedPrompts } from "./cancel.js";
-import { wakePromptIdleWaiters } from "./prompt.js";
+import { sessionTurnBusy, wakePromptIdleWaiters } from "./prompt.js";
 
 export interface SessionBuildDeps {
   env: NodeJS.ProcessEnv;
@@ -74,19 +74,20 @@ export async function registerSession(
     sessions.delete(sessionId);
     replaced.closed = true;
     wakePromptIdleWaiters(replaced);
-    await cancelQueuedPrompts(replaced);
     replaced.promptAbort?.abort();
+    cancelQueuedPrompts(replaced);
     await replaced.agy.close().catch(() => {});
   }
 
   while (sessions.size >= maxActiveSessions) {
-    const candidate = [...sessions].find(([, current]) => !current.activePrompt);
+    const candidate = [...sessions].find(([, current]) => !sessionTurnBusy(current));
     if (!candidate) break;
     const [evictedId, evicted] = candidate;
     sessions.delete(evictedId);
     evicted.closed = true;
     wakePromptIdleWaiters(evicted);
-    await cancelQueuedPrompts(evicted);
+    evicted.promptAbort?.abort();
+    cancelQueuedPrompts(evicted);
     await evicted.agy.close().catch((error) => {
       console.error(
         `[agy-acp] WARN: failed to close evicted session ${evictedId}: ${(error as Error).message}`

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -14,6 +14,7 @@ import { buildModelCatalog } from "../../agy/model/catalog.js";
 import { applyModelSelection, initialModelSelection, restoredModelSelection } from "../../agy/model/selection.js";
 import type { SessionStore, StoredSession } from "./store.js";
 import type { SessionState } from "./types.js";
+import { cancelQueuedPrompts } from "./cancel.js";
 
 export interface SessionBuildDeps {
   env: NodeJS.ProcessEnv;
@@ -55,6 +56,7 @@ export async function buildSession(
     selectedBaseModel: selection.baseModel,
     selectedReasoningEffort: selection.reasoningEffort,
     activePrompt: false,
+    promptQueue: [],
     v2UserMessageIdsByStep: { ...(stored?.v2UserMessageIdsByStep ?? {}) }
   };
 }
@@ -69,6 +71,7 @@ export async function registerSession(
   const replaced = sessions.get(sessionId);
   if (replaced && replaced !== session) {
     sessions.delete(sessionId);
+    await cancelQueuedPrompts(replaced);
     replaced.promptAbort?.abort();
     await replaced.agy.close().catch(() => {});
   }
@@ -78,6 +81,7 @@ export async function registerSession(
     if (!candidate) break;
     const [evictedId, evicted] = candidate;
     sessions.delete(evictedId);
+    await cancelQueuedPrompts(evicted);
     await evicted.agy.close().catch((error) => {
       console.error(
         `[agy-acp] WARN: failed to close evicted session ${evictedId}: ${(error as Error).message}`

--- a/src/acp/session/turn-scheduler.ts
+++ b/src/acp/session/turn-scheduler.ts
@@ -16,6 +16,10 @@
 //      so cancel/close/evict always have something to abort in every phase.
 //  I3. Cancellation unwinds by throwing (`TurnCancelled`), not by polling a
 //      flag after each await. Callers cannot forget to re-check.
+//  I4. Every client-bound delivery is raced against the turn's claim (or a
+//      queued item's controller). agy's prompt loop awaits each update
+//      callback, so a client transport that never settles would otherwise pin
+//      the slot forever — killing the backend cannot settle a wedged notify.
 
 /** Thrown when a claim is aborted; unwinds the turn pipeline to its reporter. */
 export class TurnCancelled extends Error {
@@ -87,14 +91,21 @@ export class TurnClaim {
   }
 }
 
-/** Await `promise`, rejecting as soon as `claim` is aborted. */
-export function raceClaim<T>(promise: Promise<T>, claim: TurnClaim): Promise<T> {
+/**
+ * Await `promise`, rejecting with `TurnCancelled` as soon as `signal` aborts.
+ *
+ * The single implementation behind invariant I4: every client-bound delivery
+ * goes through here (directly, or via `raceClaim` for turn claims), so a
+ * client transport that never settles unwinds on cancel/close instead of
+ * pinning the turn slot or the queue-preparation chain.
+ */
+export function raceSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    if (claim.aborted) {
+    if (signal.aborted) {
       reject(new TurnCancelled());
       return;
     }
-    const off = onAbort(claim.signal, () => reject(new TurnCancelled()));
+    const off = onAbort(signal, () => reject(new TurnCancelled()));
     promise.then(
       (value) => {
         off();
@@ -106,6 +117,11 @@ export function raceClaim<T>(promise: Promise<T>, claim: TurnClaim): Promise<T> 
       }
     );
   });
+}
+
+/** Await `promise`, rejecting as soon as `claim` is aborted. */
+export function raceClaim<T>(promise: Promise<T>, claim: TurnClaim): Promise<T> {
+  return raceSignal(promise, claim.signal);
 }
 
 /** Lazily attach a scheduler to a session-like object. */

--- a/src/acp/session/turn-scheduler.ts
+++ b/src/acp/session/turn-scheduler.ts
@@ -1,0 +1,242 @@
+// Turn ownership for a single ACP session.
+//
+// One session may only run one prompt turn against the agy backend at a time.
+// Requests compete for that slot in three ways: an idle request claims it
+// directly, a `queue` request waits in FIFO, and a `steer` request reserves it
+// and displaces whatever is running.
+//
+// The invariants below exist because ad-hoc ownership flags spread across the
+// prompt handlers made every `await` a window where the session could be
+// half-owned, and every such window was a cancellation bug:
+//
+//  I1. A claim is one object that exists from admission until the turn is fully
+//      finished — including a steer's wait for the previous turn to stop. There
+//      is no phase where a request owns the session but has no claim.
+//  I2. Every claim carries its AbortController from the moment it is created,
+//      so cancel/close/evict always have something to abort in every phase.
+//  I3. Cancellation unwinds by throwing (`TurnCancelled`), not by polling a
+//      flag after each await. Callers cannot forget to re-check.
+
+/** Thrown when a claim is aborted; unwinds the turn pipeline to its reporter. */
+export class TurnCancelled extends Error {
+  constructor(message = "turn cancelled") {
+    super(message);
+    this.name = "TurnCancelled";
+  }
+}
+
+export function isTurnCancelled(error: unknown): boolean {
+  const name = (error as { name?: unknown } | null | undefined)?.name;
+  return error instanceof TurnCancelled || name === "TurnCancelled" || name === "AbortError";
+}
+
+/**
+ * Run `fn` for an abort signal, now or later. Plain `addEventListener` never
+ * fires for a signal that is already aborted, which repeatedly produced turns
+ * that ran after they had been cancelled.
+ */
+export function onAbort(signal: AbortSignal, fn: () => void): () => void {
+  if (signal.aborted) {
+    fn();
+    return () => {};
+  }
+  signal.addEventListener("abort", fn, { once: true });
+  return () => signal.removeEventListener("abort", fn);
+}
+
+export type TurnKind = "foreground" | "queued" | "steer";
+
+/** A request's ownership of (or reservation on) the session's single turn slot. */
+export class TurnClaim {
+  readonly kind: TurnKind;
+  private readonly controller = new AbortController();
+  private isReleased = false;
+
+  constructor(kind: TurnKind, parent?: AbortSignal) {
+    this.kind = kind;
+    // A request-scoped signal (v1 `session/prompt` cancellation) folds into the
+    // claim, so downstream code only ever consults one signal.
+    if (parent) onAbort(parent, () => this.abort());
+  }
+
+  get signal(): AbortSignal {
+    return this.controller.signal;
+  }
+
+  get aborted(): boolean {
+    return this.controller.signal.aborted;
+  }
+
+  get released(): boolean {
+    return this.isReleased;
+  }
+
+  abort(): void {
+    if (!this.controller.signal.aborted) this.controller.abort(new TurnCancelled());
+  }
+
+  throwIfAborted(): void {
+    if (this.aborted) throw new TurnCancelled();
+  }
+
+  /** @internal — the scheduler marks a claim finished exactly once. */
+  markReleased(): boolean {
+    if (this.isReleased) return false;
+    this.isReleased = true;
+    return true;
+  }
+}
+
+/** Await `promise`, rejecting as soon as `claim` is aborted. */
+export function raceClaim<T>(promise: Promise<T>, claim: TurnClaim): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    if (claim.aborted) {
+      reject(new TurnCancelled());
+      return;
+    }
+    const off = onAbort(claim.signal, () => reject(new TurnCancelled()));
+    promise.then(
+      (value) => {
+        off();
+        resolve(value);
+      },
+      (error) => {
+        off();
+        reject(error);
+      }
+    );
+  });
+}
+
+/** Lazily attach a scheduler to a session-like object. */
+export function turnsOf(session: { turns?: TurnScheduler }): TurnScheduler {
+  return (session.turns ??= new TurnScheduler());
+}
+
+export class TurnScheduler {
+  private active?: TurnClaim;
+  /** Steer reservations in FIFO order; the head is next to take the slot. */
+  private reservations: TurnClaim[] = [];
+  private waiters = new Set<() => void>();
+  private closed = false;
+
+  /** True when a turn is running or a steer has reserved the next turn. */
+  busy(): boolean {
+    return this.active !== undefined || this.reservations.length > 0;
+  }
+
+  get activeClaim(): TurnClaim | undefined {
+    return this.active;
+  }
+
+  /**
+   * Take the slot for a request that found the session idle. Synchronous by
+   * design: no await may separate the busy check from the claim (I1).
+   */
+  claimIdle(kind: Exclude<TurnKind, "steer">, parent?: AbortSignal): TurnClaim {
+    if (this.busy()) {
+      // Callers must check `busy()` with no await in between; overwriting the
+      // slot here would silently orphan a running turn.
+      throw new Error("cannot claim a busy session turn slot");
+    }
+    const claim = new TurnClaim(kind, parent);
+    this.active = claim;
+    if (this.closed) claim.abort();
+    return claim;
+  }
+
+  /**
+   * Reserve the next turn for a steer. Synchronous, so the claim — and its
+   * abort controller — exist before the first await (I1, I2). The reservation
+   * keeps the session `busy()`, so no queued follow-up can slip in front.
+   */
+  reserveSteer(parent?: AbortSignal): TurnClaim {
+    const claim = new TurnClaim("steer", parent);
+    this.reservations.push(claim);
+    if (this.closed) claim.abort();
+    return claim;
+  }
+
+  /**
+   * Wait for `claim` to reach the head of the reservation queue, stop whatever
+   * is running, and hand it the slot. Throws `TurnCancelled` if the claim is
+   * aborted at any point, including while the backend is being killed.
+   *
+   * A reservation stays in the queue until it is *released*, not merely until
+   * it is promoted. Otherwise a later steer would reach the head while an
+   * earlier one was running and displace it before it ever reached the backend.
+   */
+  async promote(claim: TurnClaim, cancelActive: () => Promise<void>): Promise<void> {
+    claim.throwIfAborted();
+
+    while (this.reservations[0] !== claim) {
+      if (!this.reservations.includes(claim)) throw new TurnCancelled();
+      await this.nextChange(claim);
+    }
+
+    const displaced = this.active;
+    if (displaced) {
+      displaced.abort();
+      // Cancellable while the backend shuts down: a stop arriving during a slow
+      // kill must not be swallowed and then followed by the replacement turn.
+      await raceClaim(cancelActive(), claim);
+      while (this.active) await this.nextChange(claim);
+    }
+
+    claim.throwIfAborted();
+    if (this.reservations[0] !== claim) throw new TurnCancelled();
+    this.active = claim;
+    this.change();
+  }
+
+  /**
+   * Finish a claim. Idempotent, and safe to call from a `finally` on any exit
+   * path — success, cancellation, or setup failure.
+   */
+  release(claim: TurnClaim): void {
+    if (!claim.markReleased()) return;
+    if (this.active === claim) this.active = undefined;
+    const idx = this.reservations.indexOf(claim);
+    if (idx >= 0) this.reservations.splice(idx, 1);
+    this.change();
+  }
+
+  /** Abort every live claim (`session/cancel`). Queued items are untouched. */
+  abortAll(): void {
+    this.active?.abort();
+    for (const reservation of [...this.reservations]) reservation.abort();
+  }
+
+  /** Abort everything and refuse further claims (close / delete / evict). */
+  close(): void {
+    this.closed = true;
+    this.abortAll();
+    this.change();
+  }
+
+  private change(): void {
+    const pending = [...this.waiters];
+    this.waiters.clear();
+    for (const waiter of pending) waiter();
+  }
+
+  /** Resolve on the next ownership change, or reject if `claim` is aborted. */
+  private nextChange(claim: TurnClaim): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (claim.aborted) {
+        reject(new TurnCancelled());
+        return;
+      }
+      let off = () => {};
+      const waiter = () => {
+        off();
+        resolve();
+      };
+      this.waiters.add(waiter);
+      off = onAbort(claim.signal, () => {
+        this.waiters.delete(waiter);
+        reject(new TurnCancelled());
+      });
+    });
+  }
+}

--- a/src/acp/session/turn-scheduler.ts
+++ b/src/acp/session/turn-scheduler.ts
@@ -53,11 +53,18 @@ export type TurnKind = "foreground" | "queued" | "steer";
 /** A request's ownership of (or reservation on) the session's single turn slot. */
 export class TurnClaim {
   readonly kind: TurnKind;
+  /**
+   * For claimed queued prompts, the client-visible queue id. Lets a targeted
+   * `session/cancel` find the turn its queued item grew into, so it aborts
+   * exactly that claim instead of falling back to a session-wide abort.
+   */
+  readonly tag?: string;
   private readonly controller = new AbortController();
   private isReleased = false;
 
-  constructor(kind: TurnKind, parent?: AbortSignal) {
+  constructor(kind: TurnKind, parent?: AbortSignal, tag?: string) {
     this.kind = kind;
+    this.tag = tag;
     // A request-scoped signal (v1 `session/prompt` cancellation) folds into the
     // claim, so downstream code only ever consults one signal.
     if (parent) onAbort(parent, () => this.abort());
@@ -149,13 +156,13 @@ export class TurnScheduler {
    * Take the slot for a request that found the session idle. Synchronous by
    * design: no await may separate the busy check from the claim (I1).
    */
-  claimIdle(kind: Exclude<TurnKind, "steer">, parent?: AbortSignal): TurnClaim {
+  claimIdle(kind: Exclude<TurnKind, "steer">, parent?: AbortSignal, tag?: string): TurnClaim {
     if (this.busy()) {
       // Callers must check `busy()` with no await in between; overwriting the
       // slot here would silently orphan a running turn.
       throw new Error("cannot claim a busy session turn slot");
     }
-    const claim = new TurnClaim(kind, parent);
+    const claim = new TurnClaim(kind, parent, tag);
     this.active = claim;
     if (this.closed) claim.abort();
     return claim;

--- a/src/acp/session/types.ts
+++ b/src/acp/session/types.ts
@@ -13,6 +13,12 @@ export interface QueuedPromptV1 {
   deps: PromptV1Deps;
   resolve: (response: import("@agentclientprotocol/sdk").PromptResponse) => void;
   reject: (error: Error) => void;
+  /**
+   * Detaches the in-FIFO cancel listener. Called when the item leaves the
+   * queue by any path — afterwards the turn's claim owns cancellation, and a
+   * long-lived request signal must not pin the session.
+   */
+  detachQueueCancel?: () => void;
 }
 
 export interface QueuedPromptV2 {

--- a/src/acp/session/types.ts
+++ b/src/acp/session/types.ts
@@ -44,6 +44,11 @@ export interface SessionState {
   promptIdleNotify?: () => void;
   /** Serializes steer replacements so competing requests cannot overlap. */
   promptSteerInProgress?: Promise<void>;
+  /**
+   * Number of in-flight steer replacements that have reserved the next turn.
+   * While > 0, the queue must not auto-start — a steer owns the claim.
+   */
+  steerClaims?: number;
   /** Set when the session is being closed or deleted. */
   closed?: boolean;
   /** Stable v2 user-message IDs keyed by their persisted agy step index. */

--- a/src/acp/session/types.ts
+++ b/src/acp/session/types.ts
@@ -39,24 +39,18 @@ export interface SessionState {
   catalog: ModelCatalog;
   selectedBaseModel: string;
   selectedReasoningEffort: string;
-  activePrompt: boolean;
+  /**
+   * Owns the session's single turn slot: who is running, who has reserved the
+   * next turn, and the abort controller for each. Created lazily via
+   * `turnsOf(session)`; see `turn-scheduler.ts` for the invariants.
+   */
+  turns?: import("./turn-scheduler.js").TurnScheduler;
   /** Per-session FIFO of queued follow-up prompts. */
   promptQueue: QueuedPrompt[];
   /** Serializes v2 queued-message preparation and publication in FIFO order. */
   promptQueuePreparation?: Promise<void>;
-  /** Resolves when the active turn reaches idle and the queue consumer can proceed. */
-  promptIdleNotify?: () => void;
-  /** Serializes steer replacements so competing requests cannot overlap. */
-  promptSteerInProgress?: Promise<void>;
-  /**
-   * Number of in-flight steer replacements that have reserved the next turn.
-   * While > 0, the queue must not auto-start — a steer owns the claim.
-   */
-  steerClaims?: number;
   /** Set when the session is being closed or deleted. */
   closed?: boolean;
   /** Stable v2 user-message IDs keyed by their persisted agy step index. */
   v2UserMessageIdsByStep: Record<string, string>;
-  /** Active prompt-turn abort controller, including pre-launch preparation. */
-  promptAbort?: AbortController;
 }

--- a/src/acp/session/types.ts
+++ b/src/acp/session/types.ts
@@ -20,8 +20,10 @@ export interface QueuedPromptV2 {
   version: "v2";
   params: import("@agentclientprotocol/sdk/experimental/v2").PromptRequest;
   client: import("@agentclientprotocol/sdk/experimental/v2").AgentContext;
-  promptText: string;
-  userMessageId: string;
+  /** Preparation starts at admission, but the placeholder enters FIFO first. */
+  ready: Promise<void>;
+  promptText?: string;
+  userMessageId?: string;
   controller: AbortController;
   deps: PromptV2Deps;
 }
@@ -40,6 +42,8 @@ export interface SessionState {
   activePrompt: boolean;
   /** Per-session FIFO of queued follow-up prompts. */
   promptQueue: QueuedPrompt[];
+  /** Serializes v2 queued-message preparation and publication in FIFO order. */
+  promptQueuePreparation?: Promise<void>;
   /** Resolves when the active turn reaches idle and the queue consumer can proceed. */
   promptIdleNotify?: () => void;
   /** Serializes steer replacements so competing requests cannot overlap. */

--- a/src/acp/session/types.ts
+++ b/src/acp/session/types.ts
@@ -57,6 +57,6 @@ export interface SessionState {
   closed?: boolean;
   /** Stable v2 user-message IDs keyed by their persisted agy step index. */
   v2UserMessageIdsByStep: Record<string, string>;
-  /** Active v2 prompt-turn abort controller, if any. */
+  /** Active prompt-turn abort controller, including pre-launch preparation. */
   promptAbort?: AbortController;
 }

--- a/src/acp/session/types.ts
+++ b/src/acp/session/types.ts
@@ -42,6 +42,10 @@ export interface SessionState {
   promptQueue: QueuedPrompt[];
   /** Resolves when the active turn reaches idle and the queue consumer can proceed. */
   promptIdleNotify?: () => void;
+  /** Serializes steer replacements so competing requests cannot overlap. */
+  promptSteerInProgress?: Promise<void>;
+  /** Set when the session is being closed or deleted. */
+  closed?: boolean;
   /** Stable v2 user-message IDs keyed by their persisted agy step index. */
   v2UserMessageIdsByStep: Record<string, string>;
   /** Active v2 prompt-turn abort controller, if any. */

--- a/src/acp/session/types.ts
+++ b/src/acp/session/types.ts
@@ -1,8 +1,32 @@
-// Shared in-memory session shape used across session setup, config options, and the prompt turn.
-// Docs: https://agentclientprotocol.com/protocol/v1/session-setup
-
 import type { AgyCliSession } from "../../agy/cli.js";
 import type { ModelCatalog } from "../../agy/model/catalog.js";
+import type { PromptV1Deps, PromptV2Deps } from "./prompt.js";
+
+export type TurnIntent = "queue" | "steer";
+
+export interface QueuedPromptV1 {
+  id: string;
+  version: "v1";
+  params: import("@agentclientprotocol/sdk").PromptRequest;
+  client: import("@agentclientprotocol/sdk").AgentContext;
+  signal?: AbortSignal;
+  deps: PromptV1Deps;
+  resolve: (response: import("@agentclientprotocol/sdk").PromptResponse) => void;
+  reject: (error: Error) => void;
+}
+
+export interface QueuedPromptV2 {
+  id: string;
+  version: "v2";
+  params: import("@agentclientprotocol/sdk/experimental/v2").PromptRequest;
+  client: import("@agentclientprotocol/sdk/experimental/v2").AgentContext;
+  promptText: string;
+  userMessageId: string;
+  controller: AbortController;
+  deps: PromptV2Deps;
+}
+
+export type QueuedPrompt = QueuedPromptV1 | QueuedPromptV2;
 
 export interface SessionState {
   sessionId: string;
@@ -14,6 +38,10 @@ export interface SessionState {
   selectedBaseModel: string;
   selectedReasoningEffort: string;
   activePrompt: boolean;
+  /** Per-session FIFO of queued follow-up prompts. */
+  promptQueue: QueuedPrompt[];
+  /** Resolves when the active turn reaches idle and the queue consumer can proceed. */
+  promptIdleNotify?: () => void;
   /** Stable v2 user-message IDs keyed by their persisted agy step index. */
   v2UserMessageIdsByStep: Record<string, string>;
   /** Active v2 prompt-turn abort controller, if any. */

--- a/src/acp/slash-commands/index.ts
+++ b/src/acp/slash-commands/index.ts
@@ -8,7 +8,7 @@
 // session config surfaces already mapped to `agy --mode` / `--model` / `--effort`.
 // Full TUI palette (/settings, /mcp, /help overlays, …) is intentionally omitted.
 
-import type { AvailableCommand, SessionUpdate } from "@agentclientprotocol/sdk";
+import type { AvailableCommand, ContentBlock, SessionUpdate } from "@agentclientprotocol/sdk";
 
 export const MODE_SLASH = "mode";
 export const PLAN_SLASH = "plan";
@@ -72,6 +72,29 @@ export function parseSlashCommand(promptText: string): ParsedSlashCommand | null
     name: match[1].toLowerCase(),
     input: (match[2] ?? "").trim()
   };
+}
+
+/**
+ * True when the client's original ContentBlocks are a pure text slash command
+ * (exactly one non-empty text block, no images/resources/links).
+ *
+ * Slash interception must not fire on flattened resource bodies that merely
+ * contain text like `/plan` — those should be forwarded to agy as normal
+ * prompt content.
+ */
+export function isClientTextSlashPrompt(blocks: ContentBlock[]): boolean {
+  let textBlock: Extract<ContentBlock, { type: "text" }> | undefined;
+  for (const block of blocks) {
+    if (block.type === "text") {
+      if (block.text.trim().length === 0) continue;
+      if (textBlock) return false;
+      textBlock = block;
+      continue;
+    }
+    // Any non-text block means this is not a client slash-menu selection.
+    return false;
+  }
+  return textBlock !== undefined;
 }
 
 export type SlashConfigAction = {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -558,8 +558,9 @@ export class AgyCliSession {
         if (candidateRevision === poller.revision && this.#ptyIdleMarkerCount >= requiredIdleMarkerCount) {
           // Background work can finish after the TUI looks idle. Stay on this
           // user turn and keep polling — do not inject a synthetic "continue".
+          // Do not re-arm deadline here: only poller revision progress (above)
+          // refreshes the timeout, so a missing completion cannot hang forever.
           if (poller.hasActiveBackgroundTasks && !this.#cancelled) {
-            deadline = Date.now() + timeoutMs;
             const exited = await Promise.race([activePtyExit.then(() => true), sleep(POLL_INTERVAL_MS).then(() => false)]);
             if (exited && !this.#cancelled) throw new AgyCliError(`agy interactive PTY exited unexpectedly: ${this.#ptyOutput.trim() || "<no output>"}`, [this.config.agyPath], null, this.#ptyOutput);
             continue;
@@ -801,11 +802,14 @@ export class AgyCliSession {
       await this.stopPty();
       return;
     }
+    // Always mark cancelled first: print-mode may still be draining background
+    // task rows after the child has already exited, and that loop only checks
+    // `#cancelled` (the process handle alone is no longer enough to interrupt).
+    this.#cancelled = true;
     const child = this.#process;
     if (!child || child.exitCode !== null) {
       return;
     }
-    this.#cancelled = true;
     const exitPromise = once(child, "exit");
     // SIGINT (rather than SIGTERM) gives agy a chance to flush its last
     // conversation-database write before exiting. Windows has no real SIGINT,

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -283,6 +283,12 @@ export class AgyCliSession {
    * appended steps while the process runs, and invoke `onUpdate` with the
    * translated ACP updates in order. Resolves once the process exits and a few
    * trailing polls have drained any steps flushed right around exit.
+   *
+   * Invariant: `prompt` must be client-originated user content only. Never
+   * invent follow-ups (e.g. "continue") for background-task wakeups — keep the
+   * turn open and poll instead. PTY writes during a turn are permission keys
+   * (or the same user `prompt` when reusing an interactive TUI), not adapter
+   * prose.
    */
   async prompt(
     prompt: string,
@@ -549,8 +555,17 @@ export class AgyCliSession {
           if (this.#cancelled || choice === "cancelled") { this.#cancelled = true; break; }
           if (normalizePermissionChoice(choice) === "agy-reject-once") revertEditToolCall(toolCall);
         }
-        if (this.#cancelled) break;
-        if (candidateRevision === poller.revision && this.#ptyIdleMarkerCount >= requiredIdleMarkerCount) break;
+        if (candidateRevision === poller.revision && this.#ptyIdleMarkerCount >= requiredIdleMarkerCount) {
+          // Background work can finish after the TUI looks idle. Stay on this
+          // user turn and keep polling — do not inject a synthetic "continue".
+          if (poller.hasActiveBackgroundTasks && !this.#cancelled) {
+            deadline = Date.now() + timeoutMs;
+            const exited = await Promise.race([activePtyExit.then(() => true), sleep(POLL_INTERVAL_MS).then(() => false)]);
+            if (exited && !this.#cancelled) throw new AgyCliError(`agy interactive PTY exited unexpectedly: ${this.#ptyOutput.trim() || "<no output>"}`, [this.config.agyPath], null, this.#ptyOutput);
+            continue;
+          }
+          break;
+        }
         const exited = await Promise.race([activePtyExit.then(() => true), sleep(POLL_INTERVAL_MS).then(() => false)]);
         if (exited && !this.#cancelled) throw new AgyCliError(`agy interactive PTY exited unexpectedly: ${this.#ptyOutput.trim() || "<no output>"}`, [this.config.agyPath], null, this.#ptyOutput);
       }
@@ -672,6 +687,17 @@ export class AgyCliSession {
           exitCode,
           stderr
         );
+      }
+
+      // Print-mode child may exit before background task rows finish writing.
+      // Keep draining the DB for this user turn only — no synthetic prompts.
+      if (poller.hasActiveBackgroundTasks && !this.#cancelled) {
+        while (poller.hasActiveBackgroundTasks && !this.#cancelled) {
+          await sleep(POLL_INTERVAL_MS);
+          for (const update of poller.poll()) {
+            await onUpdate(update);
+          }
+        }
       }
 
       return { stopReason: this.#cancelled ? "cancelled" : "end_turn" };

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -284,11 +284,11 @@ export class AgyCliSession {
    * translated ACP updates in order. Resolves once the process exits and a few
    * trailing polls have drained any steps flushed right around exit.
    *
-   * Invariant: `prompt` must be client-originated user content only. Never
-   * invent follow-ups (e.g. "continue") for background-task wakeups — keep the
-   * turn open and poll instead. PTY writes during a turn are permission keys
-   * (or the same user `prompt` when reusing an interactive TUI), not adapter
-   * prose.
+   * Invariant (zero prompt injection): `prompt` is only client-originated
+   * content from ACP session/prompt. Never invent labels, instructions, or
+   * follow-ups (e.g. "continue") — for background wakeups, keep the turn open
+   * and poll instead. PTY writes during a turn are permission keys (or the same
+   * user `prompt` when reusing an interactive TUI), never adapter prose.
    */
   async prompt(
     prompt: string,
@@ -691,11 +691,21 @@ export class AgyCliSession {
 
       // Print-mode child may exit before background task rows finish writing.
       // Keep draining the DB for this user turn only — no synthetic prompts.
+      // Re-arm the deadline on DB progress so long tasks can finish; still
+      // bound idle silence by printTimeout so a missing completion cannot hang.
       if (poller.hasActiveBackgroundTasks && !this.#cancelled) {
+        const timeoutMs = parsePrintTimeoutMs(this.config.printTimeout);
+        let deadline = Date.now() + timeoutMs;
+        let seenRevision = poller.revision;
         while (poller.hasActiveBackgroundTasks && !this.#cancelled) {
+          if (Date.now() >= deadline) break;
           await sleep(POLL_INTERVAL_MS);
           for (const update of poller.poll()) {
             await onUpdate(update);
+          }
+          if (poller.revision !== seenRevision) {
+            seenRevision = poller.revision;
+            deadline = Date.now() + timeoutMs;
           }
         }
       }

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -699,7 +699,14 @@ export class AgyCliSession {
         let deadline = Date.now() + timeoutMs;
         let seenRevision = poller.revision;
         while (poller.hasActiveBackgroundTasks && !this.#cancelled) {
-          if (Date.now() >= deadline) break;
+          if (Date.now() >= deadline) {
+            throw new AgyCliError(
+              `agy print turn timed out after ${this.config.printTimeout} while waiting for background tasks to complete`,
+              command,
+              null,
+              Buffer.concat(stderrChunks).toString("utf8")
+            );
+          }
           await sleep(POLL_INTERVAL_MS);
           for (const update of poller.poll()) {
             await onUpdate(update);

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -165,7 +165,12 @@ export class StreamPoller {
       ) {
         this._hasBackgroundWaiting = true;
       }
-      if (row.stepType === 101 || isSystemMessage(text)) {
+      // Defer completion tracking until the lifecycle row is terminal so a
+      // still-streaming system-message envelope cannot close the wait early.
+      if (
+        (row.stepType === 101 || isSystemMessage(text)) &&
+        isTerminalStepStatus(row.status)
+      ) {
         this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
         let matchedTask = false;
         for (const taskId of this._launchedTaskIds) {
@@ -269,3 +274,9 @@ function isBackgroundWaitAgentText(text: string): boolean {
   // Slight variants still seen with task_details present.
   return /waiting for.*background|preserving context while waiting/i.test(trimmed);
 }
+
+/** status 3/6/7 — completed, cancelled/aborted, or failed. */
+function isTerminalStepStatus(status: number): boolean {
+  return status === 3 || status === 6 || status === 7;
+}
+

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -5,6 +5,7 @@
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { ConversationDb } from "./database.js";
 import { newConversationId } from "./scan.js";
+import { isSystemMessage } from "./system-message.js";
 import { toolCallId } from "./tool-call-updates.js";
 import { Translator } from "./translator.js";
 import type { StepRow } from "./types.js";
@@ -50,6 +51,11 @@ export class StreamPoller {
   private rowSnapshot = "";
   private readonly activePending = new Map<string, PendingInteraction>();
   private readonly observedUserStepIdxs = new Set<number>();
+  private _lastUserStepIdx = -1;
+  private _latestSystemMessageStepIdx = -1;
+  private _hasBackgroundWaiting = false;
+  private readonly _launchedTaskIds = new Set<string>();
+  private readonly _completedTaskIds = new Set<string>();
 
   constructor(private readonly opts: StreamOptions) {
     this.boundId = opts.conversationId;
@@ -75,6 +81,23 @@ export class StreamPoller {
   /** User-prompt rows observed during this prompt-scoped polling session. */
   get userStepIdxs(): number[] {
     return [...this.observedUserStepIdxs];
+  }
+
+  get lastUserStepIdx(): number {
+    return this._lastUserStepIdx;
+  }
+
+  get latestSystemMessageStepIdx(): number {
+    return this._latestSystemMessageStepIdx;
+  }
+
+  get hasUnansweredSystemMessage(): boolean {
+    return this._latestSystemMessageStepIdx > this._lastUserStepIdx && this._latestSystemMessageStepIdx !== -1;
+  }
+
+  get hasActiveBackgroundTasks(): boolean {
+    if (this._launchedTaskIds.size > this._completedTaskIds.size) return true;
+    return this._hasBackgroundWaiting && !this.hasUnansweredSystemMessage;
   }
 
   /** Newly observed status-9 tool calls from the most recent poll. */
@@ -117,7 +140,26 @@ export class StreamPoller {
 
     const rows = this.db.readAfter(this.opts.baseStepIdx);
     for (const row of rows) {
-      if (row.stepType === 14) this.observedUserStepIdxs.add(row.idx);
+      if (row.stepType === 14) {
+        this.observedUserStepIdxs.add(row.idx);
+        this._lastUserStepIdx = Math.max(this._lastUserStepIdx, row.idx);
+        this._hasBackgroundWaiting = false;
+      }
+      if (row.task?.taskId) {
+        this._launchedTaskIds.add(row.task.taskId);
+      }
+      const text = row.stepPayload.agentText?.text ?? "";
+      if (text && /waiting for.*background|preserving context/i.test(text)) {
+        this._hasBackgroundWaiting = true;
+      }
+      if (row.stepType === 101 || isSystemMessage(text)) {
+        this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
+        for (const taskId of this._launchedTaskIds) {
+          if (text.includes(taskId)) {
+            this._completedTaskIds.add(taskId);
+          }
+        }
+      }
     }
     if (!rows.hasDecodeError) {
       this.dataVersion = dataVersion;

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -174,7 +174,7 @@ export class StreamPoller {
         this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
         let matchedTask = false;
         for (const taskId of this._launchedTaskIds) {
-          if (taskId && text.includes(taskId)) {
+          if (taskId && textMentionsTaskId(text, taskId)) {
             this._completedTaskIds.add(taskId);
             matchedTask = true;
           }
@@ -280,3 +280,21 @@ function isTerminalStepStatus(status: number): boolean {
   return status === 3 || status === 6 || status === 7;
 }
 
+/**
+ * True when `text` contains `taskId` as a whole token (not a prefix of a longer
+ * id). Avoids `task-1` matching inside `task-10`.
+ */
+function textMentionsTaskId(text: string, taskId: string): boolean {
+  if (!taskId || !text) return false;
+  let from = 0;
+  while (from <= text.length) {
+    const index = text.indexOf(taskId, from);
+    if (index < 0) return false;
+    const before = index === 0 ? "" : text[index - 1]!;
+    const after = text[index + taskId.length] ?? "";
+    const boundary = (ch: string) => ch === "" || !/[\w-]/.test(ch);
+    if (boundary(before) && boundary(after)) return true;
+    from = index + 1;
+  }
+  return false;
+}

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -95,6 +95,12 @@ export class StreamPoller {
     return this._latestSystemMessageStepIdx > this._lastUserStepIdx && this._latestSystemMessageStepIdx !== -1;
   }
 
+  /**
+   * True while this user turn should stay open for background work.
+   * Prefer explicit task_details launch/completion tracking; fall back to the
+   * "preserving context / waiting for background" agent text plus a later
+   * system/lifecycle message. Never requires injecting a synthetic prompt.
+   */
   get hasActiveBackgroundTasks(): boolean {
     if (this._launchedTaskIds.size > this._completedTaskIds.size) return true;
     return this._hasBackgroundWaiting && !this.hasUnansweredSystemMessage;
@@ -154,8 +160,18 @@ export class StreamPoller {
       }
       if (row.stepType === 101 || isSystemMessage(text)) {
         this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
+        let matchedTask = false;
         for (const taskId of this._launchedTaskIds) {
-          if (text.includes(taskId)) {
+          if (taskId && text.includes(taskId)) {
+            this._completedTaskIds.add(taskId);
+            matchedTask = true;
+          }
+        }
+        // Lifecycle/system wake without an embedded task id (common for stop_hook
+        // type 101): close every still-pending launch so the turn cannot hang
+        // forever waiting for a match that never arrives.
+        if (!matchedTask) {
+          for (const taskId of this._launchedTaskIds) {
             this._completedTaskIds.add(taskId);
           }
         }

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -93,7 +93,8 @@ export class StreamPoller {
   }
 
   get hasUnansweredSystemMessage(): boolean {
-    return this._latestSystemMessageStepIdx > this._lastUserStepIdx && this._latestSystemMessageStepIdx !== -1;
+    // _lastUserStepIdx starts at -1, so `>` already excludes "no system message".
+    return this._latestSystemMessageStepIdx > this._lastUserStepIdx;
   }
 
   /**

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -54,7 +54,8 @@ export class StreamPoller {
   private _lastUserStepIdx = -1;
   private _latestSystemMessageStepIdx = -1;
   private _hasBackgroundWaiting = false;
-  private readonly _launchedTaskIds = new Set<string>();
+  /** Launched background task id -> idx of the first row that carried it. */
+  private readonly _launchedTaskIdxs = new Map<string, number>();
   private readonly _completedTaskIds = new Set<string>();
 
   constructor(private readonly opts: StreamOptions) {
@@ -102,7 +103,7 @@ export class StreamPoller {
    * system/lifecycle message. Never requires injecting a synthetic prompt.
    */
   get hasActiveBackgroundTasks(): boolean {
-    if (this._launchedTaskIds.size > this._completedTaskIds.size) return true;
+    if (this._launchedTaskIdxs.size > this._completedTaskIds.size) return true;
     return this._hasBackgroundWaiting && !this.hasUnansweredSystemMessage;
   }
 
@@ -151,15 +152,15 @@ export class StreamPoller {
         this._lastUserStepIdx = Math.max(this._lastUserStepIdx, row.idx);
         this._hasBackgroundWaiting = false;
       }
-      if (row.task?.taskId) {
-        this._launchedTaskIds.add(row.task.taskId);
+      if (row.task?.taskId && !this._launchedTaskIdxs.has(row.task.taskId)) {
+        this._launchedTaskIdxs.set(row.task.taskId, row.idx);
       }
       const text = row.stepPayload.agentText?.text ?? "";
       // Only enter the background-wait path with corroborating task evidence.
       // A bare prose mention of "preserving context" must not pin the turn open
       // (and eventually time out) when no background task was launched.
       if (
-        this._launchedTaskIds.size > 0 &&
+        this._launchedTaskIdxs.size > 0 &&
         text &&
         isBackgroundWaitAgentText(text)
       ) {
@@ -172,8 +173,14 @@ export class StreamPoller {
         isTerminalStepStatus(row.status)
       ) {
         this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
+        // Rows are re-read on every poll, so an id-less lifecycle row observed
+        // before a later launch would otherwise close that newer task on the
+        // next revision. Only tasks launched BEFORE this row can complete here.
+        const launchedBefore = [...this._launchedTaskIdxs]
+          .filter(([, launchIdx]) => launchIdx < row.idx)
+          .map(([taskId]) => taskId);
         let matchedTask = false;
-        for (const taskId of this._launchedTaskIds) {
+        for (const taskId of launchedBefore) {
           if (taskId && textMentionsTaskId(text, taskId)) {
             this._completedTaskIds.add(taskId);
             matchedTask = true;
@@ -183,7 +190,7 @@ export class StreamPoller {
         // type 101): close every still-pending launch so the turn cannot hang
         // forever waiting for a match that never arrives.
         if (!matchedTask) {
-          for (const taskId of this._launchedTaskIds) {
+          for (const taskId of launchedBefore) {
             this._completedTaskIds.add(taskId);
           }
         }

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -155,7 +155,14 @@ export class StreamPoller {
         this._launchedTaskIds.add(row.task.taskId);
       }
       const text = row.stepPayload.agentText?.text ?? "";
-      if (text && /waiting for.*background|preserving context/i.test(text)) {
+      // Only enter the background-wait path with corroborating task evidence.
+      // A bare prose mention of "preserving context" must not pin the turn open
+      // (and eventually time out) when no background task was launched.
+      if (
+        this._launchedTaskIds.size > 0 &&
+        text &&
+        isBackgroundWaitAgentText(text)
+      ) {
         this._hasBackgroundWaiting = true;
       }
       if (row.stepType === 101 || isSystemMessage(text)) {
@@ -250,4 +257,15 @@ export class StreamPoller {
     this.db?.close();
     this.db = null;
   }
+}
+
+/** agy's known lifecycle prose when it parks a turn on a background task. */
+const BACKGROUND_WAIT_SENTINEL =
+  "Preserving context while waiting for background command output...";
+
+function isBackgroundWaitAgentText(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed === BACKGROUND_WAIT_SENTINEL) return true;
+  // Slight variants still seen with task_details present.
+  return /waiting for.*background|preserving context while waiting/i.test(trimmed);
 }

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -131,10 +131,12 @@ function titleUpdate(stepRow: StepRow): SessionUpdate[] {
 }
 
 /**
- * Step type 14 — the user's prompt/input that opened a turn. Text is wrapped
- * in `<user_text>`/`<resource_link>`/`<embedded_resource>` tags by our own
- * prompt encoder (see prompt-content.ts); unwrap them back into ACP content
- * blocks for replay.
+ * Step type 14 — the user's prompt/input that opened a turn.
+ *
+ * Live encoding (`contentBlocksToPrompt`) sends plain text plus `@path` image
+ * refs. Older tagged envelopes (`<user_text>`, `<resource_link>`,
+ * `<embedded_resource>`) are still unwrapped when present so historical
+ * conversation DBs replay cleanly; otherwise the raw text is one text block.
  */
 function userPromptUpdate(stepRow: StepRow): SessionUpdate[] {
   const up = stepRow.stepPayload.userPrompt;

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -135,9 +135,12 @@ function titleUpdate(stepRow: StepRow): SessionUpdate[] {
  *
  * Live encoding (`contentBlocksToPrompt`) forwards client text/URI/body only
  * plus agy `@path` image transport — no adapter framing prose. Older tagged
- * envelopes (`<user_text>`, `<resource_link>`, `<embedded_resource>`) are still
- * unwrapped when present so historical conversation DBs replay cleanly;
- * otherwise the raw text is one text block.
+ * envelopes (`<user_text>`, `<resource_link>`, `<embedded_resource>`) wrapped
+ * EVERY block of the prompt, so a historical row consists solely of envelope
+ * tags joined by newlines. Only unwrap when the envelopes cover the entire
+ * text; a raw prompt that merely quotes a legacy-looking tag among other
+ * prose must replay verbatim instead of being shredded into resource blocks
+ * with the surrounding text discarded.
  */
 function userPromptUpdate(stepRow: StepRow): SessionUpdate[] {
   const up = stepRow.stepPayload.userPrompt;
@@ -146,19 +149,24 @@ function userPromptUpdate(stepRow: StepRow): SessionUpdate[] {
   const blockPattern =
     /<user_text>\n([\s\S]*?)\n<\/user_text>|<resource_link uri="(.*?)" title="(.*?)"\/>|<embedded_resource uri="(.*?)">\n([\s\S]*?)\n<\/embedded_resource>/g;
 
+  const matches = [...text.matchAll(blockPattern)];
+  const isLegacyEnvelope = matches.length > 0 && text.replace(blockPattern, "").trim().length === 0;
+
   const blocks: Record<string, unknown>[] = [];
-  for (const match of text.matchAll(blockPattern)) {
-    if (match[1] !== undefined) {
-      blocks.push({ type: "text", text: match[1] });
-    } else if (match[2] !== undefined) {
-      const uri = match[2].replace(/&quot;/g, '"');
-      const title = (match[3] || "").replace(/&quot;/g, '"');
-      blocks.push({ type: "resource_link", uri, name: title, title });
-    } else if (match[4] !== undefined) {
-      blocks.push({
-        type: "resource",
-        resource: { uri: match[4].replace(/&quot;/g, '"'), text: match[5] || "" }
-      });
+  if (isLegacyEnvelope) {
+    for (const match of matches) {
+      if (match[1] !== undefined) {
+        blocks.push({ type: "text", text: match[1] });
+      } else if (match[2] !== undefined) {
+        const uri = match[2].replace(/&quot;/g, '"');
+        const title = (match[3] || "").replace(/&quot;/g, '"');
+        blocks.push({ type: "resource_link", uri, name: title, title });
+      } else if (match[4] !== undefined) {
+        blocks.push({
+          type: "resource",
+          resource: { uri: match[4].replace(/&quot;/g, '"'), text: match[5] || "" }
+        });
+      }
     }
   }
   if (blocks.length === 0) blocks.push({ type: "text", text });

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -133,10 +133,11 @@ function titleUpdate(stepRow: StepRow): SessionUpdate[] {
 /**
  * Step type 14 — the user's prompt/input that opened a turn.
  *
- * Live encoding (`contentBlocksToPrompt`) sends plain text plus `@path` image
- * refs. Older tagged envelopes (`<user_text>`, `<resource_link>`,
- * `<embedded_resource>`) are still unwrapped when present so historical
- * conversation DBs replay cleanly; otherwise the raw text is one text block.
+ * Live encoding (`contentBlocksToPrompt`) forwards client text/URI/body only
+ * plus agy `@path` image transport — no adapter framing prose. Older tagged
+ * envelopes (`<user_text>`, `<resource_link>`, `<embedded_resource>`) are still
+ * unwrapped when present so historical conversation DBs replay cleanly;
+ * otherwise the raw text is one text block.
  */
 function userPromptUpdate(stepRow: StepRow): SessionUpdate[] {
   const up = stepRow.stepPayload.userPrompt;

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -144,7 +144,8 @@ function titleUpdate(stepRow: StepRow): SessionUpdate[] {
  */
 function userPromptUpdate(stepRow: StepRow): SessionUpdate[] {
   const up = stepRow.stepPayload.userPrompt;
-  const text = (up?.text || up?.content?.text || "").trim();
+  const rawText = up?.text || up?.content?.text || "";
+  const text = rawText.trim();
 
   const blockPattern =
     /<user_text>\n([\s\S]*?)\n<\/user_text>|<resource_link uri="(.*?)" title="(.*?)"\/>|<embedded_resource uri="(.*?)">\n([\s\S]*?)\n<\/embedded_resource>/g;
@@ -169,7 +170,7 @@ function userPromptUpdate(stepRow: StepRow): SessionUpdate[] {
       }
     }
   }
-  if (blocks.length === 0) blocks.push({ type: "text", text });
+  if (blocks.length === 0) blocks.push({ type: "text", text: rawText });
 
   return blocks.map((content) => ({ sessionUpdate: "user_message_chunk", content, messageId: String(stepRow.idx) })) as SessionUpdate[];
 }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -22,6 +22,7 @@ import { createConversationDb, insertStep } from "./fixtures/conversation-db.js"
 import { encodeCommandResult, encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 import { createTerminalOutputTracker, createToolCallContentTracker, expandSessionUpdateToV2, sessionUpdateToV1, sessionUpdateToV2 } from "../src/acp/session/update-wire.js";
 import { filterUpdatesForReplayFrom } from "../src/acp/session/setup.js";
+import { turnsOf } from "../src/acp/session/turn-scheduler.js";
 import { terminalIdForToolCall } from "../src/acp/terminal/index.js";
 import { parseClientToolCallName } from "../src/acp/initialize.js";
 import type { SessionConfigOption, SessionUpdate } from "@agentclientprotocol/sdk";
@@ -821,7 +822,7 @@ describe("active session retention", () => {
     const close3 = vi.fn(async () => {});
     const session = (id: string, close: () => Promise<void>) => ({
       sessionId: id,
-      activePrompt: false,
+      promptQueue: [],
       agy: { close }
     });
     type SessionRetentionAgent = {
@@ -848,19 +849,18 @@ describe("active session retention", () => {
     const close1 = vi.fn(async () => {});
     const close2 = vi.fn(async () => {});
     const close3 = vi.fn(async () => {});
-    const session = (id: string, close: () => Promise<void>, steerClaims = 0) => ({
-      sessionId: id,
-      activePrompt: false,
-      steerClaims,
-      agy: { close }
-    });
+    const session = (id: string, close: () => Promise<void>, reserved = false) => {
+      const state = { sessionId: id, promptQueue: [], agy: { close } };
+      if (reserved) turnsOf(state as any).reserveSteer();
+      return state;
+    };
     type SessionRetentionAgent = {
       registerSession(id: string, session: unknown): Promise<void>;
       requireSession(id: string): unknown;
     };
     const retention = agent as unknown as SessionRetentionAgent;
 
-    await retention.registerSession("s1", session("s1", close1, 1));
+    await retention.registerSession("s1", session("s1", close1, true));
     await retention.registerSession("s2", session("s2", close2));
     await retention.registerSession("s3", session("s3", close3));
 

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -2124,11 +2124,11 @@ describe("ACP v2 (experimental draft)", () => {
 const TEST_MODELS_OUTPUT =
   "gemini-3.5-flash-medium\ngemini-3.5-flash-high\nclaude-opus-4-6-thinking\nclaude-sonnet-4-6\n";
 
-function printModeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+export function printModeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return { AGY_ACP_MODEL_CACHE: "0", ...overrides, AGY_ACP_INTERACTIVE_PERMISSIONS: "0" };
 }
 
-async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+export async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
   const start = Date.now();
   while (!predicate()) {
     if (Date.now() - start > timeoutMs) {
@@ -2139,7 +2139,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void
 }
 
 /** Run `fn` with a throwaway conversations directory, cleaned up afterwards. */
-async function withConversationsDir(fn: (dir: string) => Promise<void>): Promise<void> {
+export async function withConversationsDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-test-"));
   try {
     await fn(dir);
@@ -2154,7 +2154,7 @@ async function withConversationsDir(fn: (dir: string) => Promise<void>): Promise
  * database (as agy itself would) before exiting, so the ACP server's poller
  * picks them up.
  */
-function spawnAgyWritingConversation(
+export function spawnAgyWritingConversation(
   dir: string,
   conversationId: string,
   steps: Parameters<typeof insertStep>[1][]
@@ -2170,7 +2170,7 @@ function spawnAgyWritingConversation(
   }) as unknown as SpawnFactory;
 }
 
-class FakeProcess extends EventEmitter {
+export class FakeProcess extends EventEmitter {
   stdin = new Writable({ write: (_chunk, _encoding, callback) => callback() });
   stdout: Readable;
   stderr: Readable;

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -840,6 +840,36 @@ describe("active session retention", () => {
     expect(close3).not.toHaveBeenCalled();
     expect(() => retention.requireSession("s2")).toThrow("Unknown session");
   });
+
+  it("does not evict a session reserved by a steer", async () => {
+    const agent = new AcpAgent({
+      env: printModeEnv({ AGY_ACP_MAX_ACTIVE_SESSIONS: "2" })
+    });
+    const close1 = vi.fn(async () => {});
+    const close2 = vi.fn(async () => {});
+    const close3 = vi.fn(async () => {});
+    const session = (id: string, close: () => Promise<void>, steerClaims = 0) => ({
+      sessionId: id,
+      activePrompt: false,
+      steerClaims,
+      agy: { close }
+    });
+    type SessionRetentionAgent = {
+      registerSession(id: string, session: unknown): Promise<void>;
+      requireSession(id: string): unknown;
+    };
+    const retention = agent as unknown as SessionRetentionAgent;
+
+    await retention.registerSession("s1", session("s1", close1, 1));
+    await retention.registerSession("s2", session("s2", close2));
+    await retention.registerSession("s3", session("s3", close3));
+
+    expect(close1).not.toHaveBeenCalled();
+    expect(close2).toHaveBeenCalledOnce();
+    expect(close3).not.toHaveBeenCalled();
+    expect(() => retention.requireSession("s1")).not.toThrow();
+    expect(() => retention.requireSession("s2")).toThrow("Unknown session");
+  });
 });
 
 describe("session modes and config option sync", () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1477,6 +1477,43 @@ describe("cancel", () => {
     expect((await pending).stopReason).toBe("cancelled");
   });
 
+  it("fails the print-mode turn when background drain exceeds printTimeout", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-print-bg-timeout-"));
+    try {
+      const session = new AgyCliSession(
+        { ...defaultConfig(), conversationsDir: dir, printTimeout: "200ms" },
+        (command, args, options) => {
+          const db = createConversationDb(dir, "print-bg-timeout");
+          insertStep(db, {
+            idx: 1,
+            stepType: 21,
+            status: 3,
+            stepPayload: encodeStepPayload({
+              commandResult: encodeCommandResult({ command: "sleep 999 &", output: "Task task-to launched" })
+            }),
+            task: encodeTaskDetails({ taskId: "task-to", logUri: "", description: "Background task" })
+          });
+          insertStep(db, {
+            idx: 2,
+            stepType: 15,
+            status: 3,
+            stepPayload: encodeStepPayload({
+              agentText: "Preserving context while waiting for background command output..."
+            })
+          });
+          db.close();
+          return new FakeProcess([]).spawnFactory([])(command, args, options);
+        }
+      );
+
+      await expect(collectUpdates(session, "run bg")).rejects.toThrow(
+        /timed out after 200ms while waiting for background tasks/
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("cancels print-mode background drain after the child has already exited", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-print-bg-cancel-"));
     try {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -569,7 +569,7 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("maintains turn execution while background tasks are active until completed", async () => {
+  it("maintains turn execution while background tasks are active until completed (gh#68)", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-"));
     const pty = new FakePty(() => {
       const db = createConversationDb(dir, "bg-test");
@@ -588,6 +588,8 @@ describe("permission bridge", () => {
       });
       db.close();
 
+      // Fresh TUI needs two idle markers. Emit the turn-complete marker early;
+      // without hasActiveBackgroundTasks the prompt would resolve here.
       setTimeout(() => {
         pty.emitData("? for shortcuts");
         setTimeout(async () => {
@@ -601,22 +603,32 @@ describe("permission bridge", () => {
             })
           });
           db2.close();
-        }, 80);
+        }, 250);
       }, 20);
     });
 
     const session = interactiveSession(dir, pty);
     const updates: any[] = [];
-    const outcome = await session.prompt("run bg", async (update) => {
+    let resolved = false;
+    const pending = session.prompt("run bg", async (update) => {
       updates.push(update);
-    }, async () => "agy-allow-once");
+    }, async () => "agy-allow-once").then((value) => {
+      resolved = true;
+      return value;
+    });
 
+    // Idle marker has fired and "preserving context" is on disk, but the
+    // background task is still active — turn must stay open (gh#68).
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(resolved).toBe(false);
+
+    const outcome = await pending;
     expect(outcome.stopReason).toBe("end_turn");
+    expect(resolved).toBe(true);
     expect(updates.some(u => u.sessionUpdate === "agent_message_chunk" && u.content.text.includes("Preserving context"))).toBe(true);
-    // Background wait must not invent follow-up prompts (e.g. "continue").
+    // Zero prompt injection: never invent follow-ups (e.g. "continue").
     // Fresh interactive spawn puts the user prompt in argv; PTY writes stay empty.
     expect(pty.writes).toEqual([]);
-    expect(pty.writes.some((w) => /continue/i.test(w))).toBe(false);
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -569,6 +569,41 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("times out while waiting for background completion when no DB progress arrives", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-timeout-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "bg-timeout");
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          commandResult: encodeCommandResult({ command: "sleep 999 &", output: "Task task-t launched" })
+        }),
+        task: encodeTaskDetails({ taskId: "task-t", logUri: "", description: "Background task" })
+      });
+      insertStep(db, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          agentText: "Preserving context while waiting for background command output..."
+        })
+      });
+      db.close();
+      // Idle markers arrive, but no completion row — deadline must still expire.
+      setTimeout(() => pty.emitData("? for shortcuts"), 20);
+    });
+
+    const session = interactiveSession(dir, pty, "250ms");
+    await expect(
+      session.prompt("run bg", async () => {}, async () => "agy-allow-once")
+    ).rejects.toThrow(/timed out after 250ms/);
+    expect(pty.writes).toEqual([]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("maintains turn execution while background tasks are active until completed (gh#68)", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-"));
     const pty = new FakePty(() => {
@@ -1440,6 +1475,48 @@ describe("cancel", () => {
     expect(fake.killedWith).toBe("SIGINT");
     expect(session.wasCancelled).toBe(true);
     expect((await pending).stopReason).toBe("cancelled");
+  });
+
+  it("cancels print-mode background drain after the child has already exited", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-print-bg-cancel-"));
+    try {
+      const session = new AgyCliSession(
+        { ...defaultConfig(), conversationsDir: dir, printTimeout: "5s" },
+        (command, args, options) => {
+          // Child exits immediately, but background task rows remain incomplete.
+          const db = createConversationDb(dir, "print-bg-cancel");
+          insertStep(db, {
+            idx: 1,
+            stepType: 21,
+            status: 3,
+            stepPayload: encodeStepPayload({
+              commandResult: encodeCommandResult({ command: "sleep 999 &", output: "Task task-c launched" })
+            }),
+            task: encodeTaskDetails({ taskId: "task-c", logUri: "", description: "Background task" })
+          });
+          insertStep(db, {
+            idx: 2,
+            stepType: 15,
+            status: 3,
+            stepPayload: encodeStepPayload({
+              agentText: "Preserving context while waiting for background command output..."
+            })
+          });
+          db.close();
+          return new FakeProcess([]).spawnFactory([])(command, args, options);
+        }
+      );
+
+      const pending = collectUpdates(session, "run bg");
+      // Let the child exit and enter the post-exit background drain loop.
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      await session.cancel();
+
+      expect(session.wasCancelled).toBe(true);
+      expect((await pending).stopReason).toBe("cancelled");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -28,7 +28,7 @@ import {
 } from "../src/acp/tool-calls/permissions.js";
 import { requestPermissionV1, requestPermissionV2 } from "../src/acp/session/request-permission.js";
 import { createConversationDb, insertStep, updateStep } from "./fixtures/conversation-db.js";
-import { encodePermissions, encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
+import { encodeCommandResult, encodePermissions, encodeStepPayload, encodeTaskDetails, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 
 /** Collects updates via the `onUpdate` callback `AgyCliSession.prompt` takes. */
 async function collectUpdates(
@@ -565,6 +565,58 @@ describe("permission bridge", () => {
     expect(resolved).toBe(false);
     pty.emitData("? for shortcuts");
     expect((await result).stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("maintains turn execution while background tasks are active until completed", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "bg-test");
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "sleep 10 &", output: "Task task-1 launched" }) }),
+        task: encodeTaskDetails({ taskId: "task-1", logUri: "", description: "Background task" })
+      });
+      insertStep(db, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "Preserving context while waiting for background command output..." })
+      });
+      db.close();
+
+      setTimeout(() => {
+        pty.emitData("? for shortcuts");
+        setTimeout(async () => {
+          const db2 = new (await import("better-sqlite3")).default(path.join(dir, "bg-test.db"));
+          insertStep(db2, {
+            idx: 3,
+            stepType: 15,
+            status: 3,
+            stepPayload: encodeStepPayload({
+              agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-1 content=Task id "task-1" finished'
+            })
+          });
+          db2.close();
+        }, 80);
+      }, 20);
+    });
+
+    const session = interactiveSession(dir, pty);
+    const updates: any[] = [];
+    const outcome = await session.prompt("run bg", async (update) => {
+      updates.push(update);
+    }, async () => "agy-allow-once");
+
+    expect(outcome.stopReason).toBe("end_turn");
+    expect(updates.some(u => u.sessionUpdate === "agent_message_chunk" && u.content.text.includes("Preserving context"))).toBe(true);
+    // Background wait must not invent follow-up prompts (e.g. "continue").
+    // Fresh interactive spawn puts the user prompt in argv; PTY writes stay empty.
+    expect(pty.writes).toEqual([]);
+    expect(pty.writes.some((w) => /continue/i.test(w))).toBe(false);
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2121,6 +2121,49 @@ describe("StreamPoller", () => {
     poller.close();
     db.close();
   });
+
+  it("clears background wait on stop_hook type 101 even without task id in text", () => {
+    const db = createConversationDb(dir, "conv-bg-stop-hook");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "sleep 1 &", output: "launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-42", logUri: "", description: "bg" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Preserving context while waiting for background command output..."
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-stop-hook",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    insertStep(db, {
+      idx: 3,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({})
+    });
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
 });
 
 describe("ReplayCache", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2304,6 +2304,70 @@ describe("StreamPoller", () => {
     poller.close();
     db.close();
   });
+
+  it("does not close tasks launched after an id-less terminal lifecycle row", () => {
+    const db = createConversationDb(dir, "conv-bg-lifecycle-precedes-launch");
+    // Auto-proceed stop_hook with no embedded task id, written BEFORE the launch.
+    insertStep(db, {
+      idx: 1,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({})
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "sleep 10 &", output: "launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-b", logUri: "", description: "bg" })
+    });
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Preserving context while waiting for background command output..."
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-lifecycle-precedes-launch",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    // Any later revision re-reads the old id-less lifecycle row; it must not
+    // close task-b, which launched after that row was written.
+    insertStep(db, {
+      idx: 4,
+      stepType: 15,
+      status: 1,
+      stepPayload: encodeStepPayload({ agentText: "still working" })
+    });
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    // The genuine completion message still closes it.
+    insertStep(db, {
+      idx: 5,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-b content=Task id "task-b" finished'
+      })
+    });
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
 });
 
 describe("ReplayCache", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2596,3 +2596,46 @@ describe("tool call name support (gh#52)", () => {
     expect(routedUpdate).toMatchObject({ name: "run_command", kind: "execute" });
   });
 });
+
+describe("user prompt envelope replay", () => {
+  function promptUpdates(id: string, text: string): Array<Record<string, unknown>> {
+    const db = createConversationDb(dir, id);
+    insertStep(db, { idx: 1, stepType: 14, status: 3, stepPayload: encodeStepPayload({ userPrompt: text }) });
+    db.close();
+    const conn = ConversationDb.open(dir, id);
+    const rows = conn!.readAfter(-1);
+    conn!.close();
+    return sessionUpdateFromStep(rows[0]) as unknown as Array<Record<string, unknown>>;
+  }
+
+  it("unwraps a fully-tagged legacy envelope row", () => {
+    const updates = promptUpdates(
+      "conv-legacy-envelope",
+      '<user_text>\nhello\n</user_text>\n<embedded_resource uri="file:///x.ts">\nbody\n</embedded_resource>'
+    );
+    expect(updates).toEqual([
+      { sessionUpdate: "user_message_chunk", messageId: "1", content: { type: "text", text: "hello" } },
+      {
+        sessionUpdate: "user_message_chunk",
+        messageId: "1",
+        content: { type: "resource", resource: { uri: "file:///x.ts", text: "body" } }
+      }
+    ]);
+  });
+
+  it("replays verbatim a raw prompt that quotes a legacy-looking tag among other text", () => {
+    const raw = 'what does <embedded_resource uri="x">\nfoo\n</embedded_resource> do?';
+    const updates = promptUpdates("conv-raw-quoted-envelope", raw);
+    expect(updates).toEqual([
+      { sessionUpdate: "user_message_chunk", messageId: "1", content: { type: "text", text: raw } }
+    ]);
+  });
+
+  it("replays verbatim a raw prompt with an envelope-shaped prefix and trailing text", () => {
+    const raw = '<user_text>\nhello\n</user_text>\nwait, ignore that tag';
+    const updates = promptUpdates("conv-raw-envelope-prefix", raw);
+    expect(updates).toEqual([
+      { sessionUpdate: "user_message_chunk", messageId: "1", content: { type: "text", text: raw } }
+    ]);
+  });
+});

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2122,6 +2122,31 @@ describe("StreamPoller", () => {
     db.close();
   });
 
+  it("does not treat prose about preserving context as a background wait without a task", () => {
+    const db = createConversationDb(dir, "conv-bg-prose-only");
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Preserving context while waiting for background command output..."
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-prose-only",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
+
   it("clears background wait on stop_hook type 101 even without task id in text", () => {
     const db = createConversationDb(dir, "conv-bg-stop-hook");
     insertStep(db, {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -17,6 +17,7 @@ import {
   encodePermissions,
   encodeSearchHit,
   encodeStepPayload,
+  encodeTaskDetails,
   encodeToolCall,
   encodeToolRun,
   encodeUrlContentResult,
@@ -2067,6 +2068,55 @@ describe("StreamPoller", () => {
     });
     expect(poller.poll()).toHaveLength(1);
     expect(poller.turnCompleteCandidate).toBe(true);
+
+    poller.close();
+    db.close();
+  });
+
+  it("tracks background tasks as active until completion system message, without requiring a new user prompt", () => {
+    const db = createConversationDb(dir, "conv-bg-active");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "sleep 10 &", output: "Task task-9 launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-9", logUri: "", description: "bg" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Preserving context while waiting for background command output..."
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-active",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+    expect(poller.hasUnansweredSystemMessage).toBe(false);
+
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-9 content=Task id "task-9" finished'
+      })
+    });
+    const afterDone = poller.poll();
+    // SYSTEM_MESSAGE is filtered from client updates; completion is poller state only.
+    expect(afterDone.some((u) => (u as { sessionUpdate?: string }).sessionUpdate === "agent_message_chunk")).toBe(false);
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+    expect(poller.hasUnansweredSystemMessage).toBe(true);
 
     poller.close();
     db.close();

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2638,4 +2638,12 @@ describe("user prompt envelope replay", () => {
       { sessionUpdate: "user_message_chunk", messageId: "1", content: { type: "text", text: raw } }
     ]);
   });
+
+  it("preserves surrounding whitespace when replaying a raw prompt", () => {
+    const raw = "\n  const value = 1;  \n\n";
+    const updates = promptUpdates("conv-raw-whitespace", raw);
+    expect(updates).toEqual([
+      { sessionUpdate: "user_message_chunk", messageId: "1", content: { type: "text", text: raw } }
+    ]);
+  });
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2174,6 +2174,69 @@ describe("StreamPoller", () => {
     db.close();
   });
 
+  it("matches completed task ids with token boundaries, not prefixes", () => {
+    const db = createConversationDb(dir, "conv-bg-task-prefix");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "a &", output: "launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-1", logUri: "", description: "one" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "b &", output: "launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-10", logUri: "", description: "ten" })
+    });
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Preserving context while waiting for background command output..."
+      })
+    });
+    insertStep(db, {
+      idx: 4,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-10 content=Task id "task-10" finished'
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-task-prefix",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    // task-10 completed; task-1 must remain active (includes() would false-complete it).
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    insertStep(db, {
+      idx: 5,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-1 content=Task id "task-1" finished'
+      })
+    });
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
+
   it("does not treat prose about preserving context as a background wait without a task", () => {
     const db = createConversationDb(dir, "conv-bg-prose-only");
     insertStep(db, {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2122,6 +2122,58 @@ describe("StreamPoller", () => {
     db.close();
   });
 
+  it("does not complete launched tasks from a non-terminal system message row", () => {
+    const db = createConversationDb(dir, "conv-bg-nonterminal-sys");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "sleep 1 &", output: "launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-nt", logUri: "", description: "bg" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Preserving context while waiting for background command output..."
+      })
+    });
+    // Streaming system envelope (status still active) must not end the wait.
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 1,
+      stepPayload: encodeStepPayload({
+        agentText: "<SYSTEM_MESSAGE>\n[Message] partial"
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-nonterminal-sys",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    updateStep(db, 3, {
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-nt content=Task id "task-nt" finished'
+      })
+    });
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
+
   it("does not treat prose about preserving context as a background wait without a task", () => {
     const db = createConversationDb(dir, "conv-bg-prose-only");
     insertStep(db, {

--- a/tests/fixtures/conversation-db.ts
+++ b/tests/fixtures/conversation-db.ts
@@ -23,17 +23,19 @@ export function insertStep(
     stepPayload: Uint8Array;
     permissions?: Uint8Array;
     errorDetails?: Uint8Array;
+    task?: Uint8Array;
   }
 ): void {
   db.prepare(
-    "INSERT INTO steps (idx, step_type, status, step_payload, permissions, error_details) VALUES (?, ?, ?, ?, ?, ?)"
+    "INSERT INTO steps (idx, step_type, status, step_payload, permissions, error_details, task_details) VALUES (?, ?, ?, ?, ?, ?, ?)"
   ).run(
     row.idx,
     row.stepType,
     row.status ?? 3,
     Buffer.from(row.stepPayload),
     row.permissions ? Buffer.from(row.permissions) : null,
-    row.errorDetails ? Buffer.from(row.errorDetails) : null
+    row.errorDetails ? Buffer.from(row.errorDetails) : null,
+    row.task ? Buffer.from(row.task) : null
   );
 }
 

--- a/tests/fixtures/step-encoder.ts
+++ b/tests/fixtures/step-encoder.ts
@@ -172,6 +172,14 @@ export function encodeGrepSearchResult(result: {
   return w.finish();
 }
 
+export function encodeTaskDetails(task: { taskId?: string; logUri?: string; description?: string }): Uint8Array {
+  const w = new BinaryWriter();
+  if (task.taskId) w.tag(1, 2).string(task.taskId);
+  if (task.logUri) w.tag(2, 2).string(task.logUri);
+  if (task.description) w.tag(3, 2).string(task.description);
+  return w.finish();
+}
+
 /** permissions column: { 2: { 1: { 1: kind, 2: value }, 2: decision } }. */
 export function encodePermissions(info: { kind?: string; value?: string; decision?: number }): Uint8Array {
   const target = new BinaryWriter();

--- a/tests/prompt-content.test.ts
+++ b/tests/prompt-content.test.ts
@@ -2,11 +2,38 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { contentBlocksToPrompt } from "../src/acp/content/index.js";
+import { contentBlocksToPrompt, contentBlocksToText } from "../src/acp/content/index.js";
 
 const PNG_PIXEL = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
 
+/** Adapter must never invent conversational framing around client content. */
+const INJECTED_PROSE = [
+  /Referenced resource:/i,
+  /Resource\s+\S+:/,
+  /blob omitted/i,
+  /\[image:/i,
+  /\bcontinue\b/i,
+  /\/fast\b/i
+];
+
+function assertNoInjectedProse(prompt: string): void {
+  for (const pattern of INJECTED_PROSE) {
+    expect(prompt, `must not contain injected prose matching ${pattern}`).not.toMatch(pattern);
+  }
+}
+
 describe("contentBlocksToPrompt", () => {
+  it("passes text blocks through unmodified", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agy-acp-prompt-"));
+    try {
+      const prompt = await contentBlocksToPrompt([{ type: "text", text: "hello user" }], cwd);
+      expect(prompt).toBe("hello user");
+      assertNoInjectedProse(prompt);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("writes image blocks to the session workspace and references them for agy", async () => {
     const cwd = await mkdtemp(path.join(os.tmpdir(), "agy-acp-prompt-"));
     try {
@@ -19,6 +46,7 @@ describe("contentBlocksToPrompt", () => {
       const imagePath = prompt.split("\n")[1].slice(1);
       expect(imagePath).toContain(`${path.join(cwd, ".agy-acp", "attachments")}`);
       expect(await readFile(imagePath)).toEqual(Buffer.from(PNG_PIXEL, "base64"));
+      assertNoInjectedProse(prompt);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -37,8 +65,95 @@ describe("contentBlocksToPrompt", () => {
       ], cwd);
 
       expect(prompt).toBe(`@${path.resolve("/tmp/example.png")}`);
+      assertNoInjectedProse(prompt);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  it("forwards non-image resource_link URI without adapter framing", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agy-acp-prompt-"));
+    try {
+      const prompt = await contentBlocksToPrompt([
+        { type: "text", text: "see also" },
+        {
+          type: "resource_link",
+          uri: "file:///repo/src/main.ts",
+          name: "main.ts",
+          mimeType: "text/typescript"
+        }
+      ], cwd);
+
+      expect(prompt).toBe("see also\nfile:///repo/src/main.ts");
+      assertNoInjectedProse(prompt);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("forwards embedded resource text body without URI labels", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agy-acp-prompt-"));
+    try {
+      const prompt = await contentBlocksToPrompt([
+        { type: "text", text: "review" },
+        {
+          type: "resource",
+          resource: { uri: "file:///repo/notes.md", text: "line one\nline two", mimeType: "text/markdown" }
+        }
+      ], cwd);
+
+      expect(prompt).toBe("review\nline one\nline two");
+      assertNoInjectedProse(prompt);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("omits non-image blobs instead of inventing omission copy", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agy-acp-prompt-"));
+    try {
+      const prompt = await contentBlocksToPrompt([
+        { type: "text", text: "attach" },
+        {
+          type: "resource",
+          resource: {
+            uri: "file:///repo/data.bin",
+            blob: Buffer.from("binary").toString("base64"),
+            mimeType: "application/octet-stream"
+          }
+        }
+      ], cwd);
+
+      expect(prompt).toBe("attach");
+      assertNoInjectedProse(prompt);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("contentBlocksToText", () => {
+  it("joins client text without invented labels", () => {
+    expect(contentBlocksToText([
+      { type: "text", text: "first" },
+      { type: "text", text: "second" }
+    ])).toBe("first\nsecond");
+  });
+
+  it("uses client URI and resource body only", () => {
+    const text = contentBlocksToText([
+      {
+        type: "resource_link",
+        uri: "file:///x.ts",
+        name: "x.ts"
+      },
+      {
+        type: "resource",
+        resource: { uri: "file:///y.ts", text: "export {}", mimeType: "text/typescript" }
+      },
+      { type: "image", mimeType: "image/png", data: PNG_PIXEL }
+    ]);
+    expect(text).toBe("file:///x.ts\nexport {}");
+    assertNoInjectedProse(text);
   });
 });

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -466,6 +466,232 @@ describe("queue and steer-by-cancel", () => {
     });
   });
 
+  it("does not start a queued follow-up between competing steers", async () => {
+    await withConversationsDir(async (dir) => {
+      const processes: ControlledFakeProcess[] = [];
+      const executedPrompts: string[] = [];
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        const promptIdx = args.indexOf("--print");
+        executedPrompts.push(promptIdx >= 0 ? args[promptIdx + 1] : "");
+        const db = createConversationDb(dir, `conv-steer-queue-${processes.length}`);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt" }) });
+        db.close();
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        () => {}
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+        await waitFor(() => processes.length === 1);
+
+        // Queue a follow-up, then two steers that must replace without letting the
+        // queue claim the session between them.
+        const pq = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "queued should wait" }],
+          _meta: { "agy-acp/turnIntent": "queue" }
+        } as any);
+        const s1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "steer 1" }],
+          _meta: { "agy-acp/turnIntent": "steer" }
+        } as any);
+        const s2 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "steer 2" }],
+          _meta: { "agy-acp/turnIntent": "steer" }
+        } as any);
+
+        await waitFor(() => processes.length === 2);
+        expect(executedPrompts).toEqual(["prompt 1", "steer 1"]);
+        processes[1].finish();
+        await p1;
+        await s1;
+
+        await waitFor(() => processes.length === 3);
+        expect(executedPrompts).toEqual(["prompt 1", "steer 1", "steer 2"]);
+        processes[2].finish();
+        await s2;
+
+        await waitFor(() => processes.length === 4);
+        expect(executedPrompts).toEqual(["prompt 1", "steer 1", "steer 2", "queued should wait"]);
+        processes[3].finish();
+        const rq = (await pq) as acp.PromptResponse;
+        expect(rq.stopReason).toBe("end_turn");
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  it("cancels an in-flight steer when the session is closed", async () => {
+    await withConversationsDir(async (dir) => {
+      const processes: ControlledFakeProcess[] = [];
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        const db = createConversationDb(dir, `conv-steer-close-${processes.length}`);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt" }) });
+        db.close();
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        () => {}
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+        await waitFor(() => processes.length === 1);
+
+        const steer = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "steer after close" }],
+          _meta: { "agy-acp/turnIntent": "steer" }
+        } as any);
+
+        await connection.agent.request(methods.agent.session.close, {
+          sessionId: session.sessionId
+        });
+
+        const r1 = await p1;
+        const rs = (await steer) as acp.PromptResponse;
+        expect(r1.stopReason).toBe("cancelled");
+        expect(rs.stopReason).toBe("cancelled");
+        // Steer must not start a replacement after cleanup.
+        expect(processes.length).toBe(1);
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  it("does not treat a queued resource body of /plan as a config slash command", async () => {
+    await withConversationsDir(async (dir) => {
+      const processes: ControlledFakeProcess[] = [];
+      const executedPrompts: string[] = [];
+      const updates: Array<Record<string, unknown>> = [];
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        const promptIdx = args.indexOf("--print");
+        executedPrompts.push(promptIdx >= 0 ? args[promptIdx + 1] : "");
+        const db = createConversationDb(dir, `conv-queued-resource-${processes.length}`);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt" }) });
+        insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ok" }) });
+        db.close();
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        (ctx) => {
+          updates.push(ctx.params.update as Record<string, unknown>);
+        }
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+        await waitFor(() => processes.length === 1);
+
+        const p2 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [
+            {
+              type: "resource",
+              resource: { uri: "file:///notes.md", text: "/plan", mimeType: "text/markdown" }
+            }
+          ],
+          _meta: { "agy-acp/turnIntent": "queue" }
+        } as any);
+
+        processes[0].finish();
+        await p1;
+
+        await waitFor(() => processes.length === 2);
+        processes[1].finish();
+        const r2 = (await p2) as acp.PromptResponse;
+        expect(r2.stopReason).toBe("end_turn");
+        // Resource body is forwarded to agy, not intercepted as /plan mode change.
+        expect(executedPrompts[1]).toBe("/plan");
+        expect(
+          updates.some(
+            (u) =>
+              u.sessionUpdate === "current_mode_update" ||
+              (u.sessionUpdate === "config_option_update" &&
+                Array.isArray(u.configOptions) &&
+                (u.configOptions as Array<{ id?: string; currentValue?: string }>).some(
+                  (o) => o.id === "mode" && o.currentValue === "plan"
+                ))
+          )
+        ).toBe(false);
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
   // The ACP SDK request helper does not currently expose a request-abort
   // option, so queued request cancellation is covered by session close below.
   it.skip("cancels a specific queued prompt via signal abort", async () => {

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -397,6 +397,75 @@ describe("queue and steer-by-cancel", () => {
     });
   });
 
+  it("serializes competing steer requests", async () => {
+    await withConversationsDir(async (dir) => {
+      const processes: ControlledFakeProcess[] = [];
+      const executedPrompts: string[] = [];
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        const promptIdx = args.indexOf("--print");
+        executedPrompts.push(promptIdx >= 0 ? args[promptIdx + 1] : "");
+        const db = createConversationDb(dir, `conv-steer-serial-${processes.length}`);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt" }) });
+        db.close();
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        () => {}
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+        await waitFor(() => processes.length === 1);
+
+        const p2 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "steer 1" }],
+          _meta: { "agy-acp/turnIntent": "steer" }
+        } as any);
+        const p3 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "steer 2" }],
+          _meta: { "agy-acp/turnIntent": "steer" }
+        } as any);
+
+        await waitFor(() => processes.length === 2);
+        expect(executedPrompts).toEqual(["prompt 1", "steer 1"]);
+        processes[1].finish();
+        await p1;
+        await p2;
+
+        await waitFor(() => processes.length === 3);
+        expect(executedPrompts).toEqual(["prompt 1", "steer 1", "steer 2"]);
+        processes[2].finish();
+        await p3;
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
   // The ACP SDK request helper does not currently expose a request-abort
   // option, so queued request cancellation is covered by session close below.
   it.skip("cancels a specific queued prompt via signal abort", async () => {

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -1383,6 +1383,125 @@ describe("queue and steer-by-cancel", () => {
     turns.release(nextActive);
   });
 
+  it("cancels a claimed queued turn by id without aborting a concurrent steer", async () => {
+    // PR #84 review: a targeted cancel whose item had already left the FIFO
+    // fell through to abortAll(), killing the unrelated steer reservation too.
+    const updates: any[] = [];
+    let promptCalls = 0;
+    let settlePrompt: (outcome: { stopReason: string }) => void = () => {};
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      promptQueue: [],
+      v2UserMessageIdsByStep: {},
+      agy: {
+        config: { mode: "default" },
+        cancel: async () => { settlePrompt({ stopReason: "cancelled" }); },
+        prompt: async () => {
+          promptCalls++;
+          return new Promise<{ stopReason: string }>((resolve) => { settlePrompt = resolve; });
+        },
+        lastPromptUserStepIdxs: []
+      }
+    } as unknown as SessionState;
+    const turns = turnsOf(session);
+    const deps = {
+      requireSession: () => session,
+      persistSession: async () => {},
+      applyConfigOption: async () => {},
+      notifyConfigOptionUpdateV2: async () => {}
+    } as unknown as PromptV2Deps;
+    const client = { notify: async (_m: string, p: any) => { updates.push(p.update); } } as any;
+
+    // Queue item 1 behind a held slot, then let it claim the turn.
+    const held = turns.claimIdle("foreground");
+    const queuedResponse = await handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "queued" }],
+      _meta: { "agy-acp/turnIntent": "queue" }
+    } as any, client, deps);
+    const queuedId = (queuedResponse as any)._meta["agy-acp/queuedPromptId"] as string;
+    await waitFor(() => updates.some((u) => u.sessionUpdate === "user_message"));
+    turns.release(held);
+    notifyIdleAndDrainQueue(session);
+    await waitFor(() => promptCalls === 1); // the queued turn is running
+
+    // A steer reserves the next turn; displacement starts on the next task, so
+    // the reservation exists but the queued turn's claim is still untouched.
+    const steer = handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "steer" }],
+      _meta: { "agy-acp/turnIntent": "steer" }
+    } as any, client, deps);
+    await steer; // acceptance only
+
+    // Targeted cancel of the queued item must abort only its claimed turn.
+    await handleCancel("s1", new Map([["s1", session]]), { "agy-acp/queuedPromptId": queuedId });
+
+    // The steer survives, displaces the cancelled turn, and runs.
+    await waitFor(() => promptCalls === 2);
+    settlePrompt({ stopReason: "end_turn" });
+    await waitFor(() =>
+      updates.some(
+        (u) => u.sessionUpdate === "state_update" && u.state === "idle" && u.stopReason === "end_turn"
+      )
+    );
+    expect(turns.busy()).toBe(false);
+  });
+
+  it("treats a stale queued cancellation id as a no-op", async () => {
+    // PR #84 review: an unmatched targeted cancel fell through to abortAll(),
+    // so a stale id could cancel whichever newer turn happened to be active.
+    let promptCalls = 0;
+    let cancelCalls = 0;
+    let settlePrompt: (outcome: { stopReason: string }) => void = () => {};
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      promptQueue: [],
+      v2UserMessageIdsByStep: {},
+      agy: {
+        config: { mode: "default" },
+        cancel: async () => {
+          cancelCalls++;
+          settlePrompt({ stopReason: "cancelled" });
+        },
+        prompt: async () => {
+          promptCalls++;
+          return new Promise<{ stopReason: string }>((resolve) => { settlePrompt = resolve; });
+        },
+        lastPromptUserStepIdxs: []
+      }
+    } as unknown as SessionState;
+    const turns = turnsOf(session);
+    const deps = {
+      requireSession: () => session,
+      persistSession: async () => {},
+      applyConfigOption: async () => {},
+      notifyConfigOptionUpdateV2: async () => {}
+    } as unknown as PromptV2Deps;
+    const client = { notify: async () => {} } as any;
+
+    // A foreground v2 turn is running.
+    await handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "active" }]
+    } as any, client, deps);
+    await waitFor(() => promptCalls === 1);
+
+    // A targeted cancel for an unknown id must not touch the active turn.
+    await handleCancel("s1", new Map([["s1", session]]), { "agy-acp/queuedPromptId": "q-stale" });
+    expect(cancelCalls).toBe(0);
+    expect(turns.busy()).toBe(true);
+
+    // A plain session/cancel still stops the active turn.
+    await handleCancel("s1", new Map([["s1", session]]));
+    await waitFor(() => !turns.busy());
+    expect(cancelCalls).toBeGreaterThan(0);
+  });
+
   it("rejects a non-intent prompt while a steer replacement is in progress", async () => {
     await withConversationsDir(async (dir) => {
       const processes: ControlledFakeProcess[] = [];

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -1,0 +1,611 @@
+import { EventEmitter } from "node:events";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Readable, Writable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import * as acp from "@agentclientprotocol/sdk";
+import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
+import { client as acpClient, methods, PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
+import { createAcpApp, createAcpV2App } from "../src/agent.js";
+import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
+import { encodeStepPayload } from "./fixtures/step-encoder.js";
+import type { SpawnFactory } from "../src/agy/cli.js";
+
+const TEST_MODELS_OUTPUT =
+  "gemini-3.5-flash-medium\ngemini-3.5-flash-high\nclaude-opus-4-6-thinking\nclaude-sonnet-4-6\n";
+
+function printModeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { AGY_ACP_MODEL_CACHE: "0", ...overrides, AGY_ACP_INTERACTIVE_PERMISSIONS: "0" };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitFor timed out");
+    }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+async function withConversationsDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-test-"));
+  try {
+    await fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+class FakeProcess extends EventEmitter {
+  stdin = new Writable({ write: (_chunk, _encoding, callback) => callback() });
+  stdout: Readable;
+  stderr: Readable;
+  exitCode = 0;
+  pid = 1;
+
+  constructor(
+    chunks: string[],
+    options: { exitCode?: number; stderr?: string } = {}
+  ) {
+    super();
+    this.exitCode = options.exitCode ?? 0;
+    this.stdout = Readable.from(chunks);
+    this.stderr = Readable.from(options.stderr ? [options.stderr] : []);
+    queueMicrotask(() => this.emit("exit", this.exitCode, null));
+  }
+
+  kill() {
+    this.exitCode = -15;
+    this.emit("exit", -15, "SIGTERM");
+    return true;
+  }
+}
+
+function spawnAgyWritingConversation(
+  dir: string,
+  conversationId: string,
+  steps: Parameters<typeof insertStep>[1][]
+): SpawnFactory {
+  return ((command: string, args: string[]) => {
+    if (args[0] === "models") {
+      return new FakeProcess([TEST_MODELS_OUTPUT]);
+    }
+    const db = createConversationDb(dir, conversationId);
+    for (const step of steps) insertStep(db, step);
+    db.close();
+    return new FakeProcess([]);
+  }) as unknown as SpawnFactory;
+}
+
+class ControlledFakeProcess extends EventEmitter {
+  stdin = new Writable({ write: (_chunk, _encoding, callback) => callback() });
+  stdout = new Readable({ read() {} });
+  stderr = new Readable({ read() {} });
+  exitCode: number | null = null;
+  pid = 1;
+
+  finish(code = 0) {
+    this.exitCode = code;
+    this.stdout.push(null);
+    this.stderr.push(null);
+    this.emit("exit", code, null);
+  }
+
+  kill(signal?: string) {
+    this.exitCode = signal === "SIGKILL" ? -9 : -15;
+    this.stdout.push(null);
+    this.stderr.push(null);
+    this.emit("exit", this.exitCode, signal ?? "SIGTERM");
+    return true;
+  }
+}
+
+describe("queue and steer-by-cancel", () => {
+  it("rejects overlapping prompts when no turnIntent meta is provided", async () => {
+    await withConversationsDir(async (dir) => {
+      let activeProc: ControlledFakeProcess | null = null;
+      let promptCount = 0;
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        promptCount++;
+        const convId = `conv-${promptCount}`;
+        const db = createConversationDb(dir, convId);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt" }) });
+        insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "reply" }) });
+        db.close();
+        const proc = new ControlledFakeProcess();
+        activeProc = proc;
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        () => {}
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        // Start first prompt (which stays active)
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+
+        await waitFor(() => activeProc !== null);
+
+        // Overlapping prompt without turnIntent should reject immediately
+        await expect(
+          connection.agent.request(methods.agent.session.prompt, {
+            sessionId: session.sessionId,
+            prompt: [{ type: "text", text: "prompt 2" }]
+          })
+        ).rejects.toThrow();
+
+        (activeProc as ControlledFakeProcess | null)?.finish();
+        await p1;
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  it("queues v1 follow-up prompts and executes them in FIFO order", async () => {
+    await withConversationsDir(async (dir) => {
+      const executedPrompts: string[] = [];
+      const processes: ControlledFakeProcess[] = [];
+      let promptCount = 0;
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        const promptIdx = args.indexOf("--print");
+        const promptText = promptIdx >= 0 ? args[promptIdx + 1] : "";
+        executedPrompts.push(promptText);
+
+        promptCount++;
+        const convId = `conv-${promptCount}`;
+        const db = createConversationDb(dir, convId);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: promptText }) });
+        insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: `ans ${promptText}` }) });
+        db.close();
+
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        () => {}
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        // First prompt
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+
+        await waitFor(() => processes.length === 1);
+
+        // Second prompt queued
+        const p2 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 2" }],
+          _meta: { "agy-acp/turnIntent": "queue" }
+        } as any);
+
+        // Third prompt queued
+        const p3 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 3" }],
+          _meta: { "agy-acp/turnIntent": "queue" }
+        } as any);
+
+        // Finish prompt 1
+        processes[0].finish();
+        const r1 = await p1;
+
+        // Prompt 2 should now be running
+        await waitFor(() => processes.length === 2);
+        processes[1].finish();
+        const r2 = (await p2) as acp.PromptResponse;
+
+        // Prompt 3 should now be running
+        await waitFor(() => processes.length === 3);
+        processes[2].finish();
+        const r3 = (await p3) as acp.PromptResponse;
+
+        expect(r1.stopReason).toBe("end_turn");
+        expect(r2.stopReason).toBe("end_turn");
+        expect(r3.stopReason).toBe("end_turn");
+
+        expect(executedPrompts).toEqual(["prompt 1", "prompt 2", "prompt 3"]);
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  it("queues v2 follow-up prompts, returning {} immediately and ordering updates", async () => {
+    await withConversationsDir(async (dir) => {
+      const updates: Array<Record<string, unknown>> = [];
+      const client = acpV2.client({ name: "test-client" }).onNotification(
+        acpV2.methods.client.session.update,
+        (ctx) => {
+          updates.push(ctx.params.update as Record<string, unknown>);
+        }
+      );
+      const connection = client.connect(
+        createAcpV2App({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess: spawnAgyWritingConversation(dir, "conv-v2-queue", [
+            { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt 1" }) },
+            { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ans 1" }) },
+            { idx: 2, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt 2" }) },
+            { idx: 3, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ans 2" }) }
+          ])
+        })
+      );
+      try {
+        await connection.agent.request(acpV2.methods.agent.initialize, {
+          protocolVersion: 2,
+          info: { name: "test-client", version: "0.0.0" },
+          capabilities: {}
+        });
+        const session = await connection.agent.request(acpV2.methods.agent.session.new, {
+          cwd: "/repo"
+        });
+
+        // Prompt 1
+        const r1 = await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+        expect(r1).toEqual({});
+
+        // Prompt 2 queued while 1 is active
+        const r2 = await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 2" }],
+          _meta: { "agy-acp/turnIntent": "queue" }
+        } as any);
+        expect(r2).toEqual({});
+
+        await waitFor(() => {
+          const idleCount = updates.filter((u) => u.sessionUpdate === "state_update" && u.state === "idle").length;
+          return idleCount >= 2;
+        });
+
+        const userMessages = updates.filter((u) => u.sessionUpdate === "user_message");
+        expect(userMessages.length).toBe(2);
+
+        const states = updates.filter((u) => u.sessionUpdate === "state_update");
+        // State updates: running (p1) -> idle (p1) -> running (p2) -> idle (p2)
+        expect(states.map((s) => ({ state: s.state, stopReason: s.stopReason }))).toEqual([
+          { state: "running", stopReason: undefined },
+          { state: "idle", stopReason: "end_turn" },
+          { state: "running", stopReason: undefined },
+          { state: "idle", stopReason: "end_turn" }
+        ]);
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  it("steers an active turn by cancelling it and executing the steer prompt", async () => {
+    await withConversationsDir(async (dir) => {
+      const executedPrompts: string[] = [];
+      const processes: ControlledFakeProcess[] = [];
+      let promptCount = 0;
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        const promptIdx = args.indexOf("--print");
+        const promptText = promptIdx >= 0 ? args[promptIdx + 1] : "";
+        executedPrompts.push(promptText);
+
+        promptCount++;
+        const convId = `conv-steer-${promptCount}`;
+        const db = createConversationDb(dir, convId);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: promptText }) });
+        insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: `ans ${promptText}` }) });
+        db.close();
+
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        () => {}
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        // Start long-running prompt 1
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "long running turn" }]
+        });
+
+        await waitFor(() => processes.length === 1);
+
+        // Steer with prompt 2
+        const p2 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "steer turn" }],
+          _meta: { "agy-acp/turnIntent": "steer" }
+        } as any);
+
+        // Turn 1 should be cancelled via SIGINT kill
+        const r1 = await p1;
+        expect(r1.stopReason).toBe("cancelled");
+
+        // Complete steer process
+        await waitFor(() => processes.length === 2);
+        processes[1].finish();
+
+        const r2 = (await p2) as acp.PromptResponse;
+        expect(r2.stopReason).toBe("end_turn");
+
+        expect(executedPrompts).toEqual(["long running turn", "steer turn"]);
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  // The ACP SDK request helper does not currently expose a request-abort
+  // option, so queued request cancellation is covered by session close below.
+  it.skip("cancels a specific queued prompt via signal abort", async () => {
+    await withConversationsDir(async (dir) => {
+      const processes: ControlledFakeProcess[] = [];
+      const executedPrompts: string[] = [];
+      let promptCount = 0;
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        const promptIdx = args.indexOf("--print");
+        const promptText = promptIdx >= 0 ? args[promptIdx + 1] : "";
+        executedPrompts.push(promptText);
+
+        promptCount++;
+        const convId = `conv-abort-${promptCount}`;
+        const db = createConversationDb(dir, convId);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: promptText }) });
+        insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: `ans ${promptText}` }) });
+        db.close();
+
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        () => {}
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+
+        await waitFor(() => processes.length === 1);
+
+        // Queue item 2 with AbortController
+        const controller = new AbortController();
+        const p2 = (connection.agent.request as any)(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 2" }],
+          _meta: { "agy-acp/turnIntent": "queue" }
+        } as any, { signal: controller.signal });
+
+        // Abort p2 while p1 is active
+        controller.abort();
+
+        const r2 = (await p2) as acp.PromptResponse;
+        expect(r2.stopReason).toBe("cancelled");
+
+        // Complete p1
+        processes[0].finish();
+        const r1 = await p1;
+        expect(r1.stopReason).toBe("end_turn");
+
+        // Only prompt 1 was executed
+        expect(executedPrompts).toEqual(["prompt 1"]);
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  it("drains and cancels queued prompts on session close", async () => {
+    await withConversationsDir(async (dir) => {
+      const processes: ControlledFakeProcess[] = [];
+      let promptCount = 0;
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        promptCount++;
+        const convId = `conv-close-${promptCount}`;
+        const db = createConversationDb(dir, convId);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt" }) });
+        db.close();
+
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        () => {}
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+
+        await waitFor(() => processes.length === 1);
+
+        const p2 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 2" }],
+          _meta: { "agy-acp/turnIntent": "queue" }
+        } as any);
+
+        // Close session while p1 is active and p2 is queued
+        await connection.agent.request(methods.agent.session.close, {
+          sessionId: session.sessionId
+        });
+
+        const r1 = await p1;
+        const r2 = (await p2) as acp.PromptResponse;
+
+        expect(r1.stopReason).toBe("cancelled");
+        expect(r2.stopReason).toBe("cancelled");
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  it("continues draining the queue if an active turn fails with an error", async () => {
+    await withConversationsDir(async (dir) => {
+      const executedPrompts: string[] = [];
+      let promptCount = 0;
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        const promptIdx = args.indexOf("--print");
+        const promptText = promptIdx >= 0 ? args[promptIdx + 1] : "";
+        executedPrompts.push(promptText);
+
+        promptCount++;
+        const convId = `conv-fail-${promptCount}`;
+        const db = createConversationDb(dir, convId);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: promptText }) });
+        insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: `ans ${promptText}` }) });
+        db.close();
+
+        if (promptText === "failing prompt") {
+          return new FakeProcess([], { exitCode: 1, stderr: "error" });
+        }
+        const proc = new ControlledFakeProcess();
+        queueMicrotask(() => proc.finish(0));
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        () => {}
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "failing prompt" }]
+        });
+
+        const p2 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "queued after failure" }],
+          _meta: { "agy-acp/turnIntent": "queue" }
+        } as any);
+
+        await expect(p1).rejects.toThrow();
+
+        const r2 = (await p2) as acp.PromptResponse;
+        expect(r2.stopReason).toBe("end_turn");
+        expect(executedPrompts).toEqual(["failing prompt", "queued after failure"]);
+      } finally {
+        connection.close();
+      }
+    });
+  });
+});

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -609,6 +609,244 @@ describe("queue and steer-by-cancel", () => {
     });
   });
 
+  it("drains the queue after a slash-command steer", async () => {
+    await withConversationsDir(async (dir) => {
+      const processes: ControlledFakeProcess[] = [];
+      const executedPrompts: string[] = [];
+      const updates: Array<Record<string, unknown>> = [];
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        const promptIdx = args.indexOf("--print");
+        executedPrompts.push(promptIdx >= 0 ? args[promptIdx + 1] : "");
+        const db = createConversationDb(dir, `conv-slash-steer-${processes.length}`);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt" }) });
+        insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ok" }) });
+        db.close();
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        (ctx) => {
+          updates.push(ctx.params.update as Record<string, unknown>);
+        }
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+        await waitFor(() => processes.length === 1);
+
+        const queued = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "queued after slash steer" }],
+          _meta: { "agy-acp/turnIntent": "queue" }
+        } as any);
+
+        const steer = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "/plan" }],
+          _meta: { "agy-acp/turnIntent": "steer" }
+        } as any);
+
+        const r1 = await p1;
+        expect(r1.stopReason).toBe("cancelled");
+
+        const rs = (await steer) as acp.PromptResponse;
+        expect(rs.stopReason).toBe("end_turn");
+        expect(
+          updates.some(
+            (u) =>
+              u.sessionUpdate === "current_mode_update" && u.currentModeId === "plan"
+          )
+        ).toBe(true);
+
+        // Queue must still run after the slash-only steer releases its claim.
+        await waitFor(() => processes.length === 2);
+        processes[1].finish();
+        const rq = (await queued) as acp.PromptResponse;
+        expect(rq.stopReason).toBe("end_turn");
+        expect(executedPrompts).toEqual(["prompt 1", "queued after slash steer"]);
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  it("releases the steer slot when slash-command setup throws", async () => {
+    await withConversationsDir(async (dir) => {
+      const processes: ControlledFakeProcess[] = [];
+      const executedPrompts: string[] = [];
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        const promptIdx = args.indexOf("--print");
+        executedPrompts.push(promptIdx >= 0 ? args[promptIdx + 1] : "");
+        const db = createConversationDb(dir, `conv-steer-throw-${processes.length}`);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt" }) });
+        insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ok" }) });
+        db.close();
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        () => {}
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+        await waitFor(() => processes.length === 1);
+
+        const queued = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "queued after failed steer" }],
+          _meta: { "agy-acp/turnIntent": "queue" }
+        } as any);
+
+        const badSteer = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "/model nonexistent-model-xyz" }],
+          _meta: { "agy-acp/turnIntent": "steer" }
+        } as any);
+
+        // ACP wraps handler errors; the important bit is rejection + claim release.
+        await expect(badSteer).rejects.toThrow();
+        const r1 = await p1;
+        expect(r1.stopReason).toBe("cancelled");
+
+        // Failed steer must release its claim so the queue can proceed.
+        await waitFor(() => processes.length === 2);
+        processes[1].finish();
+        const rq = (await queued) as acp.PromptResponse;
+        expect(rq.stopReason).toBe("end_turn");
+        expect(executedPrompts).toEqual(["prompt 1", "queued after failed steer"]);
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  it("cancels a queued v2 turn aborted during startup notifications", async () => {
+    await withConversationsDir(async (dir) => {
+      const processes: ControlledFakeProcess[] = [];
+      const updates: Array<Record<string, unknown>> = [];
+      let promptSpawnCount = 0;
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        promptSpawnCount++;
+        const db = createConversationDb(dir, `conv-v2-abort-${processes.length}`);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt" }) });
+        insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ok" }) });
+        db.close();
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      const client = acpV2.client({ name: "test-client" }).onNotification(
+        acpV2.methods.client.session.update,
+        (ctx) => {
+          updates.push(ctx.params.update as Record<string, unknown>);
+        }
+      );
+      const connection = client.connect(
+        createAcpV2App({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(acpV2.methods.agent.initialize, {
+          protocolVersion: 2,
+          info: { name: "test-client", version: "0.0.0" },
+          capabilities: {}
+        });
+        const session = await connection.agent.request(acpV2.methods.agent.session.new, {
+          cwd: "/repo"
+        });
+
+        // Start a long-running v2 turn so we can queue behind it.
+        const r1 = await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+        expect(r1).toEqual({});
+        await waitFor(() => processes.length === 1);
+
+        const r2 = await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "queued v2" }],
+          _meta: { "agy-acp/turnIntent": "queue" }
+        } as any);
+        expect(r2).toEqual({});
+
+        // Close while p1 is active and p2 is queued — queued turn must not spawn agy.
+        await connection.agent.request(acpV2.methods.agent.session.close, {
+          sessionId: session.sessionId
+        } as any);
+
+        await waitFor(() =>
+          updates.some(
+            (u) =>
+              u.sessionUpdate === "state_update" &&
+              u.state === "idle" &&
+              u.stopReason === "cancelled"
+          )
+        );
+
+        // Only the first (active) prompt may have spawned; queued must not start after teardown.
+        expect(promptSpawnCount).toBe(1);
+        expect(
+          updates.filter(
+            (u) =>
+              u.sessionUpdate === "state_update" &&
+              u.state === "idle" &&
+              u.stopReason === "cancelled"
+          ).length
+        ).toBeGreaterThanOrEqual(1);
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
   it("does not treat a queued resource body of /plan as a config slash command", async () => {
     await withConversationsDir(async (dir) => {
       const processes: ControlledFakeProcess[] = [];

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -276,6 +276,39 @@ describe("queue and steer-by-cancel", () => {
     expect(session.promptIdleNotify).toBeUndefined();
   });
 
+  it("cancels a v2 turn while prompt content is still being prepared", async () => {
+    let promptCalls = 0;
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      activePrompt: false,
+      promptQueue: [],
+      agy: {
+        prompt: async () => {
+          promptCalls++;
+          return { stopReason: "end_turn" };
+        },
+        cancel: async () => {}
+      }
+    } as unknown as SessionState;
+    const deps = {
+      requireSession: () => session
+    } as unknown as PromptV2Deps;
+
+    const response = handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "prepared asynchronously" }]
+    } as any, { notify: async () => {} } as any, deps);
+
+    expect(session.promptAbort).toBeDefined();
+    session.promptAbort!.abort();
+
+    await expect(response).resolves.toEqual({});
+    expect(promptCalls).toBe(0);
+    expect(session.promptAbort).toBeUndefined();
+    expect(session.activePrompt).toBe(false);
+  });
+
   it("does not install a new idle waiter when a competing steer resumes after close", async () => {
     const session = {
       sessionId: "s1",

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -156,6 +156,50 @@ describe("queue and steer-by-cancel", () => {
     expect(session.activePrompt).toBe(false);
   });
 
+  it("cancels a v1 turn while prompt content is still being prepared", async () => {
+    let promptCalls = 0;
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      activePrompt: false,
+      promptQueue: [],
+      v2UserMessageIdsByStep: {},
+      catalog: { models: [], byBase: new Map() },
+      selectedBaseModel: "m",
+      selectedReasoningEffort: "",
+      agy: {
+        config: { mode: "default" },
+        prompt: async () => {
+          promptCalls++;
+          return { stopReason: "end_turn" };
+        },
+        cancel: async () => {}
+      }
+    } as unknown as SessionState;
+    const deps = {
+      requireSession: () => session,
+      applyConfigOption: async () => {},
+      persistSession: async () => {},
+      notifyCurrentModeUpdate: async () => {},
+      notifyConfigOptionUpdateV1: async () => {},
+      clientFileSystemV1: () => undefined
+    } satisfies PromptV1Deps;
+
+    const response = handlePromptV1({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "prepared asynchronously" }]
+    } as any, { notify: async () => {} } as any, undefined, deps);
+
+    expect(session.promptAbort).toBeDefined();
+    session.promptAbort!.abort();
+
+    await expect(response).resolves.toEqual({ stopReason: "cancelled" });
+    expect(promptCalls).toBe(0);
+    expect(session.promptAbort).toBeUndefined();
+    expect(session.activePrompt).toBe(false);
+  });
+
   it("places concurrent v2 queue requests in FIFO before notification awaits", async () => {
     const session = {
       sessionId: "s1",

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -8,15 +8,15 @@ import * as acp from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import { client as acpClient, methods, PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
 import { createAcpApp, createAcpV2App } from "../src/agent.js";
-import { cancelQueuedPrompts } from "../src/acp/session/cancel.js";
+import { cancelQueuedPrompts, handleCancel } from "../src/acp/session/cancel.js";
 import { handleCloseSession } from "../src/acp/session/close.js";
 import {
   handlePromptV1,
   handlePromptV2,
-  wakePromptIdleWaiters,
   type PromptV1Deps,
   type PromptV2Deps
 } from "../src/acp/session/prompt.js";
+import { turnsOf } from "../src/acp/session/turn-scheduler.js";
 import type { SessionState } from "../src/acp/session/types.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload } from "./fixtures/step-encoder.js";
@@ -122,7 +122,6 @@ describe("queue and steer-by-cancel", () => {
       sessionId: "s1",
       cwd: "/repo",
       additionalDirectories: [],
-      activePrompt: false,
       promptQueue: [],
       v2UserMessageIdsByStep: {},
       catalog: { models: [], byBase: new Map() },
@@ -144,7 +143,7 @@ describe("queue and steer-by-cancel", () => {
       sessionId: "s1",
       prompt: [{ type: "text", text: "/plan" }]
     } as any, client, undefined, deps);
-    await waitFor(() => session.activePrompt);
+    await waitFor(() => turnsOf(session).busy());
 
     await expect(handlePromptV1({
       sessionId: "s1",
@@ -153,7 +152,7 @@ describe("queue and steer-by-cancel", () => {
 
     releaseConfigNotification();
     await expect(first).resolves.toEqual({ stopReason: "end_turn" });
-    expect(session.activePrompt).toBe(false);
+    expect(turnsOf(session).busy()).toBe(false);
   });
 
   it("cancels a v1 turn while prompt content is still being prepared", async () => {
@@ -162,7 +161,6 @@ describe("queue and steer-by-cancel", () => {
       sessionId: "s1",
       cwd: "/repo",
       additionalDirectories: [],
-      activePrompt: false,
       promptQueue: [],
       v2UserMessageIdsByStep: {},
       catalog: { models: [], byBase: new Map() },
@@ -191,22 +189,23 @@ describe("queue and steer-by-cancel", () => {
       prompt: [{ type: "text", text: "prepared asynchronously" }]
     } as any, { notify: async () => {} } as any, undefined, deps);
 
-    expect(session.promptAbort).toBeDefined();
-    session.promptAbort!.abort();
+    expect(turnsOf(session).activeClaim).toBeDefined();
+    turnsOf(session).activeClaim!.abort();
 
     await expect(response).resolves.toEqual({ stopReason: "cancelled" });
     expect(promptCalls).toBe(0);
-    expect(session.promptAbort).toBeUndefined();
-    expect(session.activePrompt).toBe(false);
+    expect(turnsOf(session).activeClaim).toBeUndefined();
+    expect(turnsOf(session).busy()).toBe(false);
   });
 
   it("places concurrent v2 queue requests in FIFO before notification awaits", async () => {
     const session = {
       sessionId: "s1",
       cwd: "/repo",
-      activePrompt: true,
       promptQueue: []
     } as unknown as SessionState;
+    // A turn is already running, so both requests must queue rather than start.
+    turnsOf(session).claimIdle("foreground");
     const deps = {
       requireSession: () => session
     } as unknown as PromptV2Deps;
@@ -245,9 +244,7 @@ describe("queue and steer-by-cancel", () => {
     const session = {
       sessionId: "s1",
       cwd: "/repo",
-      activePrompt: true,
       promptQueue: [],
-      steerClaims: 0,
       agy: {
         cancel: () => {
           cancelCalls++;
@@ -258,6 +255,8 @@ describe("queue and steer-by-cancel", () => {
     const deps = {
       requireSession: () => session
     } as unknown as PromptV2Deps;
+    const turns = turnsOf(session);
+    const activeClaim = turns.claimIdle("foreground");
 
     const response = handlePromptV2({
       sessionId: "s1",
@@ -265,15 +264,16 @@ describe("queue and steer-by-cancel", () => {
       _meta: { "agy-acp/turnIntent": "steer" }
     } as any, { notify: async () => {} } as any, deps);
 
+    // Accepted while the backend cancellation is still pending.
     await expect(response).resolves.toEqual({});
-    expect(session.steerClaims).toBe(1);
+    expect(turns.busy()).toBe(true);
     await waitFor(() => cancelCalls === 1);
 
     session.closed = true;
-    wakePromptIdleWaiters(session);
+    turns.close();
+    turns.release(activeClaim);
     releaseCancel();
-    await waitFor(() => session.steerClaims === 0);
-    expect(session.promptIdleNotify).toBeUndefined();
+    await waitFor(() => !turns.busy());
   });
 
   it("cancels a v2 turn while prompt content is still being prepared", async () => {
@@ -281,7 +281,6 @@ describe("queue and steer-by-cancel", () => {
     const session = {
       sessionId: "s1",
       cwd: "/repo",
-      activePrompt: false,
       promptQueue: [],
       agy: {
         prompt: async () => {
@@ -300,13 +299,13 @@ describe("queue and steer-by-cancel", () => {
       prompt: [{ type: "text", text: "prepared asynchronously" }]
     } as any, { notify: async () => {} } as any, deps);
 
-    expect(session.promptAbort).toBeDefined();
-    session.promptAbort!.abort();
+    expect(turnsOf(session).activeClaim).toBeDefined();
+    turnsOf(session).activeClaim!.abort();
 
     await expect(response).resolves.toEqual({});
+    await waitFor(() => !turnsOf(session).busy());
     expect(promptCalls).toBe(0);
-    expect(session.promptAbort).toBeUndefined();
-    expect(session.activePrompt).toBe(false);
+    expect(turnsOf(session).activeClaim).toBeUndefined();
   });
 
   it("does not install a new idle waiter when a competing steer resumes after close", async () => {
@@ -314,9 +313,7 @@ describe("queue and steer-by-cancel", () => {
       sessionId: "s1",
       cwd: "/repo",
       additionalDirectories: [],
-      activePrompt: true,
       promptQueue: [],
-      steerClaims: 0,
       v2UserMessageIdsByStep: {},
       catalog: { models: [], byBase: new Map() },
       selectedBaseModel: "m",
@@ -342,30 +339,30 @@ describe("queue and steer-by-cancel", () => {
       _meta: { "agy-acp/turnIntent": "steer" }
     } as any, client, undefined, deps);
 
+    const turns = turnsOf(session);
+    const activeClaim = turns.claimIdle("foreground");
+
     const first = steer("first");
-    await waitFor(() => session.promptIdleNotify !== undefined);
     const second = steer("second");
-    await waitFor(() => session.steerClaims === 2);
+    await waitFor(() => activeClaim.aborted);
 
     session.closed = true;
-    wakePromptIdleWaiters(session);
+    turns.close();
+    turns.release(activeClaim);
 
     await expect(Promise.all([first, second])).resolves.toEqual([
       { stopReason: "cancelled" },
       { stopReason: "cancelled" }
     ]);
-    expect(session.promptIdleNotify).toBeUndefined();
-    expect(session.steerClaims).toBe(0);
+    expect(turns.busy()).toBe(false);
   });
 
   it("does not let stalled queued v2 notifications block session teardown", async () => {
-    const activeController = new AbortController();
     const queuedController = new AbortController();
     const notify = vi.fn(() => new Promise<void>(() => {}));
     const close = vi.fn(async () => {});
     const session = {
       sessionId: "s1",
-      activePrompt: true,
       promptQueue: [{
         id: "q1",
         version: "v2",
@@ -373,14 +370,14 @@ describe("queue and steer-by-cancel", () => {
         client: { notify },
         controller: queuedController
       }],
-      promptAbort: activeController,
       agy: { close }
     } as unknown as SessionState;
+    const activeClaim = turnsOf(session).claimIdle("foreground");
     const sessions = new Map([["s1", session]]);
 
     await handleCloseSession({ sessionId: "s1" }, sessions);
 
-    expect(activeController.signal.aborted).toBe(true);
+    expect(activeClaim.aborted).toBe(true);
     expect(queuedController.signal.aborted).toBe(true);
     expect(notify).toHaveBeenCalledOnce();
     expect(close).toHaveBeenCalledOnce();
@@ -895,14 +892,11 @@ describe("queue and steer-by-cancel", () => {
 
   it("stops an aborted v1 steer before launching the replacement", async () => {
     let promptCalls = 0;
-    let wakeIdle: (() => void) | undefined;
     const session = {
       sessionId: "s1",
       cwd: "/repo",
       additionalDirectories: [],
-      activePrompt: true,
       promptQueue: [],
-      steerClaims: 0,
       v2UserMessageIdsByStep: {},
       catalog: { models: [], byBase: new Map() },
       selectedBaseModel: "m",
@@ -910,7 +904,7 @@ describe("queue and steer-by-cancel", () => {
       agy: {
         config: { mode: "default" },
         cancel: async () => {
-          // Keep activePrompt true until the steer is waiting on idle.
+          // Keep the turn owned until the steer is waiting on idle.
         },
         prompt: async () => {
           promptCalls++;
@@ -928,6 +922,8 @@ describe("queue and steer-by-cancel", () => {
       clientFileSystemV1: () => undefined
     };
 
+    const turns = turnsOf(session);
+    const activeClaim = turns.claimIdle("foreground");
     const controller = new AbortController();
     const steerPromise = handlePromptV1(
       {
@@ -940,19 +936,150 @@ describe("queue and steer-by-cancel", () => {
       deps
     );
 
-    // Wait until the steer has registered its idle waiter.
-    await waitFor(() => session.promptIdleNotify !== undefined);
-    wakeIdle = session.promptIdleNotify;
+    // Wait until the steer has displaced the active turn and is awaiting idle.
+    await waitFor(() => activeClaim.aborted);
 
     // Abort while still waiting for the prior turn to settle.
     controller.abort();
-    session.activePrompt = false;
-    wakeIdle?.();
+    turns.release(activeClaim);
 
     const result = await steerPromise;
     expect(result.stopReason).toBe("cancelled");
     expect(promptCalls).toBe(0);
-    expect(session.steerClaims ?? 0).toBe(0);
+    expect(turns.busy()).toBe(false);
+  });
+
+  it("cancels a reserved v2 steer that is still waiting for the active turn", async () => {
+    // PR #84 review: an accepted steer holds a reservation while it waits for
+    // the previous turn to stop. A stop arriving in that window was dropped,
+    // and the replacement launched anyway.
+    let promptCalls = 0;
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      promptQueue: [],
+      v2UserMessageIdsByStep: {},
+      agy: {
+        config: { mode: "default" },
+        cancel: async () => {},
+        prompt: async () => {
+          promptCalls++;
+          return { stopReason: "end_turn" };
+        },
+        lastPromptUserStepIdxs: []
+      }
+    } as unknown as SessionState;
+    const turns = turnsOf(session);
+    const activeClaim = turns.claimIdle("foreground");
+    const deps = {
+      requireSession: () => session,
+      persistSession: async () => {},
+      applyConfigOption: async () => {},
+      notifyConfigOptionUpdateV2: async () => {}
+    } as unknown as PromptV2Deps;
+
+    await expect(handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "replacement" }],
+      _meta: { "agy-acp/turnIntent": "steer" }
+    } as any, { notify: async () => {} } as any, deps)).resolves.toEqual({});
+
+    await waitFor(() => activeClaim.aborted);
+    await handleCancel("s1", new Map([["s1", session]]));
+    turns.release(activeClaim);
+
+    await waitFor(() => !turns.busy());
+    expect(promptCalls).toBe(0);
+  });
+
+  it("reports a failed v2 steer setup as a terminal idle update", async () => {
+    // PR #84 review: the RPC has already returned {}, so a setup failure that
+    // is only logged leaves the client stuck in `running` forever.
+    const updates: any[] = [];
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      promptQueue: [],
+      v2UserMessageIdsByStep: {},
+      agy: {
+        config: { mode: "default" },
+        cancel: async () => {
+          throw new Error("backend kill failed");
+        },
+        prompt: async () => ({ stopReason: "end_turn" }),
+        lastPromptUserStepIdxs: []
+      }
+    } as unknown as SessionState;
+    const turns = turnsOf(session);
+    const activeClaim = turns.claimIdle("foreground");
+    const deps = {
+      requireSession: () => session,
+      persistSession: async () => {},
+      applyConfigOption: async () => {},
+      notifyConfigOptionUpdateV2: async () => {}
+    } as unknown as PromptV2Deps;
+    const client = { notify: async (_m: string, p: any) => { updates.push(p.update); } } as any;
+
+    await expect(handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "replacement" }],
+      _meta: { "agy-acp/turnIntent": "steer" }
+    } as any, client, deps)).resolves.toEqual({});
+
+    await waitFor(() => updates.length > 0);
+    expect(updates.at(-1)).toMatchObject({ sessionUpdate: "state_update", state: "idle" });
+    // The failed steer released its reservation; only the simulated turn holds
+    // the slot, so the session frees up once that finishes.
+    turns.release(activeClaim);
+    expect(turns.busy()).toBe(false);
+  });
+
+  it("releases the turn slot when a terminal update stalls and the session closes", async () => {
+    // A wedged client transport must not hold the turn slot forever: closing
+    // the session aborts the claim, which unblocks the terminal notification.
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      promptQueue: [],
+      v2UserMessageIdsByStep: {},
+      agy: {
+        config: { mode: "default" },
+        cancel: async () => {},
+        close: async () => {},
+        prompt: async () => ({ stopReason: "end_turn" }),
+        lastPromptUserStepIdxs: []
+      }
+    } as unknown as SessionState;
+    const turns = turnsOf(session);
+    const deps = {
+      requireSession: () => session,
+      persistSession: async () => {},
+      applyConfigOption: async () => {},
+      notifyConfigOptionUpdateV2: async () => {}
+    } as unknown as PromptV2Deps;
+    // Every notification after the first two (user_message, running) stalls.
+    let sent = 0;
+    const client = {
+      notify: async () => {
+        sent++;
+        if (sent > 2) await new Promise<void>(() => {});
+      }
+    } as any;
+
+    await expect(handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "hello" }]
+    } as any, client, deps)).resolves.toEqual({});
+
+    await waitFor(() => sent >= 3);
+    expect(turns.busy()).toBe(true);
+
+    await handleCloseSession({ sessionId: "s1" }, new Map([["s1", session]]) as any);
+
+    await waitFor(() => !turns.busy());
   });
 
   it("rejects a non-intent prompt while a steer replacement is in progress", async () => {

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -3,12 +3,20 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Readable, Writable } from "node:stream";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import * as acp from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import { client as acpClient, methods, PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
 import { createAcpApp, createAcpV2App } from "../src/agent.js";
-import { handlePromptV1, type PromptV1Deps } from "../src/acp/session/prompt.js";
+import { cancelQueuedPrompts } from "../src/acp/session/cancel.js";
+import { handleCloseSession } from "../src/acp/session/close.js";
+import {
+  handlePromptV1,
+  handlePromptV2,
+  wakePromptIdleWaiters,
+  type PromptV1Deps,
+  type PromptV2Deps
+} from "../src/acp/session/prompt.js";
 import type { SessionState } from "../src/acp/session/types.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload } from "./fixtures/step-encoder.js";
@@ -105,6 +113,163 @@ class ControlledFakeProcess extends EventEmitter {
 }
 
 describe("queue and steer-by-cancel", () => {
+  it("claims an idle v1 turn before asynchronous slash setup", async () => {
+    let releaseConfigNotification!: () => void;
+    const configNotification = new Promise<void>((resolve) => {
+      releaseConfigNotification = resolve;
+    });
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      activePrompt: false,
+      promptQueue: [],
+      v2UserMessageIdsByStep: {},
+      catalog: { models: [], byBase: new Map() },
+      selectedBaseModel: "m",
+      selectedReasoningEffort: "",
+      agy: { config: { mode: "default" } }
+    } as unknown as SessionState;
+    const deps: PromptV1Deps = {
+      requireSession: () => session,
+      applyConfigOption: async () => {},
+      persistSession: async () => {},
+      notifyCurrentModeUpdate: async () => {},
+      notifyConfigOptionUpdateV1: async () => configNotification,
+      clientFileSystemV1: () => undefined
+    };
+    const client = { notify: async () => {} } as any;
+
+    const first = handlePromptV1({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "/plan" }]
+    } as any, client, undefined, deps);
+    await waitFor(() => session.activePrompt);
+
+    await expect(handlePromptV1({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "overlap" }]
+    } as any, client, undefined, deps)).rejects.toThrow("already has an active prompt");
+
+    releaseConfigNotification();
+    await expect(first).resolves.toEqual({ stopReason: "end_turn" });
+    expect(session.activePrompt).toBe(false);
+  });
+
+  it("places concurrent v2 queue requests in FIFO before notification awaits", async () => {
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      activePrompt: true,
+      promptQueue: []
+    } as unknown as SessionState;
+    const deps = {
+      requireSession: () => session
+    } as unknown as PromptV2Deps;
+    const firstNotify = vi.fn(() => new Promise<void>(() => {}));
+    const secondNotify = vi.fn(async () => {});
+    const firstClient = { notify: firstNotify } as any;
+    const secondClient = { notify: secondNotify } as any;
+
+    const first = handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "first" }],
+      _meta: { "agy-acp/turnIntent": "queue" }
+    } as any, firstClient, deps);
+    const second = handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "second" }],
+      _meta: { "agy-acp/turnIntent": "queue" }
+    } as any, secondClient, deps);
+
+    expect(session.promptQueue.map((item) => (item.params.prompt[0] as any).text))
+      .toEqual(["first", "second"]);
+    await expect(Promise.all([first, second])).resolves.toEqual([{}, {}]);
+    // Acceptance responses precede queued user_message publication.
+    expect(firstNotify).not.toHaveBeenCalled();
+    expect(secondNotify).not.toHaveBeenCalled();
+
+    cancelQueuedPrompts(session);
+  });
+
+  it("does not install a new idle waiter when a competing steer resumes after close", async () => {
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      activePrompt: true,
+      promptQueue: [],
+      steerClaims: 0,
+      v2UserMessageIdsByStep: {},
+      catalog: { models: [], byBase: new Map() },
+      selectedBaseModel: "m",
+      selectedReasoningEffort: "",
+      agy: {
+        config: { mode: "default" },
+        cancel: async () => {},
+        prompt: async () => ({ stopReason: "end_turn" })
+      }
+    } as unknown as SessionState;
+    const deps = {
+      requireSession: () => session,
+      applyConfigOption: async () => {},
+      persistSession: async () => {},
+      notifyCurrentModeUpdate: async () => {},
+      notifyConfigOptionUpdateV1: async () => {},
+      clientFileSystemV1: () => undefined
+    } satisfies PromptV1Deps;
+    const client = { notify: async () => {} } as any;
+    const steer = (text: string) => handlePromptV1({
+      sessionId: "s1",
+      prompt: [{ type: "text", text }],
+      _meta: { "agy-acp/turnIntent": "steer" }
+    } as any, client, undefined, deps);
+
+    const first = steer("first");
+    await waitFor(() => session.promptIdleNotify !== undefined);
+    const second = steer("second");
+    await waitFor(() => session.steerClaims === 2);
+
+    session.closed = true;
+    wakePromptIdleWaiters(session);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { stopReason: "cancelled" },
+      { stopReason: "cancelled" }
+    ]);
+    expect(session.promptIdleNotify).toBeUndefined();
+    expect(session.steerClaims).toBe(0);
+  });
+
+  it("does not let stalled queued v2 notifications block session teardown", async () => {
+    const activeController = new AbortController();
+    const queuedController = new AbortController();
+    const notify = vi.fn(() => new Promise<void>(() => {}));
+    const close = vi.fn(async () => {});
+    const session = {
+      sessionId: "s1",
+      activePrompt: true,
+      promptQueue: [{
+        id: "q1",
+        version: "v2",
+        params: { sessionId: "s1" },
+        client: { notify },
+        controller: queuedController
+      }],
+      promptAbort: activeController,
+      agy: { close }
+    } as unknown as SessionState;
+    const sessions = new Map([["s1", session]]);
+
+    await handleCloseSession({ sessionId: "s1" }, sessions);
+
+    expect(activeController.signal.aborted).toBe(true);
+    expect(queuedController.signal.aborted).toBe(true);
+    expect(notify).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+    expect(sessions.has("s1")).toBe(false);
+  });
+
   it("rejects overlapping prompts when no turnIntent meta is provided", async () => {
     await withConversationsDir(async (dir) => {
       let activeProc: ControlledFakeProcess | null = null;

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -609,6 +609,71 @@ describe("queue and steer-by-cancel", () => {
     });
   });
 
+  it("rejects a non-intent prompt while a steer replacement is in progress", async () => {
+    await withConversationsDir(async (dir) => {
+      const processes: ControlledFakeProcess[] = [];
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        const db = createConversationDb(dir, `conv-steer-busy-${processes.length}`);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt" }) });
+        insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ok" }) });
+        db.close();
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      const client = acpClient({ name: "test-client" }).onNotification(
+        methods.client.session.update,
+        () => {}
+      );
+      const connection = client.connect(
+        createAcpApp({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {}
+        });
+        const session = await connection.agent.request(methods.agent.session.new, {
+          cwd: "/repo",
+          mcpServers: []
+        });
+
+        const p1 = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+        await waitFor(() => processes.length === 1);
+
+        const steer = connection.agent.request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "steer turn" }],
+          _meta: { "agy-acp/turnIntent": "steer" }
+        } as any);
+
+        await waitFor(() => processes.length === 2);
+
+        // Steer owns the session (active or claim); concurrent no-intent must not start.
+        await expect(
+          connection.agent.request(methods.agent.session.prompt, {
+            sessionId: session.sessionId,
+            prompt: [{ type: "text", text: "sneak in" }]
+          })
+        ).rejects.toThrow();
+
+        processes[1].finish();
+        await p1;
+        await steer;
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
   it("drains the queue after a slash-command steer", async () => {
     await withConversationsDir(async (dir) => {
       const processes: ControlledFakeProcess[] = [];
@@ -757,6 +822,96 @@ describe("queue and steer-by-cancel", () => {
         const rq = (await queued) as acp.PromptResponse;
         expect(rq.stopReason).toBe("end_turn");
         expect(executedPrompts).toEqual(["prompt 1", "queued after failed steer"]);
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
+  it("does not leave a v2 queue item stuck when the session closes during enqueue", async () => {
+    await withConversationsDir(async (dir) => {
+      const processes: ControlledFakeProcess[] = [];
+      const updates: Array<Record<string, unknown>> = [];
+      let blockUserMessage: (() => void) | undefined;
+      const userMessageGate = new Promise<void>((resolve) => {
+        blockUserMessage = resolve;
+      });
+
+      const spawnProcess: SpawnFactory = (_command: string, args: string[]) => {
+        if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+        const db = createConversationDb(dir, `conv-v2-enqueue-close-${processes.length}`);
+        insertStep(db, { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt" }) });
+        insertStep(db, { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ok" }) });
+        db.close();
+        const proc = new ControlledFakeProcess();
+        processes.push(proc);
+        return proc as any;
+      };
+
+      let userMessageCount = 0;
+      const client = acpV2.client({ name: "test-client" }).onNotification(
+        acpV2.methods.client.session.update,
+        async (ctx) => {
+          const update = ctx.params.update as Record<string, unknown>;
+          updates.push(update);
+          if (update.sessionUpdate === "user_message") {
+            userMessageCount++;
+            // Hold the second user_message (queued) so close can interleave.
+            if (userMessageCount === 2 && blockUserMessage) {
+              await userMessageGate;
+            }
+          }
+        }
+      );
+      const connection = client.connect(
+        createAcpV2App({
+          env: printModeEnv({ AGY_ACP_CONVERSATIONS_DIR: dir, AGY_ACP_STATE_DIR: dir }),
+          spawnProcess
+        })
+      );
+      try {
+        await connection.agent.request(acpV2.methods.agent.initialize, {
+          protocolVersion: 2,
+          info: { name: "test-client", version: "0.0.0" },
+          capabilities: {}
+        });
+        const session = await connection.agent.request(acpV2.methods.agent.session.new, {
+          cwd: "/repo"
+        });
+
+        const r1 = await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "prompt 1" }]
+        });
+        expect(r1).toEqual({});
+        await waitFor(() => processes.length === 1);
+
+        const queued = connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "queued v2 during close" }],
+          _meta: { "agy-acp/turnIntent": "queue" }
+        } as any);
+
+        await waitFor(() => userMessageCount >= 2);
+
+        await connection.agent.request(acpV2.methods.agent.session.close, {
+          sessionId: session.sessionId
+        } as any);
+
+        blockUserMessage?.();
+        await queued;
+
+        // Must emit a terminal cancelled update rather than silently dropping the queue item.
+        await waitFor(() =>
+          updates.some(
+            (u) =>
+              u.sessionUpdate === "state_update" &&
+              u.state === "idle" &&
+              u.stopReason === "cancelled"
+          )
+        );
+        // Queued turn must not spawn agy after close.
+        expect(processes.length).toBe(1);
       } finally {
         connection.close();
       }

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -13,6 +13,7 @@ import { handleCloseSession } from "../src/acp/session/close.js";
 import {
   handlePromptV1,
   handlePromptV2,
+  notifyIdleAndDrainQueue,
   type PromptV1Deps,
   type PromptV2Deps
 } from "../src/acp/session/prompt.js";
@@ -227,7 +228,10 @@ describe("queue and steer-by-cancel", () => {
 
     expect(session.promptQueue.map((item) => (item.params.prompt[0] as any).text))
       .toEqual(["first", "second"]);
-    await expect(Promise.all([first, second])).resolves.toEqual([{}, {}]);
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { _meta: { "agy-acp/queuedPromptId": expect.any(String) } },
+      { _meta: { "agy-acp/queuedPromptId": expect.any(String) } }
+    ]);
     // Acceptance responses precede queued user_message publication.
     expect(firstNotify).not.toHaveBeenCalled();
     expect(secondNotify).not.toHaveBeenCalled();
@@ -535,7 +539,7 @@ describe("queue and steer-by-cancel", () => {
     });
   });
 
-  it("queues v2 follow-up prompts, returning {} immediately and ordering updates", async () => {
+  it("queues v2 follow-up prompts, accepting immediately and ordering updates", async () => {
     await withConversationsDir(async (dir) => {
       const updates: Array<Record<string, unknown>> = [];
       const client = acpV2.client({ name: "test-client" }).onNotification(
@@ -578,7 +582,7 @@ describe("queue and steer-by-cancel", () => {
           prompt: [{ type: "text", text: "prompt 2" }],
           _meta: { "agy-acp/turnIntent": "queue" }
         } as any);
-        expect(r2).toEqual({});
+        expect(r2).toEqual({ _meta: { "agy-acp/queuedPromptId": expect.any(String) } });
 
         await waitFor(() => {
           const idleCount = updates.filter((u) => u.sessionUpdate === "state_update" && u.state === "idle").length;
@@ -1238,14 +1242,18 @@ describe("queue and steer-by-cancel", () => {
       sessionId: "s1",
       prompt: [{ type: "text", text: "first" }],
       _meta: { "agy-acp/turnIntent": "queue" }
-    } as any, client, deps)).resolves.toEqual({});
+    } as any, client, deps)).resolves.toEqual({
+      _meta: { "agy-acp/queuedPromptId": expect.any(String) }
+    });
     await waitFor(() => notifyCalls === 1); // item 1's user_message is wedged
 
     await expect(handlePromptV2({
       sessionId: "s1",
       prompt: [{ type: "text", text: "second" }],
       _meta: { "agy-acp/turnIntent": "queue" }
-    } as any, client, deps)).resolves.toEqual({});
+    } as any, client, deps)).resolves.toEqual({
+      _meta: { "agy-acp/queuedPromptId": expect.any(String) }
+    });
 
     // Cancel the wedged item through the real session/cancel path.
     const queuedId = session.promptQueue[0].id;
@@ -1255,6 +1263,124 @@ describe("queue and steer-by-cancel", () => {
     await waitFor(() => updates.some((u) => u.sessionUpdate === "user_message"));
 
     turns.release(activeClaim);
+  });
+
+  it("returns a cancellation id for queued v2 prompts", async () => {
+    // PR #84 review: targeted cancellation of a queued v2 prompt requires
+    // agy-acp/queuedPromptId, but it was generated internally and never
+    // returned, so clients could not cancel individual queued items.
+    const updates: any[] = [];
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      promptQueue: [],
+      v2UserMessageIdsByStep: {},
+      agy: {
+        config: { mode: "default" },
+        cancel: async () => {},
+        prompt: async () => ({ stopReason: "end_turn" }),
+        lastPromptUserStepIdxs: []
+      }
+    } as unknown as SessionState;
+    const turns = turnsOf(session);
+    const activeClaim = turns.claimIdle("foreground"); // hold the slot so the prompt queues
+    const deps = {
+      requireSession: () => session,
+      persistSession: async () => {},
+      applyConfigOption: async () => {},
+      notifyConfigOptionUpdateV2: async () => {}
+    } as unknown as PromptV2Deps;
+    const client = { notify: async (_m: string, p: any) => { updates.push(p.update); } } as any;
+
+    const response = await handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "follow up" }],
+      _meta: { "agy-acp/turnIntent": "queue" }
+    } as any, client, deps);
+
+    const queuedId = (response as any)._meta?.["agy-acp/queuedPromptId"];
+    expect(typeof queuedId).toBe("string");
+    expect(session.promptQueue.map((item) => item.id)).toContain(queuedId);
+
+    // The id cancels exactly that queued item through session/cancel.
+    await handleCancel("s1", new Map([["s1", session]]), { "agy-acp/queuedPromptId": queuedId });
+    expect(session.promptQueue).toHaveLength(0);
+    expect(
+      updates.some((u) => u.sessionUpdate === "state_update" && u.stopReason === "cancelled")
+    ).toBe(true);
+
+    turns.release(activeClaim);
+  });
+
+  it("unblocks later v2 queue preparation when a claimed queued turn is cancelled", async () => {
+    // PR #84 review: once a queued v2 item is claimed, session/cancel aborts
+    // its TurnClaim but not its preparation controller; a `ready` promise
+    // still wedged on user_message delivery stayed pinned in
+    // promptQueuePreparation and jammed every later queued prompt.
+    const updates: any[] = [];
+    let notifyCalls = 0;
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      promptQueue: [],
+      v2UserMessageIdsByStep: {},
+      agy: {
+        config: { mode: "default" },
+        cancel: async () => {},
+        prompt: async () => ({ stopReason: "end_turn" }),
+        lastPromptUserStepIdxs: []
+      }
+    } as unknown as SessionState;
+    const turns = turnsOf(session);
+    const deps = {
+      requireSession: () => session,
+      persistSession: async () => {},
+      applyConfigOption: async () => {},
+      notifyConfigOptionUpdateV2: async () => {}
+    } as unknown as PromptV2Deps;
+    const client = {
+      notify: async (_method: string, p: any) => {
+        notifyCalls++;
+        if (notifyCalls === 1) await new Promise<void>(() => {}); // wedge item 1's user_message
+        updates.push(p.update);
+      }
+    } as any;
+
+    const activeClaim = turns.claimIdle("foreground");
+    await expect(handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "first" }],
+      _meta: { "agy-acp/turnIntent": "queue" }
+    } as any, client, deps)).resolves.toEqual({
+      _meta: { "agy-acp/queuedPromptId": expect.any(String) }
+    });
+    await waitFor(() => notifyCalls === 1); // item 1's user_message is wedged
+
+    // The item leaves the FIFO and its turn claims the slot, still waiting on
+    // the wedged preparation.
+    const queuedItem = session.promptQueue[0];
+    turns.release(activeClaim);
+    notifyIdleAndDrainQueue(session);
+    await waitFor(() => turns.busy() && session.promptQueue.length === 0);
+
+    // A plain session/cancel aborts the claimed turn...
+    await handleCancel("s1", new Map([["s1", session]]));
+    await waitFor(() => !turns.busy());
+    // ...and must also abort the item's preparation controller.
+    expect((queuedItem as Extract<SessionState["promptQueue"][number], { version: "v2" }>).controller.signal.aborted).toBe(true);
+
+    // A later queued prompt prepares instead of chaining behind the wedge.
+    const nextActive = turns.claimIdle("foreground");
+    await expect(handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "second" }],
+      _meta: { "agy-acp/turnIntent": "queue" }
+    } as any, client, deps)).resolves.toBeDefined();
+    await waitFor(() => updates.some((u) => u.sessionUpdate === "user_message"));
+
+    turns.release(nextActive);
   });
 
   it("rejects a non-intent prompt while a steer replacement is in progress", async () => {
@@ -1618,7 +1744,7 @@ describe("queue and steer-by-cancel", () => {
           prompt: [{ type: "text", text: "queued v2" }],
           _meta: { "agy-acp/turnIntent": "queue" }
         } as any);
-        expect(r2).toEqual({});
+        expect(r2).toEqual({ _meta: { "agy-acp/queuedPromptId": expect.any(String) } });
 
         // Close while p1 is active and p2 is queued — queued turn must not spawn agy.
         await connection.agent.request(acpV2.methods.agent.session.close, {

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -1082,6 +1082,181 @@ describe("queue and steer-by-cancel", () => {
     await waitFor(() => !turns.busy());
   });
 
+  it("settles a v1 turn whose client notification never resolves when cancelled", async () => {
+    // PR #84 review: agy's print-mode poll loop awaits each onUpdate callback,
+    // so a wedged v1 session/update pinned the turn — killing the backend could
+    // not settle it, and the turn slot was never released.
+    let notifyCalls = 0;
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      promptQueue: [],
+      v2UserMessageIdsByStep: {},
+      catalog: { models: [], byBase: new Map() },
+      selectedBaseModel: "m",
+      selectedReasoningEffort: "",
+      agy: {
+        config: { mode: "default" },
+        cancel: async () => {},
+        prompt: async (_prompt: string, onUpdate: (update: unknown) => Promise<void>) => {
+          // Mirrors runPromptCommand: the poll loop awaits each callback, so a
+          // wedged delivery pins the turn until the callback settles.
+          await onUpdate({
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "chunk" }
+          });
+          return { stopReason: "end_turn" };
+        }
+      }
+    } as unknown as SessionState;
+    const deps: PromptV1Deps = {
+      requireSession: () => session,
+      applyConfigOption: async () => {},
+      persistSession: async () => {},
+      notifyCurrentModeUpdate: async () => {},
+      notifyConfigOptionUpdateV1: async () => {},
+      clientFileSystemV1: () => undefined
+    };
+    const client = {
+      notify: async () => {
+        notifyCalls++;
+        await new Promise<void>(() => {}); // wedged transport
+      }
+    } as any;
+
+    const promptPromise = handlePromptV1({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "hello" }]
+    } as any, client, undefined, deps);
+
+    await waitFor(() => notifyCalls === 1);
+    await handleCancel("s1", new Map([["s1", session]]));
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+    expect(turnsOf(session).busy()).toBe(false);
+  });
+
+  it("steers a v1 turn whose client notification is wedged", async () => {
+    // Same wedge as above, but displaced by a steer: the replacement must not
+    // wait forever behind a turn that can never settle.
+    let notifyCalls = 0;
+    let promptCalls = 0;
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      promptQueue: [],
+      v2UserMessageIdsByStep: {},
+      catalog: { models: [], byBase: new Map() },
+      selectedBaseModel: "m",
+      selectedReasoningEffort: "",
+      agy: {
+        config: { mode: "default" },
+        cancel: async () => {},
+        prompt: async (_prompt: string, onUpdate: (update: unknown) => Promise<void>) => {
+          promptCalls++;
+          if (promptCalls === 1) {
+            await onUpdate({
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "chunk" }
+            });
+          }
+          return { stopReason: "end_turn" };
+        }
+      }
+    } as unknown as SessionState;
+    const deps: PromptV1Deps = {
+      requireSession: () => session,
+      applyConfigOption: async () => {},
+      persistSession: async () => {},
+      notifyCurrentModeUpdate: async () => {},
+      notifyConfigOptionUpdateV1: async () => {},
+      clientFileSystemV1: () => undefined
+    };
+    const client = {
+      notify: async () => {
+        notifyCalls++;
+        await new Promise<void>(() => {}); // wedged transport
+      }
+    } as any;
+
+    const first = handlePromptV1({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "first" }]
+    } as any, client, undefined, deps);
+    await waitFor(() => notifyCalls === 1);
+
+    const steer = handlePromptV1({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "replacement" }],
+      _meta: { "agy-acp/turnIntent": "steer" }
+    } as any, client, undefined, deps);
+
+    await expect(first).resolves.toEqual({ stopReason: "cancelled" });
+    await expect(steer).resolves.toEqual({ stopReason: "end_turn" });
+    expect(promptCalls).toBe(2);
+    expect(turnsOf(session).busy()).toBe(false);
+  });
+
+  it("does not jam the v2 queue behind a wedged user_message notification", async () => {
+    // A queued v2 prompt publishes its user_message during enqueue, serialized
+    // in FIFO order. If that delivery wedges, cancelling the item must unwedge
+    // the chain so later queued prompts still prepare.
+    const updates: any[] = [];
+    let notifyCalls = 0;
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      promptQueue: [],
+      v2UserMessageIdsByStep: {},
+      agy: {
+        config: { mode: "default" },
+        cancel: async () => {},
+        prompt: async () => ({ stopReason: "end_turn" }),
+        lastPromptUserStepIdxs: []
+      }
+    } as unknown as SessionState;
+    const turns = turnsOf(session);
+    const activeClaim = turns.claimIdle("foreground"); // hold the slot so prompts queue
+    const deps = {
+      requireSession: () => session,
+      persistSession: async () => {},
+      applyConfigOption: async () => {},
+      notifyConfigOptionUpdateV2: async () => {}
+    } as unknown as PromptV2Deps;
+    const client = {
+      notify: async (_method: string, p: any) => {
+        notifyCalls++;
+        if (notifyCalls === 1) await new Promise<void>(() => {}); // wedged transport
+        updates.push(p.update);
+      }
+    } as any;
+
+    await expect(handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "first" }],
+      _meta: { "agy-acp/turnIntent": "queue" }
+    } as any, client, deps)).resolves.toEqual({});
+    await waitFor(() => notifyCalls === 1); // item 1's user_message is wedged
+
+    await expect(handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "second" }],
+      _meta: { "agy-acp/turnIntent": "queue" }
+    } as any, client, deps)).resolves.toEqual({});
+
+    // Cancel the wedged item through the real session/cancel path.
+    const queuedId = session.promptQueue[0].id;
+    await handleCancel("s1", new Map([["s1", session]]), { "agy-acp/queuedPromptId": queuedId });
+
+    // Item 2's preparation must proceed despite item 1's wedged delivery.
+    await waitFor(() => updates.some((u) => u.sessionUpdate === "user_message"));
+
+    turns.release(activeClaim);
+  });
+
   it("rejects a non-intent prompt while a steer replacement is in progress", async () => {
     await withConversationsDir(async (dir) => {
       const processes: ControlledFakeProcess[] = [];

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -8,6 +8,8 @@ import * as acp from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import { client as acpClient, methods, PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
 import { createAcpApp, createAcpV2App } from "../src/agent.js";
+import { handlePromptV1, type PromptV1Deps } from "../src/acp/session/prompt.js";
+import type { SessionState } from "../src/acp/session/types.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload } from "./fixtures/step-encoder.js";
 import type { SpawnFactory } from "../src/agy/cli.js";
@@ -607,6 +609,68 @@ describe("queue and steer-by-cancel", () => {
         connection.close();
       }
     });
+  });
+
+  it("stops an aborted v1 steer before launching the replacement", async () => {
+    let promptCalls = 0;
+    let wakeIdle: (() => void) | undefined;
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      additionalDirectories: [],
+      activePrompt: true,
+      promptQueue: [],
+      steerClaims: 0,
+      v2UserMessageIdsByStep: {},
+      catalog: { models: [], byBase: new Map() },
+      selectedBaseModel: "m",
+      selectedReasoningEffort: "",
+      agy: {
+        config: { mode: "default" },
+        cancel: async () => {
+          // Keep activePrompt true until the steer is waiting on idle.
+        },
+        prompt: async () => {
+          promptCalls++;
+          return { stopReason: "end_turn" };
+        }
+      }
+    } as unknown as SessionState;
+
+    const deps: PromptV1Deps = {
+      requireSession: () => session,
+      applyConfigOption: async () => {},
+      persistSession: async () => {},
+      notifyCurrentModeUpdate: async () => {},
+      notifyConfigOptionUpdateV1: async () => {},
+      clientFileSystemV1: () => undefined
+    };
+
+    const controller = new AbortController();
+    const steerPromise = handlePromptV1(
+      {
+        sessionId: "s1",
+        prompt: [{ type: "text", text: "replacement" }],
+        _meta: { "agy-acp/turnIntent": "steer" }
+      } as any,
+      { notify: async () => {} } as any,
+      controller.signal,
+      deps
+    );
+
+    // Wait until the steer has registered its idle waiter.
+    await waitFor(() => session.promptIdleNotify !== undefined);
+    wakeIdle = session.promptIdleNotify;
+
+    // Abort while still waiting for the prior turn to settle.
+    controller.abort();
+    session.activePrompt = false;
+    wakeIdle?.();
+
+    const result = await steerPromise;
+    expect(result.stopReason).toBe("cancelled");
+    expect(promptCalls).toBe(0);
+    expect(session.steerClaims ?? 0).toBe(0);
   });
 
   it("rejects a non-intent prompt while a steer replacement is in progress", async () => {

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -192,6 +192,46 @@ describe("queue and steer-by-cancel", () => {
     cancelQueuedPrompts(session);
   });
 
+  it("acknowledges a v2 steer before awaiting active-turn cancellation", async () => {
+    let releaseCancel!: () => void;
+    const cancelPending = new Promise<void>((resolve) => {
+      releaseCancel = resolve;
+    });
+    let cancelCalls = 0;
+    const session = {
+      sessionId: "s1",
+      cwd: "/repo",
+      activePrompt: true,
+      promptQueue: [],
+      steerClaims: 0,
+      agy: {
+        cancel: () => {
+          cancelCalls++;
+          return cancelPending;
+        }
+      }
+    } as unknown as SessionState;
+    const deps = {
+      requireSession: () => session
+    } as unknown as PromptV2Deps;
+
+    const response = handlePromptV2({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "replacement" }],
+      _meta: { "agy-acp/turnIntent": "steer" }
+    } as any, { notify: async () => {} } as any, deps);
+
+    await expect(response).resolves.toEqual({});
+    expect(session.steerClaims).toBe(1);
+    await waitFor(() => cancelCalls === 1);
+
+    session.closed = true;
+    wakePromptIdleWaiters(session);
+    releaseCancel();
+    await waitFor(() => session.steerClaims === 0);
+    expect(session.promptIdleNotify).toBeUndefined();
+  });
+
   it("does not install a new idle waiter when a competing steer resumes after close", async () => {
     const session = {
       sessionId: "s1",

--- a/tests/slash-commands.test.ts
+++ b/tests/slash-commands.test.ts
@@ -3,6 +3,7 @@ import {
   AVAILABLE_COMMANDS,
   availableCommandsUpdate,
   interpretSlashCommand,
+  isClientTextSlashPrompt,
   parseSlashCommand,
   resolveModelValue
 } from "../src/acp/slash-commands/index.js";
@@ -21,6 +22,35 @@ describe("parseSlashCommand", () => {
     expect(parseSlashCommand("hello")).toBeNull();
     expect(parseSlashCommand("/mode plan\nand more")).toBeNull();
     expect(parseSlashCommand("use /mode later")).toBeNull();
+  });
+});
+
+describe("isClientTextSlashPrompt", () => {
+  it("accepts a single non-empty text block", () => {
+    expect(isClientTextSlashPrompt([{ type: "text", text: "/plan" }])).toBe(true);
+    expect(isClientTextSlashPrompt([{ type: "text", text: "  /mode plan  " }])).toBe(true);
+  });
+
+  it("rejects resource, image, or multi-block prompts", () => {
+    expect(
+      isClientTextSlashPrompt([
+        {
+          type: "resource",
+          resource: { uri: "file:///notes.md", text: "/plan", mimeType: "text/markdown" }
+        }
+      ])
+    ).toBe(false);
+    expect(
+      isClientTextSlashPrompt([
+        { type: "text", text: "/plan" },
+        { type: "resource_link", uri: "file:///x.ts", name: "x.ts" }
+      ])
+    ).toBe(false);
+    expect(
+      isClientTextSlashPrompt([
+        { type: "image", mimeType: "image/png", data: "aa" }
+      ])
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Description

Adds explicit ACP extension semantics for queued follow-up prompts and steer-by-cancel during active turns. Queue requests run FIFO after idle, steer requests cancel and replace the active turn, and queued work is cancelled consistently during session cleanup. Adds v1/v2 lifecycle coverage and documents the extension.

## Related Issues

Fixes #50

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [x] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [ ] I have executed `npm run build` and it completed without errors
- [ ] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed

Validation note: this environment does not provide npm on PATH. Equivalent checks passed using the local Node binaries: TypeScript compilation and Vitest full suite (247 passed, 1 skipped).
