### PR TITLE
Prevent stale v2 prompts from resurrecting closed or deleted sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ### Fixed
 
+- Prevent stale or floating v2 prompt turns from resurrecting closed or deleted sessions or overwriting reloaded sessions in the persisted session store. (#77)
 - Avoid ambiguous edit rollback or ACP filesystem write-through handoff when replacement text appears multiple times in a file, failing safely instead of replacing an arbitrary occurrence. (#80)
 - Prevent generic, id-less `stepType 101` turn-end markers from clearing active background tasks before terminal system completion messages arrive, making `StreamPoller` background task tracking 100% DB-driven via SQLite protobuf `task_details` state. (#86)
 

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -568,6 +568,9 @@ export class AcpAgent {
   }
 
   private persistSession(sessionId: string, session: SessionState): Promise<void> {
+    if (session.closed || this.#sessions.get(sessionId) !== session) {
+      return Promise.resolve();
+    }
     return persistSession(this.#store, sessionId, session);
   }
 }

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -165,6 +165,7 @@ export function persistSession(
   sessionId: string,
   session: SessionState
 ): Promise<void> {
+  if (session.closed) return Promise.resolve();
   return store.persist(sessionId, sessionRecord(session));
 }
 

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1375,6 +1375,55 @@ describe("ACP v2 (experimental draft)", () => {
     });
   });
 
+  it("does not resurrect a deleted session when an in-flight prompt finishes after session/delete (gh#77)", async () => {
+    await withConversationsDir(async (dir) => {
+      const client = acpV2.client({ name: "test-client" });
+      const connection = client.connect(
+        createAcpV2App({
+          ...printModeOptions({ conversationsDir: dir, stateDir: dir }),
+          spawnProcess: spawnAgyWritingConversation(dir, "conv-resurrect-77", [
+            { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "done" }) }
+          ])
+        })
+      );
+      try {
+        await connection.agent.request(acpV2.methods.agent.initialize, {
+          protocolVersion: 2,
+          info: { name: "test-client", version: "0.0.0" },
+          capabilities: {}
+        });
+        const session = await connection.agent.request(acpV2.methods.agent.session.new, {
+          cwd: "/repo"
+        });
+        const sessionId = session.sessionId;
+
+        await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId,
+          prompt: [{ type: "text", text: "hi" }]
+        });
+
+        // Delete session immediately while prompt turn is floating in background
+        await connection.agent.request(acpV2.methods.agent.session.delete, { sessionId });
+
+        // Allow floating turn task to finish or error out
+        await new Promise((resolve) => setTimeout(resolve, 300));
+
+        // Verify session was deleted from disk and NOT resurrected
+        const listed = await connection.agent.request(acpV2.methods.agent.session.list, { cwd: "/repo" });
+        expect(listed.sessions.some((s) => s.sessionId === sessionId)).toBe(false);
+
+        await expect(
+          connection.agent.request(acpV2.methods.agent.session.resume, {
+            sessionId,
+            cwd: "/repo"
+          })
+        ).rejects.toThrow();
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
   it("keeps curated slash command IDs out of the DB step namespace", async () => {
     await withConversationsDir(async (dir) => {
       const updates: Array<Record<string, unknown>> = [];


### PR DESCRIPTION
## Description

Asynchronous ACP v2 prompt turns run as floating background tasks. Previously, when a session was closed, deleted, or replaced by a reload/resume operation while a prompt turn was in-flight, the error/completion handler would still call `persistSession()`. This caused deleted sessions to be recreated on disk (`sessions.json`) and replaced sessions to have their persisted conversation state overwritten by stale state from the old prompt task.

Now:
1. `persistSession` in `src/acp/session/setup.ts` guards against `session.closed`.
2. `this.persistSession` in `src/acp/agent.ts` guards against `session.closed` and verifies `this.#sessions.get(sessionId) === session`.
3. Stale or floating prompt tasks immediately return without persisting when their session has been closed, deleted, or replaced.

## Related Issues

Fixes #77

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed