### PR TITLE
Cancel agy process immediately when session update callback fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 ### Fixed
 
 - Prevent generic, id-less `stepType 101` turn-end markers from clearing active background tasks before terminal system completion messages arrive, making `StreamPoller` background task tracking 100% DB-driven via SQLite protobuf `task_details` state. (#86)
+- Terminate `agy` process immediately via SIGINT->SIGKILL escalation when an ACP `session/update` callback rejects during print-mode execution, preventing orphaned backend processes. (#78)
 
 ## [0.4.2] - 2026-08-04
 

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -882,22 +882,30 @@ export class AgyCliSession {
       };
 
       let polling = true;
+      let pollReject: ((reason?: unknown) => void) | undefined;
+      const pollErrorPromise = new Promise<never>((_, reject) => {
+        pollReject = reject;
+      });
+
       const pollLoop = (async () => {
-        while (polling) {
-          await pollOnce();
-          if (!polling) break;
-          await sleep(POLL_INTERVAL_MS);
+        try {
+          while (polling) {
+            await pollOnce();
+            if (!polling) break;
+            await sleep(POLL_INTERVAL_MS);
+          }
+        } catch (error) {
+          pollReject?.(error);
+          await this.cancel();
         }
       })();
-      // pollLoop runs unawaited while we wait on the child process below; if it
-      // rejects in that window Node would otherwise treat it as an unhandled
-      // rejection and crash the whole server. Attaching a no-op handler here
-      // marks it handled — the real rejection still surfaces from the `await
-      // pollLoop` a few lines down, inside this try/catch.
       pollLoop.catch(() => {});
 
       const [exitCode] = child.exitCode === null
-        ? await this.raceProcessError(exitPromise, errorPromise, command)
+        ? await Promise.race([
+            this.raceProcessError(exitPromise, errorPromise, command),
+            pollErrorPromise
+          ])
         : [child.exitCode, null];
       polling = false;
       await pollLoop;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1705,6 +1705,40 @@ describe("cancel", () => {
     expect((await pending).stopReason).toBe("cancelled");
   });
 
+  it("cancels agy process immediately and throws when onUpdate callback fails in print mode", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-print-update-fail-"));
+    try {
+      const calls: SpawnCall[] = [];
+      const fake = new FakeProcess([], { blockStdout: true, exitCode: null });
+      const session = new AgyCliSession(
+        { ...defaultConfig(), conversationsDir: dir },
+        (command, args, options) => {
+          const db = createConversationDb(dir, "print-update-fail");
+          insertStep(db, {
+            idx: 1,
+            stepType: 15,
+            status: 3,
+            stepPayload: encodeStepPayload({ agentText: "chunk one" })
+          });
+          db.close();
+          return fake.spawnFactory(calls)(command, args, options);
+        }
+      );
+
+      const callbackError = new Error("ACP client disconnected");
+      await expect(
+        session.prompt("hello", async () => {
+          throw callbackError;
+        })
+      ).rejects.toThrow("ACP client disconnected");
+
+      expect(fake.killedWith).toBe("SIGINT");
+      expect(session.wasCancelled).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("fails the print-mode turn when background drain exceeds printTimeout", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-print-bg-timeout-"));
     try {


### PR DESCRIPTION
## Description

Race child process execution against `pollLoop` callback rejections in print-mode execution. Immediately trigger `cancel()` and SIGINT->SIGKILL escalation when an ACP `session/update` callback rejects, preventing orphaned `agy` backend processes from running after client disconnection or update failure.

## Related Issues

Fixes #78

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [x] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed