### PR TITLE
Release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ pre-1.0 caveat that minor versions may include breaking changes. Starting with
 `1.0.0-alpha.0`, package pre-releases track ACP v2 draft work; the wire protocol
 for draft v2 may still change before ACP v2 stabilizes.
 
+## [0.4.3] - Unreleased
+
+### Fixed
+
+- Prevent generic, id-less `stepType 101` turn-end markers from clearing active background tasks before terminal system completion messages arrive, making `StreamPoller` background task tracking 100% DB-driven via SQLite protobuf `task_details` state. (#86)
+
 ## [0.4.2] - 2026-08-04
 
 Queued follow-up prompts and steer-by-cancel during active turns, background-task-aware turn completion, stricter zero-prompt-injection content encoding, ID-based incremental `plan_update` ops and `plan_removed`, immediate command box display with live stdout streaming for `run_command`, and removal of environment-variable configuration in favor of CLI flags and programmatic options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ pre-1.0 caveat that minor versions may include breaking changes. Starting with
 `1.0.0-alpha.0`, package pre-releases track ACP v2 draft work; the wire protocol
 for draft v2 may still change before ACP v2 stabilizes.
 
-## [0.4.3] - Unreleased
+## [0.4.3] - 2026-08-04
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 ### Fixed
 
 - Prevent generic, id-less `stepType 101` turn-end markers from clearing active background tasks before terminal system completion messages arrive, making `StreamPoller` background task tracking 100% DB-driven via SQLite protobuf `task_details` state. (#86)
+- Terminate `agy` process immediately via SIGINT->SIGKILL escalation when an ACP `session/update` callback rejects during print-mode execution, preventing orphaned backend processes. (#78)
 
 ## [0.4.2] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ### Fixed
 
+- Prevent stale or floating v2 prompt turns from resurrecting closed or deleted sessions or overwriting reloaded sessions in the persisted session store. (#77)
 - Avoid ambiguous edit rollback or ACP filesystem write-through handoff when replacement text appears multiple times in a file, failing safely instead of replacing an arbitrary occurrence. (#80)
 - Prevent generic, id-less `stepType 101` turn-end markers from clearing active background tasks before terminal system completion messages arrive, making `StreamPoller` background task tracking 100% DB-driven via SQLite protobuf `task_details` state. (#86)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ### Fixed
 
+- Avoid ambiguous edit rollback or ACP filesystem write-through handoff when replacement text appears multiple times in a file, failing safely instead of replacing an arbitrary occurrence. (#80)
 - Prevent generic, id-less `stepType 101` turn-end markers from clearing active background tasks before terminal system completion messages arrive, making `StreamPoller` background task tracking 100% DB-driven via SQLite protobuf `task_details` state. (#86)
 
 ## [0.4.2] - 2026-08-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ### Fixed
 
+- Make ACP filesystem handoff (`routeEditThroughClient` and `writeEditThroughClient`) atomic across multi-file edits, preflighting diff blocks for file existence and content divergence before modifying disk or invoking client RPCs. (#79)
 - Avoid ambiguous edit rollback or ACP filesystem write-through handoff when replacement text appears multiple times in a file, failing safely instead of replacing an arbitrary occurrence. (#80)
 - Prevent generic, id-less `stepType 101` turn-end markers from clearing active background tasks before terminal system completion messages arrive, making `StreamPoller` background task tracking 100% DB-driven via SQLite protobuf `task_details` state. (#86)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agy-acp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agy-acp",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agy-acp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Agent Client Protocol adapter that wraps the Google Antigravity CLI (ACP v1 + experimental draft ACP v2)",
   "type": "module",
   "author": {

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -568,6 +568,9 @@ export class AcpAgent {
   }
 
   private persistSession(sessionId: string, session: SessionState): Promise<void> {
+    if (session.closed || this.#sessions.get(sessionId) !== session) {
+      return Promise.resolve();
+    }
     return persistSession(this.#store, sessionId, session);
   }
 }

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -165,6 +165,7 @@ export function persistSession(
   sessionId: string,
   session: SessionState
 ): Promise<void> {
+  if (session.closed) return Promise.resolve();
   return store.persist(sessionId, sessionRecord(session));
 }
 

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -882,22 +882,30 @@ export class AgyCliSession {
       };
 
       let polling = true;
+      let pollReject: ((reason?: unknown) => void) | undefined;
+      const pollErrorPromise = new Promise<never>((_, reject) => {
+        pollReject = reject;
+      });
+
       const pollLoop = (async () => {
-        while (polling) {
-          await pollOnce();
-          if (!polling) break;
-          await sleep(POLL_INTERVAL_MS);
+        try {
+          while (polling) {
+            await pollOnce();
+            if (!polling) break;
+            await sleep(POLL_INTERVAL_MS);
+          }
+        } catch (error) {
+          pollReject?.(error);
+          await this.cancel();
         }
       })();
-      // pollLoop runs unawaited while we wait on the child process below; if it
-      // rejects in that window Node would otherwise treat it as an unhandled
-      // rejection and crash the whole server. Attaching a no-op handler here
-      // marks it handled — the real rejection still surfaces from the `await
-      // pollLoop` a few lines down, inside this try/catch.
       pollLoop.catch(() => {});
 
       const [exitCode] = child.exitCode === null
-        ? await this.raceProcessError(exitPromise, errorPromise, command)
+        ? await Promise.race([
+            this.raceProcessError(exitPromise, errorPromise, command),
+            pollErrorPromise
+          ])
         : [child.exitCode, null];
       polling = false;
       await pollLoop;

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -99,13 +99,10 @@ export class StreamPoller {
 
   /**
    * True while this user turn should stay open for background work.
-   * Prefer explicit task_details launch/completion tracking; fall back to the
-   * "preserving context / waiting for background" agent text plus a later
-   * system/lifecycle message. Never requires injecting a synthetic prompt.
+   * Driven strictly by SQLite protobuf task_details launch and completion state.
    */
   get hasActiveBackgroundTasks(): boolean {
-    if (this._launchedTaskIdxs.size > this._completedTaskIds.size) return true;
-    return this._hasBackgroundWaiting && !this.hasUnansweredSystemMessage;
+    return this._launchedTaskIdxs.size > this._completedTaskIds.size;
   }
 
   /** Newly observed status-9 tool calls from the most recent poll. */
@@ -151,26 +148,17 @@ export class StreamPoller {
       if (row.stepType === 14) {
         this.observedUserStepIdxs.add(row.idx);
         this._lastUserStepIdx = Math.max(this._lastUserStepIdx, row.idx);
-        this._hasBackgroundWaiting = false;
       }
       if (row.task?.taskId && !this._launchedTaskIdxs.has(row.task.taskId)) {
         this._launchedTaskIdxs.set(row.task.taskId, row.idx);
       }
       const text = row.stepPayload.agentText?.text ?? "";
-      // Only enter the background-wait path with corroborating task evidence.
-      // A bare prose mention of "preserving context" must not pin the turn open
-      // (and eventually time out) when no background task was launched.
-      if (
-        this._launchedTaskIdxs.size > 0 &&
-        text &&
-        isBackgroundWaitAgentText(text)
-      ) {
-        this._hasBackgroundWaiting = true;
-      }
-      // Defer completion tracking until the lifecycle row is terminal so a
+      // Defer completion tracking until a system message is terminal so a
       // still-streaming system-message envelope cannot close the wait early.
+      // Generic stepType 101 turn-end markers without a system message payload
+      // must NOT clear active tasks, as agy appends 101 at the end of every turn.
       if (
-        (row.stepType === 101 || isSystemMessage(text)) &&
+        isSystemMessage(text) &&
         isTerminalStepStatus(row.status)
       ) {
         this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
@@ -187,8 +175,8 @@ export class StreamPoller {
             matchedTask = true;
           }
         }
-        // Lifecycle/system wake without an embedded task id (common for stop_hook
-        // type 101): close every still-pending launch so the turn cannot hang
+        // Lifecycle/system wake without an embedded task id (common for system message
+        // wakes): close every still-pending launch so the turn cannot hang
         // forever waiting for a match that never arrives.
         if (!matchedTask) {
           for (const taskId of launchedBefore) {
@@ -274,17 +262,6 @@ export class StreamPoller {
     this.db?.close();
     this.db = null;
   }
-}
-
-/** agy's known lifecycle prose when it parks a turn on a background task. */
-const BACKGROUND_WAIT_SENTINEL =
-  "Preserving context while waiting for background command output...";
-
-function isBackgroundWaitAgentText(text: string): boolean {
-  const trimmed = text.trim();
-  if (trimmed === BACKGROUND_WAIT_SENTINEL) return true;
-  // Slight variants still seen with task_details present.
-  return /waiting for.*background|preserving context while waiting/i.test(trimmed);
 }
 
 /** status 3/6/7 — completed, cancelled/aborted, or failed. */

--- a/src/agy/edit/bridge.ts
+++ b/src/agy/edit/bridge.ts
@@ -28,36 +28,79 @@ export interface ClientFileSystem {
  * rejected the write-through, so the caller can fall back to the local
  * permission-bridge review.
  */
-export async function routeEditThroughClient(toolCall: SessionUpdate, bridge: ClientFileSystem): Promise<boolean> {
-  const blocks = diffBlocks(toolCall);
-  if (blocks.length === 0) return false;
+interface FileToRoute {
+  path: string;
+  fullOldText: string;
+  fullNewText: string;
+}
 
-  // Same matching rules as revertEditToolCall: oldText/newText may be the
-  // whole file (create/full-file write) or a snippet embedded in surrounding
-  // context (partial replace) — either way `current` is the full post-edit
-  // file content we hand to the client once it has the pre-edit state cached.
+function preflightRouteEdit(toolCall: SessionUpdate): FileToRoute[] | null {
+  const blocks = diffBlocks(toolCall);
+  if (blocks.length === 0) return null;
+
+  const pathsInOrder: string[] = [];
+  const blocksByPath = new Map<string, import("./revert.js").DiffBlock[]>();
+
+  for (const block of blocks) {
+    let list = blocksByPath.get(block.path);
+    if (!list) {
+      list = [];
+      blocksByPath.set(block.path, list);
+      pathsInOrder.push(block.path);
+    }
+    list.push(block);
+  }
+
+  const filesToRoute: FileToRoute[] = [];
+
+  for (const path of pathsInOrder) {
+    if (!existsSync(path)) return null;
+
+    const fullNewText = readFileSync(path, "utf8");
+    let current = fullNewText;
+    const fileBlocks = blocksByPath.get(path)!;
+
+    for (const { oldText, newText } of fileBlocks) {
+      if (current === newText) {
+        current = oldText ?? "";
+      } else if (hasUniqueOccurrence(current, newText)) {
+        current = current.replace(newText, oldText ?? "");
+      } else {
+        return null; // diverged, missing, or ambiguous match
+      }
+    }
+
+    filesToRoute.push({
+      path,
+      fullOldText: current,
+      fullNewText
+    });
+  }
+
+  return filesToRoute;
+}
+
+/**
+ * Returns true if the edit was handed off to the client (disk ends up back
+ * at newText, written by the client itself). Returns false — leaving disk
+ * untouched at newText — if there was nothing to route or the client
+ * rejected the write-through, so the caller can fall back to the local
+ * permission-bridge review.
+ */
+export async function routeEditThroughClient(toolCall: SessionUpdate, bridge: ClientFileSystem): Promise<boolean> {
+  const filesToRoute = preflightRouteEdit(toolCall);
+  if (!filesToRoute || filesToRoute.length === 0) return false;
+
   const reverted: { path: string; fullNewText: string }[] = [];
   try {
-    for (const { path, oldText, newText } of blocks) {
-      const current = existsSync(path) ? readFileSync(path, "utf8") : null;
-      if (current === null) continue;
-
-      let fullOldText: string;
-      if (current === newText) {
-        fullOldText = oldText ?? "";
-      } else if (hasUniqueOccurrence(current, newText)) {
-        fullOldText = current.replace(newText, oldText ?? "");
-      } else {
-        continue; // diverged since or ambiguous match — leave this file alone
-      }
-
+    for (const { path, fullOldText, fullNewText } of filesToRoute) {
       writeFileSync(path, fullOldText, "utf8");
-      reverted.push({ path, fullNewText: current });
+      reverted.push({ path, fullNewText });
 
       await bridge.readTextFile(path);
-      await bridge.writeTextFile(path, current);
+      await bridge.writeTextFile(path, fullNewText);
     }
-    return reverted.length > 0;
+    return true;
   } catch {
     // Restore whatever we reverted before the failure, so disk still matches
     // the content already reported via session/update.
@@ -94,16 +137,16 @@ export async function primeEditReadThroughClient(toolCall: SessionUpdate, bridge
  * no local revert needed, since disk was never touched by us in between.
  */
 export async function writeEditThroughClient(toolCall: SessionUpdate, bridge: ClientFileSystem): Promise<boolean> {
-  const paths = new Set(diffBlocks(toolCall).map((block) => block.path));
-  if (paths.size === 0) return false;
+  const paths = Array.from(new Set(diffBlocks(toolCall).map((block) => block.path)));
+  if (paths.length === 0) return false;
+  for (const path of paths) {
+    if (!existsSync(path)) return false;
+  }
   try {
-    let wrote = false;
     for (const path of paths) {
-      if (!existsSync(path)) continue;
       await bridge.writeTextFile(path, readFileSync(path, "utf8"));
-      wrote = true;
     }
-    return wrote;
+    return true;
   } catch {
     return false;
   }

--- a/src/agy/edit/bridge.ts
+++ b/src/agy/edit/bridge.ts
@@ -14,7 +14,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
-import { diffBlocks } from "./revert.js";
+import { diffBlocks, hasUniqueOccurrence } from "./revert.js";
 
 export interface ClientFileSystem {
   readTextFile(path: string): Promise<void>;
@@ -45,10 +45,10 @@ export async function routeEditThroughClient(toolCall: SessionUpdate, bridge: Cl
       let fullOldText: string;
       if (current === newText) {
         fullOldText = oldText ?? "";
-      } else if (current.includes(newText)) {
+      } else if (hasUniqueOccurrence(current, newText)) {
         fullOldText = current.replace(newText, oldText ?? "");
       } else {
-        continue; // diverged since — leave this file alone
+        continue; // diverged since or ambiguous match — leave this file alone
       }
 
       writeFileSync(path, fullOldText, "utf8");

--- a/src/agy/edit/revert.ts
+++ b/src/agy/edit/revert.ts
@@ -29,11 +29,19 @@ export function diffBlocks(toolCall: SessionUpdate): DiffBlock[] {
   return blocks;
 }
 
+export function hasUniqueOccurrence(str: string, substr: string): boolean {
+  if (!substr) return false;
+  const first = str.indexOf(substr);
+  if (first === -1) return false;
+  return str.indexOf(substr, first + 1) === -1;
+}
+
 /**
  * Restore the pre-edit text this same translator pass recorded for each diff
  * block. Only acts when the file's current content still matches what the
- * edit wrote — if it has diverged further (a later edit landed on top), the
- * block is left alone rather than guessing.
+ * edit wrote — if it has diverged further (a later edit landed on top), or
+ * if the replacement text appears multiple times ambiguously, the block is
+ * left alone rather than guessing.
  *
  * Returns the blocks actually restored, so callers can attribute exactly the
  * restoration that happened: a diverged block that was declined still holds
@@ -60,7 +68,7 @@ export function revertEditToolCall(toolCall: SessionUpdate): DiffBlock[] {
     if (current === newText) {
       writeFileSync(path, oldText, "utf8");
       restored.push(block);
-    } else if (current.includes(newText)) {
+    } else if (hasUniqueOccurrence(current, newText)) {
       writeFileSync(path, current.replace(newText, oldText), "utf8");
       restored.push(block);
     }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1375,6 +1375,55 @@ describe("ACP v2 (experimental draft)", () => {
     });
   });
 
+  it("does not resurrect a deleted session when an in-flight prompt finishes after session/delete (gh#77)", async () => {
+    await withConversationsDir(async (dir) => {
+      const client = acpV2.client({ name: "test-client" });
+      const connection = client.connect(
+        createAcpV2App({
+          ...printModeOptions({ conversationsDir: dir, stateDir: dir }),
+          spawnProcess: spawnAgyWritingConversation(dir, "conv-resurrect-77", [
+            { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "done" }) }
+          ])
+        })
+      );
+      try {
+        await connection.agent.request(acpV2.methods.agent.initialize, {
+          protocolVersion: 2,
+          info: { name: "test-client", version: "0.0.0" },
+          capabilities: {}
+        });
+        const session = await connection.agent.request(acpV2.methods.agent.session.new, {
+          cwd: "/repo"
+        });
+        const sessionId = session.sessionId;
+
+        await connection.agent.request(acpV2.methods.agent.session.prompt, {
+          sessionId,
+          prompt: [{ type: "text", text: "hi" }]
+        });
+
+        // Delete session immediately while prompt turn is floating in background
+        await connection.agent.request(acpV2.methods.agent.session.delete, { sessionId });
+
+        // Allow floating turn task to finish or error out
+        await new Promise((resolve) => setTimeout(resolve, 300));
+
+        // Verify session was deleted from disk and NOT resurrected
+        const listed = await connection.agent.request(acpV2.methods.agent.session.list, { cwd: "/repo" });
+        expect(listed.sessions.some((s) => s.sessionId === sessionId)).toBe(false);
+
+        await expect(
+          connection.agent.request(acpV2.methods.agent.session.resume, {
+            sessionId,
+            cwd: "/repo"
+          })
+        ).rejects.toThrow();
+      } finally {
+        connection.close();
+      }
+    });
+  });
+
   it("keeps curated slash command IDs out of the DB step namespace", async () => {
     await withConversationsDir(async (dir) => {
       const updates: Array<Record<string, unknown>> = [];

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1705,6 +1705,40 @@ describe("cancel", () => {
     expect((await pending).stopReason).toBe("cancelled");
   });
 
+  it("cancels agy process immediately and throws when onUpdate callback fails in print mode", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-print-update-fail-"));
+    try {
+      const calls: SpawnCall[] = [];
+      const fake = new FakeProcess([], { blockStdout: true, exitCode: null });
+      const session = new AgyCliSession(
+        { ...defaultConfig(), conversationsDir: dir },
+        (command, args, options) => {
+          const db = createConversationDb(dir, "print-update-fail");
+          insertStep(db, {
+            idx: 1,
+            stepType: 15,
+            status: 3,
+            stepPayload: encodeStepPayload({ agentText: "chunk one" })
+          });
+          db.close();
+          return fake.spawnFactory(calls)(command, args, options);
+        }
+      );
+
+      const callbackError = new Error("ACP client disconnected");
+      await expect(
+        session.prompt("hello", async () => {
+          throw callbackError;
+        })
+      ).rejects.toThrow("ACP client disconnected");
+
+      expect(fake.killedWith).toBe("SIGINT");
+      expect(session.wasCancelled).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("fails the print-mode turn when background drain exceeds printTimeout", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-print-bg-timeout-"));
     try {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -668,6 +668,35 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("writes only the verbatim user prompt back to a reused interactive PTY", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-reuse-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "reuse");
+      insertStep(db, { idx: 1, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done one" }) });
+      db.close();
+      // Fresh TUI owes a second idle marker before the first turn resolves.
+      setTimeout(() => pty.emitData("? for shortcuts"), 60);
+    });
+    const session = interactiveSession(dir, pty);
+
+    // First turn: fresh spawn, prompt rides in argv; PTY writes stay empty.
+    await session.prompt("first", async () => {}, async () => "agy-allow-once");
+    expect(pty.writes).toEqual([]);
+    expect(pty.killed).toBe(false);
+
+    // Second turn reuses the live TUI. The only PTY write must be the user's
+    // own prompt under bracketed paste — never adapter prose or "continue".
+    const db = new (await import("better-sqlite3")).default(path.join(dir, "reuse.db"));
+    insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done two" }) });
+    db.close();
+    setTimeout(() => pty.emitData("? for shortcuts"), 40);
+
+    await session.prompt("second", async () => {}, async () => "agy-allow-once");
+    expect(pty.writes).toEqual(["\x1b[200~second\x1b[201~\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("pauses turn deadline while waiting for ACP client permission response and extends turn timeout", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2985,7 +2985,7 @@ describe("StreamPoller", () => {
     db.close();
   });
 
-  it("clears background wait on stop_hook type 101 even without task id in text", () => {
+  it("does not clear background wait on empty stepType 101, but clears on system message wake", () => {
     const db = createConversationDb(dir, "conv-bg-stop-hook");
     insertStep(db, {
       idx: 1,
@@ -3001,7 +3001,7 @@ describe("StreamPoller", () => {
       stepType: 15,
       status: 3,
       stepPayload: encodeStepPayload({
-        agentText: "Preserving context while waiting for background command output..."
+        agentText: "The test run task has been launched in the background. I will wait for it to complete before providing the final summary."
       })
     });
     const poller = new StreamPoller({
@@ -3015,11 +3015,24 @@ describe("StreamPoller", () => {
     poller.poll();
     expect(poller.hasActiveBackgroundTasks).toBe(true);
 
+    // Empty stepType 101 turn-end marker appended by agy at prompt end must NOT clear active tasks
     insertStep(db, {
       idx: 3,
       stepType: 101,
       status: 3,
       stepPayload: encodeStepPayload({})
+    });
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    // Genuine system message completion wake clears the task
+    insertStep(db, {
+      idx: 4,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-42 content=Task id "task-42" finished'
+      })
     });
     poller.poll();
     expect(poller.hasActiveBackgroundTasks).toBe(false);

--- a/tests/edit-fs-bridge.test.ts
+++ b/tests/edit-fs-bridge.test.ts
@@ -98,6 +98,24 @@ describe("routeEditThroughClient", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("leaves the file alone and returns false when newText appears multiple times (ambiguous match, gh#80)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file = path.join(dir, "a.txt");
+    const content = "line 1 NEW\nline 2 NEW\nline 3";
+    fs.writeFileSync(file, content, "utf8");
+    const { bridge, writes } = recordingBridge();
+
+    const routed = await routeEditThroughClient(
+      diffToolCall([{ path: file, oldText: "OLD", newText: "NEW" }]),
+      bridge
+    );
+
+    expect(routed).toBe(false);
+    expect(writes).toEqual([]);
+    expect(fs.readFileSync(file, "utf8")).toBe(content);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("returns false and restores the post-edit content when the client rejects the write", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
     const file = path.join(dir, "a.txt");

--- a/tests/edit-fs-bridge.test.ts
+++ b/tests/edit-fs-bridge.test.ts
@@ -143,6 +143,86 @@ describe("routeEditThroughClient", () => {
     );
     expect(routed).toBe(false);
   });
+
+  it("is atomic across multi-file edits: returns false and leaves disk untouched if any file diverged or is missing", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file1 = path.join(dir, "a.txt");
+    const file2 = path.join(dir, "b.txt");
+    fs.writeFileSync(file1, "file1 NEW", "utf8");
+    fs.writeFileSync(file2, "file2 DIVERGED", "utf8");
+    const { bridge, writes } = recordingBridge();
+
+    const routed = await routeEditThroughClient(
+      diffToolCall([
+        { path: file1, oldText: "file1 OLD", newText: "file1 NEW" },
+        { path: file2, oldText: "file2 OLD", newText: "file2 EXPECTED" }
+      ]),
+      bridge
+    );
+
+    expect(routed).toBe(false);
+    expect(writes).toEqual([]);
+    // Disk for file1 must remain completely untouched (not reverted)
+    expect(fs.readFileSync(file1, "utf8")).toBe("file1 NEW");
+    expect(fs.readFileSync(file2, "utf8")).toBe("file2 DIVERGED");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("is atomic across multi-file edits: returns false and restores all files if client fails mid-handoff", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file1 = path.join(dir, "a.txt");
+    const file2 = path.join(dir, "b.txt");
+    fs.writeFileSync(file1, "file1 NEW", "utf8");
+    fs.writeFileSync(file2, "file2 NEW", "utf8");
+
+    const bridge: ClientFileSystem = {
+      readTextFile: async () => {},
+      writeTextFile: async (p) => {
+        if (p === file2) throw new Error("client failed on file2");
+      }
+    };
+
+    const routed = await routeEditThroughClient(
+      diffToolCall([
+        { path: file1, oldText: "file1 OLD", newText: "file1 NEW" },
+        { path: file2, oldText: "file2 OLD", newText: "file2 NEW" }
+      ]),
+      bridge
+    );
+
+    expect(routed).toBe(false);
+    // Both files must be restored to post-edit content
+    expect(fs.readFileSync(file1, "utf8")).toBe("file1 NEW");
+    expect(fs.readFileSync(file2, "utf8")).toBe("file2 NEW");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("routes multi-file edits successfully when all files match", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file1 = path.join(dir, "a.txt");
+    const file2 = path.join(dir, "b.txt");
+    fs.writeFileSync(file1, "file1 NEW", "utf8");
+    fs.writeFileSync(file2, "file2 NEW", "utf8");
+
+    const { bridge, writes } = recordingBridge();
+
+    const routed = await routeEditThroughClient(
+      diffToolCall([
+        { path: file1, oldText: "file1 OLD", newText: "file1 NEW" },
+        { path: file2, oldText: "file2 OLD", newText: "file2 NEW" }
+      ]),
+      bridge
+    );
+
+    expect(routed).toBe(true);
+    expect(writes).toEqual([
+      { path: file1, content: "file1 NEW" },
+      { path: file2, content: "file2 NEW" }
+    ]);
+    expect(fs.readFileSync(file1, "utf8")).toBe("file1 NEW");
+    expect(fs.readFileSync(file2, "utf8")).toBe("file2 NEW");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
 });
 
 describe("primeEditReadThroughClient + writeEditThroughClient", () => {
@@ -183,5 +263,24 @@ describe("primeEditReadThroughClient + writeEditThroughClient", () => {
       bridge
     );
     expect(routed).toBe(false);
+  });
+
+  it("writeEditThroughClient is atomic: returns false if any file in a multi-file edit is missing", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fsbridge-"));
+    const file1 = path.join(dir, "a.txt");
+    fs.writeFileSync(file1, "file1 content", "utf8");
+    const { bridge, writes } = recordingBridge();
+
+    const routed = await writeEditThroughClient(
+      diffToolCall([
+        { path: file1, oldText: "old1", newText: "file1 content" },
+        { path: "/nonexistent/gone.txt", oldText: "old2", newText: "new2" }
+      ]),
+      bridge
+    );
+
+    expect(routed).toBe(false);
+    expect(writes).toEqual([]);
+    fs.rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/tests/edit-revert.test.ts
+++ b/tests/edit-revert.test.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { describe, expect, it } from "vitest";
-import { revertEditToolCall } from "../src/agy/edit/revert.js";
+import { hasUniqueOccurrence, revertEditToolCall } from "../src/agy/edit/revert.js";
 
 function diffToolCall(blocks: Array<{ path: string; oldText: string | null; newText: string }>): SessionUpdate {
   return {
@@ -15,6 +15,22 @@ function diffToolCall(blocks: Array<{ path: string; oldText: string | null; newT
     content: blocks.map((b) => ({ type: "diff" as const, ...b }))
   } as SessionUpdate;
 }
+
+describe("hasUniqueOccurrence", () => {
+  it("returns true for exact unique occurrence", () => {
+    expect(hasUniqueOccurrence("hello world", "world")).toBe(true);
+  });
+
+  it("returns false when string occurs multiple times", () => {
+    expect(hasUniqueOccurrence("hello world hello", "hello")).toBe(false);
+    expect(hasUniqueOccurrence("repeat repeat", "repeat")).toBe(false);
+  });
+
+  it("returns false when string is missing or empty", () => {
+    expect(hasUniqueOccurrence("hello world", "foo")).toBe(false);
+    expect(hasUniqueOccurrence("hello world", "")).toBe(false);
+  });
+});
 
 describe("revertEditToolCall", () => {
   it("restores the prior full-file content", () => {
@@ -38,6 +54,19 @@ describe("revertEditToolCall", () => {
 
     expect(fs.readFileSync(file, "utf8")).toBe("before\nOLD\nafter");
     expect(restored).toEqual([{ path: file, oldText: "OLD", newText: "NEW" }]);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("leaves the file alone when newText appears multiple times (ambiguous match, gh#80)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-revert-"));
+    const file = path.join(dir, "a.txt");
+    const content = "line 1 NEW\nline 2 NEW\nline 3";
+    fs.writeFileSync(file, content, "utf8");
+
+    const restored = revertEditToolCall(diffToolCall([{ path: file, oldText: "OLD", newText: "NEW" }]));
+
+    expect(fs.readFileSync(file, "utf8")).toBe(content);
+    expect(restored).toEqual([]);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Description

This pull request aggregates protocol fidelity improvements, filesystem handoff atomicity, DB-driven task tracking, and session persistence fixes for the `0.4.3` release:

- **Atomic ACP Filesystem Handoff**: Made `routeEditThroughClient` and `writeEditThroughClient` atomic across multi-file edits, preflighting diff blocks for file existence and content divergence before modifying disk or invoking client RPCs.
- **Ambiguous Edit Guard**: Implemented `hasUniqueOccurrence` to prevent ambiguous edit rollbacks or write-through handoffs when replacement text appears multiple times in a file (#80).
- **DB-Driven Background Task Tracking**: Made `StreamPoller` background task tracking 100% DB-driven via SQLite protobuf `task_details` state, preventing generic `stepType 101` markers from clearing active background tasks prematurely (#86).
- **Session Persistence Guard**: Prevented stale or floating v2 prompt turns from resurrecting closed or deleted sessions or overwriting reloaded sessions in the persisted session store (#77).
- **Immediate Process Escalation**: Immediately terminates `agy` backend process via SIGINT->SIGKILL escalation when an ACP `session/update` callback rejects during print mode (#78).

## Related Issues

- Fixes #77
- Fixes #78
- Fixes #79
- Fixes #80
- Fixes #86

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [x] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `npm run build` and it completed without errors
- [x] I have executed `npm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed
