### PR TITLE
Fix background task clearing from id-less stepType 101 lifecycle rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ pre-1.0 caveat that minor versions may include breaking changes. Starting with
 `1.0.0-alpha.0`, package pre-releases track ACP v2 draft work; the wire protocol
 for draft v2 may still change before ACP v2 stabilizes.
 
+## [0.4.3] - Unreleased
+
+### Fixed
+
+- Prevent generic, id-less `stepType 101` turn-end markers from clearing active background tasks before terminal system completion messages arrive, making `StreamPoller` background task tracking 100% DB-driven via SQLite protobuf `task_details` state. (#86)
+
 ## [0.4.2] - 2026-08-04
 
 Queued follow-up prompts and steer-by-cancel during active turns, background-task-aware turn completion, stricter zero-prompt-injection content encoding, ID-based incremental `plan_update` ops and `plan_removed`, immediate command box display with live stdout streaming for `run_command`, and removal of environment-variable configuration in favor of CLI flags and programmatic options.

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -99,13 +99,10 @@ export class StreamPoller {
 
   /**
    * True while this user turn should stay open for background work.
-   * Prefer explicit task_details launch/completion tracking; fall back to the
-   * "preserving context / waiting for background" agent text plus a later
-   * system/lifecycle message. Never requires injecting a synthetic prompt.
+   * Driven strictly by SQLite protobuf task_details launch and completion state.
    */
   get hasActiveBackgroundTasks(): boolean {
-    if (this._launchedTaskIdxs.size > this._completedTaskIds.size) return true;
-    return this._hasBackgroundWaiting && !this.hasUnansweredSystemMessage;
+    return this._launchedTaskIdxs.size > this._completedTaskIds.size;
   }
 
   /** Newly observed status-9 tool calls from the most recent poll. */
@@ -151,26 +148,17 @@ export class StreamPoller {
       if (row.stepType === 14) {
         this.observedUserStepIdxs.add(row.idx);
         this._lastUserStepIdx = Math.max(this._lastUserStepIdx, row.idx);
-        this._hasBackgroundWaiting = false;
       }
       if (row.task?.taskId && !this._launchedTaskIdxs.has(row.task.taskId)) {
         this._launchedTaskIdxs.set(row.task.taskId, row.idx);
       }
       const text = row.stepPayload.agentText?.text ?? "";
-      // Only enter the background-wait path with corroborating task evidence.
-      // A bare prose mention of "preserving context" must not pin the turn open
-      // (and eventually time out) when no background task was launched.
-      if (
-        this._launchedTaskIdxs.size > 0 &&
-        text &&
-        isBackgroundWaitAgentText(text)
-      ) {
-        this._hasBackgroundWaiting = true;
-      }
-      // Defer completion tracking until the lifecycle row is terminal so a
+      // Defer completion tracking until a system message is terminal so a
       // still-streaming system-message envelope cannot close the wait early.
+      // Generic stepType 101 turn-end markers without a system message payload
+      // must NOT clear active tasks, as agy appends 101 at the end of every turn.
       if (
-        (row.stepType === 101 || isSystemMessage(text)) &&
+        isSystemMessage(text) &&
         isTerminalStepStatus(row.status)
       ) {
         this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
@@ -187,8 +175,8 @@ export class StreamPoller {
             matchedTask = true;
           }
         }
-        // Lifecycle/system wake without an embedded task id (common for stop_hook
-        // type 101): close every still-pending launch so the turn cannot hang
+        // Lifecycle/system wake without an embedded task id (common for system message
+        // wakes): close every still-pending launch so the turn cannot hang
         // forever waiting for a match that never arrives.
         if (!matchedTask) {
           for (const taskId of launchedBefore) {
@@ -274,17 +262,6 @@ export class StreamPoller {
     this.db?.close();
     this.db = null;
   }
-}
-
-/** agy's known lifecycle prose when it parks a turn on a background task. */
-const BACKGROUND_WAIT_SENTINEL =
-  "Preserving context while waiting for background command output...";
-
-function isBackgroundWaitAgentText(text: string): boolean {
-  const trimmed = text.trim();
-  if (trimmed === BACKGROUND_WAIT_SENTINEL) return true;
-  // Slight variants still seen with task_details present.
-  return /waiting for.*background|preserving context while waiting/i.test(trimmed);
 }
 
 /** status 3/6/7 — completed, cancelled/aborted, or failed. */

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -668,6 +668,35 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("writes only the verbatim user prompt back to a reused interactive PTY", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-reuse-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "reuse");
+      insertStep(db, { idx: 1, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done one" }) });
+      db.close();
+      // Fresh TUI owes a second idle marker before the first turn resolves.
+      setTimeout(() => pty.emitData("? for shortcuts"), 60);
+    });
+    const session = interactiveSession(dir, pty);
+
+    // First turn: fresh spawn, prompt rides in argv; PTY writes stay empty.
+    await session.prompt("first", async () => {}, async () => "agy-allow-once");
+    expect(pty.writes).toEqual([]);
+    expect(pty.killed).toBe(false);
+
+    // Second turn reuses the live TUI. The only PTY write must be the user's
+    // own prompt under bracketed paste — never adapter prose or "continue".
+    const db = new (await import("better-sqlite3")).default(path.join(dir, "reuse.db"));
+    insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done two" }) });
+    db.close();
+    setTimeout(() => pty.emitData("? for shortcuts"), 40);
+
+    await session.prompt("second", async () => {}, async () => "agy-allow-once");
+    expect(pty.writes).toEqual(["\x1b[200~second\x1b[201~\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("pauses turn deadline while waiting for ACP client permission response and extends turn timeout", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2985,7 +2985,7 @@ describe("StreamPoller", () => {
     db.close();
   });
 
-  it("clears background wait on stop_hook type 101 even without task id in text", () => {
+  it("does not clear background wait on empty stepType 101, but clears on system message wake", () => {
     const db = createConversationDb(dir, "conv-bg-stop-hook");
     insertStep(db, {
       idx: 1,
@@ -3001,7 +3001,7 @@ describe("StreamPoller", () => {
       stepType: 15,
       status: 3,
       stepPayload: encodeStepPayload({
-        agentText: "Preserving context while waiting for background command output..."
+        agentText: "The test run task has been launched in the background. I will wait for it to complete before providing the final summary."
       })
     });
     const poller = new StreamPoller({
@@ -3015,11 +3015,24 @@ describe("StreamPoller", () => {
     poller.poll();
     expect(poller.hasActiveBackgroundTasks).toBe(true);
 
+    // Empty stepType 101 turn-end marker appended by agy at prompt end must NOT clear active tasks
     insertStep(db, {
       idx: 3,
       stepType: 101,
       status: 3,
       stepPayload: encodeStepPayload({})
+    });
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    // Genuine system message completion wake clears the task
+    insertStep(db, {
+      idx: 4,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-42 content=Task id "task-42" finished'
+      })
     });
     poller.poll();
     expect(poller.hasActiveBackgroundTasks).toBe(false);


### PR DESCRIPTION
## Description

Make `StreamPoller` background task tracking 100% DB-driven via SQLite protobuf `task_details` launch and completion state. Prevent generic, id-less `stepType 101` turn-end markers (emitted by `agy` at the end of every prompt turn) from clearing active background tasks before terminal system completion messages arrive.

## Related Issues

Fixes #86

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring / Code cleanup
- [x] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed