### PR TITLE
Make ACP filesystem handoff atomic across multi-file edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ### Fixed
 
+- Make ACP filesystem handoff (`routeEditThroughClient` and `writeEditThroughClient`) atomic across multi-file edits, preflighting diff blocks for file existence and content divergence before modifying disk or invoking client RPCs. (#79)
 - Avoid ambiguous edit rollback or ACP filesystem write-through handoff when replacement text appears multiple times in a file, failing safely instead of replacing an arbitrary occurrence. (#80)
 - Prevent generic, id-less `stepType 101` turn-end markers from clearing active background tasks before terminal system completion messages arrive, making `StreamPoller` background task tracking 100% DB-driven via SQLite protobuf `task_details` state. (#86)
 

--- a/src/agy/edit/bridge.ts
+++ b/src/agy/edit/bridge.ts
@@ -28,36 +28,79 @@ export interface ClientFileSystem {
  * rejected the write-through, so the caller can fall back to the local
  * permission-bridge review.
  */
-export async function routeEditThroughClient(toolCall: SessionUpdate, bridge: ClientFileSystem): Promise<boolean> {
-  const blocks = diffBlocks(toolCall);
-  if (blocks.length === 0) return false;
+interface FileToRoute {
+  path: string;
+  fullOldText: string;
+  fullNewText: string;
+}
 
-  // Same matching rules as revertEditToolCall: oldText/newText may be the
-  // whole file (create/full-file write) or a snippet embedded in surrounding
-  // context (partial replace) — either way `current` is the full post-edit
-  // file content we hand to the client once it has the pre-edit state cached.
+function preflightRouteEdit(toolCall: SessionUpdate): FileToRoute[] | null {
+  const blocks = diffBlocks(toolCall);
+  if (blocks.length === 0) return null;
+
+  const pathsInOrder: string[] = [];
+  const blocksByPath = new Map<string, import("./revert.js").DiffBlock[]>();
+
+  for (const block of blocks) {
+    let list = blocksByPath.get(block.path);
+    if (!list) {
+      list = [];
+      blocksByPath.set(block.path, list);
+      pathsInOrder.push(block.path);
+    }
+    list.push(block);
+  }
+
+  const filesToRoute: FileToRoute[] = [];
+
+  for (const path of pathsInOrder) {
+    if (!existsSync(path)) return null;
+
+    const fullNewText = readFileSync(path, "utf8");
+    let current = fullNewText;
+    const fileBlocks = blocksByPath.get(path)!;
+
+    for (const { oldText, newText } of fileBlocks) {
+      if (current === newText) {
+        current = oldText ?? "";
+      } else if (hasUniqueOccurrence(current, newText)) {
+        current = current.replace(newText, oldText ?? "");
+      } else {
+        return null; // diverged, missing, or ambiguous match
+      }
+    }
+
+    filesToRoute.push({
+      path,
+      fullOldText: current,
+      fullNewText
+    });
+  }
+
+  return filesToRoute;
+}
+
+/**
+ * Returns true if the edit was handed off to the client (disk ends up back
+ * at newText, written by the client itself). Returns false — leaving disk
+ * untouched at newText — if there was nothing to route or the client
+ * rejected the write-through, so the caller can fall back to the local
+ * permission-bridge review.
+ */
+export async function routeEditThroughClient(toolCall: SessionUpdate, bridge: ClientFileSystem): Promise<boolean> {
+  const filesToRoute = preflightRouteEdit(toolCall);
+  if (!filesToRoute || filesToRoute.length === 0) return false;
+
   const reverted: { path: string; fullNewText: string }[] = [];
   try {
-    for (const { path, oldText, newText } of blocks) {
-      const current = existsSync(path) ? readFileSync(path, "utf8") : null;
-      if (current === null) continue;
-
-      let fullOldText: string;
-      if (current === newText) {
-        fullOldText = oldText ?? "";
-      } else if (hasUniqueOccurrence(current, newText)) {
-        fullOldText = current.replace(newText, oldText ?? "");
-      } else {
-        continue; // diverged since or ambiguous match — leave this file alone
-      }
-
+    for (const { path, fullOldText, fullNewText } of filesToRoute) {
       writeFileSync(path, fullOldText, "utf8");
-      reverted.push({ path, fullNewText: current });
+      reverted.push({ path, fullNewText });
 
       await bridge.readTextFile(path);
-      await bridge.writeTextFile(path, current);
+      await bridge.writeTextFile(path, fullNewText);
     }
-    return reverted.length > 0;
+    return true;
   } catch {
     // Restore whatever we reverted before the failure, so disk still matches
     // the content already reported via session/update.
@@ -94,16 +137,16 @@ export async function primeEditReadThroughClient(toolCall: SessionUpdate, bridge
  * no local revert needed, since disk was never touched by us in between.
  */
 export async function writeEditThroughClient(toolCall: SessionUpdate, bridge: ClientFileSystem): Promise<boolean> {
-  const paths = new Set(diffBlocks(toolCall).map((block) => block.path));
-  if (paths.size === 0) return false;
+  const paths = Array.from(new Set(diffBlocks(toolCall).map((block) => block.path)));
+  if (paths.length === 0) return false;
+  for (const path of paths) {
+    if (!existsSync(path)) return false;
+  }
   try {
-    let wrote = false;
     for (const path of paths) {
-      if (!existsSync(path)) continue;
       await bridge.writeTextFile(path, readFileSync(path, "utf8"));
-      wrote = true;
     }
-    return wrote;
+    return true;
   } catch {
     return false;
   }

--- a/tests/edit-fs-bridge.test.ts
+++ b/tests/edit-fs-bridge.test.ts
@@ -143,6 +143,86 @@ describe("routeEditThroughClient", () => {
     );
     expect(routed).toBe(false);
   });
+
+  it("is atomic across multi-file edits: returns false and leaves disk untouched if any file diverged or is missing", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file1 = path.join(dir, "a.txt");
+    const file2 = path.join(dir, "b.txt");
+    fs.writeFileSync(file1, "file1 NEW", "utf8");
+    fs.writeFileSync(file2, "file2 DIVERGED", "utf8");
+    const { bridge, writes } = recordingBridge();
+
+    const routed = await routeEditThroughClient(
+      diffToolCall([
+        { path: file1, oldText: "file1 OLD", newText: "file1 NEW" },
+        { path: file2, oldText: "file2 OLD", newText: "file2 EXPECTED" }
+      ]),
+      bridge
+    );
+
+    expect(routed).toBe(false);
+    expect(writes).toEqual([]);
+    // Disk for file1 must remain completely untouched (not reverted)
+    expect(fs.readFileSync(file1, "utf8")).toBe("file1 NEW");
+    expect(fs.readFileSync(file2, "utf8")).toBe("file2 DIVERGED");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("is atomic across multi-file edits: returns false and restores all files if client fails mid-handoff", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file1 = path.join(dir, "a.txt");
+    const file2 = path.join(dir, "b.txt");
+    fs.writeFileSync(file1, "file1 NEW", "utf8");
+    fs.writeFileSync(file2, "file2 NEW", "utf8");
+
+    const bridge: ClientFileSystem = {
+      readTextFile: async () => {},
+      writeTextFile: async (p) => {
+        if (p === file2) throw new Error("client failed on file2");
+      }
+    };
+
+    const routed = await routeEditThroughClient(
+      diffToolCall([
+        { path: file1, oldText: "file1 OLD", newText: "file1 NEW" },
+        { path: file2, oldText: "file2 OLD", newText: "file2 NEW" }
+      ]),
+      bridge
+    );
+
+    expect(routed).toBe(false);
+    // Both files must be restored to post-edit content
+    expect(fs.readFileSync(file1, "utf8")).toBe("file1 NEW");
+    expect(fs.readFileSync(file2, "utf8")).toBe("file2 NEW");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("routes multi-file edits successfully when all files match", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file1 = path.join(dir, "a.txt");
+    const file2 = path.join(dir, "b.txt");
+    fs.writeFileSync(file1, "file1 NEW", "utf8");
+    fs.writeFileSync(file2, "file2 NEW", "utf8");
+
+    const { bridge, writes } = recordingBridge();
+
+    const routed = await routeEditThroughClient(
+      diffToolCall([
+        { path: file1, oldText: "file1 OLD", newText: "file1 NEW" },
+        { path: file2, oldText: "file2 OLD", newText: "file2 NEW" }
+      ]),
+      bridge
+    );
+
+    expect(routed).toBe(true);
+    expect(writes).toEqual([
+      { path: file1, content: "file1 NEW" },
+      { path: file2, content: "file2 NEW" }
+    ]);
+    expect(fs.readFileSync(file1, "utf8")).toBe("file1 NEW");
+    expect(fs.readFileSync(file2, "utf8")).toBe("file2 NEW");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
 });
 
 describe("primeEditReadThroughClient + writeEditThroughClient", () => {
@@ -183,5 +263,24 @@ describe("primeEditReadThroughClient + writeEditThroughClient", () => {
       bridge
     );
     expect(routed).toBe(false);
+  });
+
+  it("writeEditThroughClient is atomic: returns false if any file in a multi-file edit is missing", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file1 = path.join(dir, "a.txt");
+    fs.writeFileSync(file1, "file1 content", "utf8");
+    const { bridge, writes } = recordingBridge();
+
+    const routed = await writeEditThroughClient(
+      diffToolCall([
+        { path: file1, oldText: "old1", newText: "file1 content" },
+        { path: "/nonexistent/gone.txt", oldText: "old2", newText: "new2" }
+      ]),
+      bridge
+    );
+
+    expect(routed).toBe(false);
+    expect(writes).toEqual([]);
+    fs.rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Description

Makes ACP filesystem handoff (`routeEditThroughClient` and `writeEditThroughClient`) atomic across multi-file edits. Preflights all diff blocks in a tool call to verify file existence and absence of content divergence before modifying disk or invoking client RPCs. If any file fails preflight or fails during client write-through, all previously reverted files are restored to their post-edit content and the handoff safely reports `false`.

## Related Issues

Fixes #79

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed