### PR TITLE
Avoid ambiguous edit rollback when replacement text repeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ### Fixed
 
+- Avoid ambiguous edit rollback or ACP filesystem write-through handoff when replacement text appears multiple times in a file, failing safely instead of replacing an arbitrary occurrence. (#80)
 - Prevent generic, id-less `stepType 101` turn-end markers from clearing active background tasks before terminal system completion messages arrive, making `StreamPoller` background task tracking 100% DB-driven via SQLite protobuf `task_details` state. (#86)
 
 ## [0.4.2] - 2026-08-04

--- a/src/agy/edit/bridge.ts
+++ b/src/agy/edit/bridge.ts
@@ -14,7 +14,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
-import { diffBlocks } from "./revert.js";
+import { diffBlocks, hasUniqueOccurrence } from "./revert.js";
 
 export interface ClientFileSystem {
   readTextFile(path: string): Promise<void>;
@@ -45,10 +45,10 @@ export async function routeEditThroughClient(toolCall: SessionUpdate, bridge: Cl
       let fullOldText: string;
       if (current === newText) {
         fullOldText = oldText ?? "";
-      } else if (current.includes(newText)) {
+      } else if (hasUniqueOccurrence(current, newText)) {
         fullOldText = current.replace(newText, oldText ?? "");
       } else {
-        continue; // diverged since — leave this file alone
+        continue; // diverged since or ambiguous match — leave this file alone
       }
 
       writeFileSync(path, fullOldText, "utf8");

--- a/src/agy/edit/revert.ts
+++ b/src/agy/edit/revert.ts
@@ -29,11 +29,19 @@ export function diffBlocks(toolCall: SessionUpdate): DiffBlock[] {
   return blocks;
 }
 
+export function hasUniqueOccurrence(str: string, substr: string): boolean {
+  if (!substr) return false;
+  const first = str.indexOf(substr);
+  if (first === -1) return false;
+  return str.indexOf(substr, first + 1) === -1;
+}
+
 /**
  * Restore the pre-edit text this same translator pass recorded for each diff
  * block. Only acts when the file's current content still matches what the
- * edit wrote — if it has diverged further (a later edit landed on top), the
- * block is left alone rather than guessing.
+ * edit wrote — if it has diverged further (a later edit landed on top), or
+ * if the replacement text appears multiple times ambiguously, the block is
+ * left alone rather than guessing.
  *
  * Returns the blocks actually restored, so callers can attribute exactly the
  * restoration that happened: a diverged block that was declined still holds
@@ -60,7 +68,7 @@ export function revertEditToolCall(toolCall: SessionUpdate): DiffBlock[] {
     if (current === newText) {
       writeFileSync(path, oldText, "utf8");
       restored.push(block);
-    } else if (current.includes(newText)) {
+    } else if (hasUniqueOccurrence(current, newText)) {
       writeFileSync(path, current.replace(newText, oldText), "utf8");
       restored.push(block);
     }

--- a/tests/edit-fs-bridge.test.ts
+++ b/tests/edit-fs-bridge.test.ts
@@ -98,6 +98,24 @@ describe("routeEditThroughClient", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("leaves the file alone and returns false when newText appears multiple times (ambiguous match, gh#80)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file = path.join(dir, "a.txt");
+    const content = "line 1 NEW\nline 2 NEW\nline 3";
+    fs.writeFileSync(file, content, "utf8");
+    const { bridge, writes } = recordingBridge();
+
+    const routed = await routeEditThroughClient(
+      diffToolCall([{ path: file, oldText: "OLD", newText: "NEW" }]),
+      bridge
+    );
+
+    expect(routed).toBe(false);
+    expect(writes).toEqual([]);
+    expect(fs.readFileSync(file, "utf8")).toBe(content);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("returns false and restores the post-edit content when the client rejects the write", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
     const file = path.join(dir, "a.txt");

--- a/tests/edit-revert.test.ts
+++ b/tests/edit-revert.test.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { describe, expect, it } from "vitest";
-import { revertEditToolCall } from "../src/agy/edit/revert.js";
+import { hasUniqueOccurrence, revertEditToolCall } from "../src/agy/edit/revert.js";
 
 function diffToolCall(blocks: Array<{ path: string; oldText: string | null; newText: string }>): SessionUpdate {
   return {
@@ -15,6 +15,22 @@ function diffToolCall(blocks: Array<{ path: string; oldText: string | null; newT
     content: blocks.map((b) => ({ type: "diff" as const, ...b }))
   } as SessionUpdate;
 }
+
+describe("hasUniqueOccurrence", () => {
+  it("returns true for exact unique occurrence", () => {
+    expect(hasUniqueOccurrence("hello world", "world")).toBe(true);
+  });
+
+  it("returns false when string occurs multiple times", () => {
+    expect(hasUniqueOccurrence("hello world hello", "hello")).toBe(false);
+    expect(hasUniqueOccurrence("repeat repeat", "repeat")).toBe(false);
+  });
+
+  it("returns false when string is missing or empty", () => {
+    expect(hasUniqueOccurrence("hello world", "foo")).toBe(false);
+    expect(hasUniqueOccurrence("hello world", "")).toBe(false);
+  });
+});
 
 describe("revertEditToolCall", () => {
   it("restores the prior full-file content", () => {
@@ -38,6 +54,19 @@ describe("revertEditToolCall", () => {
 
     expect(fs.readFileSync(file, "utf8")).toBe("before\nOLD\nafter");
     expect(restored).toEqual([{ path: file, oldText: "OLD", newText: "NEW" }]);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("leaves the file alone when newText appears multiple times (ambiguous match, gh#80)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-revert-"));
+    const file = path.join(dir, "a.txt");
+    const content = "line 1 NEW\nline 2 NEW\nline 3";
+    fs.writeFileSync(file, content, "utf8");
+
+    const restored = revertEditToolCall(diffToolCall([{ path: file, oldText: "OLD", newText: "NEW" }]));
+
+    expect(fs.readFileSync(file, "utf8")).toBe(content);
+    expect(restored).toEqual([]);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Description

Avoid ambiguous edit rollbacks and client filesystem handoffs when replacement text (`newText`) appears multiple times in a file. Both `src/agy/edit/revert.ts` and `src/agy/edit/bridge.ts` previously used `String.prototype.replace(newText, oldText)`, which unconditionally replaced the first matching instance in the file. Now, `hasUniqueOccurrence()` guarantees that snippet replacement only executes when `newText` uniquely identifies a single occurrence in the target file, failing safely otherwise.

## Related Issues

Fixes #80

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed