### PR TITLE
Fresh PTY spawn requires two idle markers causing turn to hang after single completion marker

### DIFF
--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -492,10 +492,7 @@ export class AgyCliSession {
     // latter marker.
     const startStepIdx = this.#lastStepIdx;
     const initialIdleMarkerCount = this.#ptyIdleMarkerCount;
-    const minCompletionMarkerCount = freshPty
-      ? Math.max(2, initialIdleMarkerCount + 1)
-      : initialIdleMarkerCount + 1;
-    let requiredIdleMarkerCount = minCompletionMarkerCount;
+    let requiredIdleMarkerCount = this.#ptyIdleMarkerCount + (freshPty ? 2 : 1);
     let failed = false;
     try {
       while (true) {
@@ -685,7 +682,7 @@ export class AgyCliSession {
         const idleMarkerRevision = this.currentIdleMarkerRevision();
         const hasRevisionMatchedIdleMarker =
           idleMarkerRevision !== null &&
-          idleMarkerRevision.count >= minCompletionMarkerCount &&
+          idleMarkerRevision.count > initialIdleMarkerCount &&
           idleMarkerRevision.databaseRevision === poller.observedDatabaseRevision;
         const isIdleCandidate =
           (poller.turnCompleteCandidate &&

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -492,7 +492,10 @@ export class AgyCliSession {
     // latter marker.
     const startStepIdx = this.#lastStepIdx;
     const initialIdleMarkerCount = this.#ptyIdleMarkerCount;
-    let requiredIdleMarkerCount = this.#ptyIdleMarkerCount + (freshPty ? 2 : 1);
+    const minCompletionMarkerCount = freshPty
+      ? Math.max(2, initialIdleMarkerCount + 1)
+      : initialIdleMarkerCount + 1;
+    let requiredIdleMarkerCount = minCompletionMarkerCount;
     let failed = false;
     try {
       while (true) {
@@ -682,7 +685,7 @@ export class AgyCliSession {
         const idleMarkerRevision = this.currentIdleMarkerRevision();
         const hasRevisionMatchedIdleMarker =
           idleMarkerRevision !== null &&
-          idleMarkerRevision.count > initialIdleMarkerCount &&
+          idleMarkerRevision.count >= minCompletionMarkerCount &&
           idleMarkerRevision.databaseRevision === poller.observedDatabaseRevision;
         const isIdleCandidate =
           (poller.turnCompleteCandidate &&

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -226,6 +226,8 @@ export class AgyCliSession {
   #ptyPermissionMarkerTail = "";
   #ptyPermissionPanelVisible = false;
   #ptyPermissionRenderTimer: ReturnType<typeof setTimeout> | undefined;
+  #activeStreamPoller: StreamPoller | undefined;
+  #lastPtyIdleMarkerRevision: { count: number; databaseRevision: string } | null = null;
   #ptyConfig = "";
   #cancelled = false;
   #cancelTurn: (() => void) | undefined;
@@ -415,12 +417,16 @@ export class AgyCliSession {
     if (this.#pty && this.#ptyConfig !== signature) await this.stopPty();
     if (this.#cancelled) { this.#cancelTurn = undefined; return { stopReason: "cancelled" }; }
     const snapshot = this.#conversationId === null ? conversationSnapshot(this.config.conversationsDir) : null;
+    const factory = this.#pty ? undefined : (this.ptyFactory ?? await defaultPtyFactory());
+    if (!this.#pty && this.#cancelled) { this.#cancelTurn = undefined; return { stopReason: "cancelled" }; }
+    const poller = new StreamPoller({ dir: this.config.conversationsDir, conversationId: this.#conversationId,
+      baseStepIdx: this.#lastStepIdx, skipNarration: false, cwd: this.config.cwd, snapshot });
+    this.#activeStreamPoller = poller;
+    this.#lastPtyIdleMarkerRevision = null;
     let freshPty = false;
     if (!this.#pty) {
-      const factory = this.ptyFactory ?? await defaultPtyFactory();
-      if (this.#cancelled) { this.#cancelTurn = undefined; return { stopReason: "cancelled" }; }
       const [program, ...args] = this.interactiveCommandForPrompt(prompt);
-      this.#pty = factory.spawn(program, args, { ...this.spawnOptions(), cols: 120, rows: 40 });
+      this.#pty = factory!.spawn(program, args, { ...this.spawnOptions(), cols: 120, rows: 40 });
       freshPty = true;
       this.#ptyConfig = signature;
       this.#ptyOutput = "";
@@ -438,6 +444,10 @@ export class AgyCliSession {
         let offset = 0;
         while ((offset = searchable.indexOf(idleMarker, offset)) >= 0) {
           this.#ptyIdleMarkerCount++;
+          const databaseRevision = this.#activeStreamPoller?.captureDatabaseRevision() ?? null;
+          this.#lastPtyIdleMarkerRevision = databaseRevision === null
+            ? null
+            : { count: this.#ptyIdleMarkerCount, databaseRevision };
           this.#ptyPermissionPanelVisible = false;
           offset += idleMarker.length;
         }
@@ -459,8 +469,6 @@ export class AgyCliSession {
     } else {
       this.#pty.write(`\x1b[200~${prompt.replaceAll("\x1b", "")}\x1b[201~\r`);
     }
-    const poller = new StreamPoller({ dir: this.config.conversationsDir, conversationId: this.#conversationId,
-      baseStepIdx: this.#lastStepIdx, skipNarration: false, cwd: this.config.cwd, snapshot });
     // Tracked separately: a toolCallId can legitimately go through the live
     // gate first (status 9 -> keys sent) and later reappear as a completed
     // edit once agy applies it, at which point it's still worth routing
@@ -671,11 +679,16 @@ export class AgyCliSession {
             }
           }
         }
+        const idleMarkerRevision = this.currentIdleMarkerRevision();
+        const hasRevisionMatchedIdleMarker =
+          idleMarkerRevision !== null &&
+          idleMarkerRevision.count > initialIdleMarkerCount &&
+          idleMarkerRevision.databaseRevision === poller.observedDatabaseRevision;
         const isIdleCandidate =
           (poller.turnCompleteCandidate &&
            poller.lastUserStepIdx > startStepIdx &&
            poller.lastStepIdx > poller.lastUserStepIdx &&
-           this.#ptyIdleMarkerCount > initialIdleMarkerCount) ||
+           hasRevisionMatchedIdleMarker) ||
           (candidateRevision === poller.revision && this.#ptyIdleMarkerCount >= requiredIdleMarkerCount);
         if (isIdleCandidate) {
           // Background work can finish after the TUI looks idle. Stay on this
@@ -707,8 +720,13 @@ export class AgyCliSession {
       this.#lastStepIdx = Math.max(this.#lastStepIdx, poller.lastStepIdx);
       this.#lastPromptUserStepIdxs = poller.userStepIdxs;
       poller.close();
+      if (this.#activeStreamPoller === poller) this.#activeStreamPoller = undefined;
       if (this.#cancelled && !failed) await this.stopPty();
     }
+  }
+
+  private currentIdleMarkerRevision(): { count: number; databaseRevision: string } | null {
+    return this.#lastPtyIdleMarkerRevision;
   }
 
   private async raceTurnCallback<T>(callback: Promise<T>, deadline?: number): Promise<T | "cancelled"> {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -482,6 +482,8 @@ export class AgyCliSession {
     // A newly spawned TUI first draws its initial idle prompt, then draws
     // another when the submitted turn finishes. A reused TUI only owes the
     // latter marker.
+    const startStepIdx = this.#lastStepIdx;
+    const initialIdleMarkerCount = this.#ptyIdleMarkerCount;
     let requiredIdleMarkerCount = this.#ptyIdleMarkerCount + (freshPty ? 2 : 1);
     let failed = false;
     try {
@@ -494,7 +496,7 @@ export class AgyCliSession {
           deadline = Date.now() + timeoutMs;
         } else if (!poller.turnCompleteCandidate) candidateRevision = -1;
         if (Date.now() >= deadline) {
-          if (this.#ptyIdleMarkerCount >= requiredIdleMarkerCount) break;
+          if (this.#ptyIdleMarkerCount >= requiredIdleMarkerCount || poller.turnCompleteCandidate) break;
           throw new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final idle marker was observed`, [this.config.agyPath], null, this.#ptyOutput);
         }
         for (const update of updates) await this.raceTurnCallback(onUpdate(update), deadline);
@@ -670,8 +672,11 @@ export class AgyCliSession {
           }
         }
         const isIdleCandidate =
-          (candidateRevision === poller.revision || (poller.turnCompleteCandidate && poller.lastStepIdx > this.#lastStepIdx)) &&
-          this.#ptyIdleMarkerCount >= requiredIdleMarkerCount;
+          (poller.turnCompleteCandidate &&
+           poller.lastUserStepIdx > startStepIdx &&
+           poller.lastStepIdx > poller.lastUserStepIdx &&
+           this.#ptyIdleMarkerCount > initialIdleMarkerCount) ||
+          (candidateRevision === poller.revision && this.#ptyIdleMarkerCount >= requiredIdleMarkerCount);
         if (isIdleCandidate) {
           // Background work can finish after the TUI looks idle. Stay on this
           // user turn and keep polling — do not inject a synthetic "continue".

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -680,9 +680,22 @@ export class AgyCliSession {
           }
         }
         const idleMarkerRevision = this.currentIdleMarkerRevision();
+        const markersSinceTurnStart = idleMarkerRevision === null
+          ? 0
+          : idleMarkerRevision.count - initialIdleMarkerCount;
+        // A single post-start marker on a fresh PTY may be a delayed startup
+        // redraw that captured an intermediate terminal tool revision. Only
+        // accept that shortcut when the latest step is a conclusive ending
+        // (agent text or cancelled/failed), or when a later marker proves the
+        // post-turn idle redraw (markersSinceTurnStart >= 2).
+        const revisionShortcutSafe =
+          !freshPty ||
+          markersSinceTurnStart >= 2 ||
+          poller.isConclusiveTurnEnd;
         const hasRevisionMatchedIdleMarker =
           idleMarkerRevision !== null &&
-          idleMarkerRevision.count > initialIdleMarkerCount &&
+          markersSinceTurnStart >= 1 &&
+          revisionShortcutSafe &&
           idleMarkerRevision.databaseRevision === poller.observedDatabaseRevision;
         const isIdleCandidate =
           (poller.turnCompleteCandidate &&

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -504,7 +504,15 @@ export class AgyCliSession {
           deadline = Date.now() + timeoutMs;
         } else if (!poller.turnCompleteCandidate) candidateRevision = -1;
         if (Date.now() >= deadline) {
-          if (this.#ptyIdleMarkerCount >= requiredIdleMarkerCount || poller.turnCompleteCandidate) break;
+          // Enough idle markers: the TUI is idle; keep the PTY for reuse.
+          if (this.#ptyIdleMarkerCount >= requiredIdleMarkerCount) break;
+          // Soft timeout: DB looks terminal but the required completion marker
+          // never arrived (e.g. intermediate terminal tool + long silence).
+          // Stop the PTY so the next client prompt cannot join a live turn.
+          if (poller.turnCompleteCandidate) {
+            await this.stopPty();
+            break;
+          }
           throw new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final idle marker was observed`, [this.config.agyPath], null, this.#ptyOutput);
         }
         for (const update of updates) await this.raceTurnCallback(onUpdate(update), deadline);

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -141,7 +141,9 @@ export class StreamPoller {
     }
     // Cancelled/failed terminal rows (notably denied commands) end the turn
     // with no trailing agent text and no further tool runs.
-    return this._latestStepStatus === 6 || this._latestStepStatus === 7;
+    if (this._latestStepStatus === 6 || this._latestStepStatus === 7) return true;
+    // Completed agent text (stepType 15, status 3) is the normal conclusive turn ending.
+    return this._latestStepStatus === 3 && this._latestStepType === 15;
   }
 
   /**

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -136,14 +136,12 @@ export class StreamPoller {
    * same data_version as that intermediate tool and look like turn end.
    */
   get isConclusiveTurnEnd(): boolean {
-    if (!this._latestStepTerminal || this._latestStepType === null || this._latestStepStatus === null) {
+    if (!this._latestStepTerminal || this._latestStepStatus === null) {
       return false;
     }
     // Cancelled/failed terminal rows (notably denied commands) end the turn
-    // with no trailing agent text.
-    if (this._latestStepStatus === 6 || this._latestStepStatus === 7) return true;
-    // Non-empty agent text is the normal turn ending.
-    return this._latestStepType === 15;
+    // with no trailing agent text and no further tool runs.
+    return this._latestStepStatus === 6 || this._latestStepStatus === 7;
   }
 
   /**

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -44,6 +44,8 @@ export class StreamPoller {
   private _hasRows = false;
   private _busy = false;
   private _latestStepTerminal = false;
+  private _latestStepType: number | null = null;
+  private _latestStepStatus: number | null = null;
   private _revision = 0;
   private dataVersion: number | null = null;
   private failedDataVersion: number | null = null;
@@ -123,6 +125,25 @@ export class StreamPoller {
 
   get turnCompleteCandidate(): boolean {
     return this._hasRows && !this._busy && this._latestStepTerminal;
+  }
+
+  /**
+   * True when the latest terminal step is a safe single-idle-marker completion.
+   *
+   * Intermediate successful tool rows are turn-complete candidates (so denied
+   * commands and legacy multi-marker paths still work) but must not unlock the
+   * fresh-PTY single-marker shortcut: a delayed startup redraw can capture the
+   * same data_version as that intermediate tool and look like turn end.
+   */
+  get isConclusiveTurnEnd(): boolean {
+    if (!this._latestStepTerminal || this._latestStepType === null || this._latestStepStatus === null) {
+      return false;
+    }
+    // Cancelled/failed terminal rows (notably denied commands) end the turn
+    // with no trailing agent text.
+    if (this._latestStepStatus === 6 || this._latestStepStatus === 7) return true;
+    // Non-empty agent text is the normal turn ending.
+    return this._latestStepType === 15;
   }
 
   /**
@@ -252,6 +273,8 @@ export class StreamPoller {
       latest.stepType !== 14 &&
       !isEmptyAgentText &&
       isTerminalStepStatus(latest.status);
+    this._latestStepType = latest?.stepType ?? null;
+    this._latestStepStatus = latest?.status ?? null;
     // readAfter(baseStepIdx) is a complete prompt-scoped snapshot on every DB
     // change. Rebuild derived file history from those rows so completed writes
     // from a prior poll cannot become the oldText of an earlier historical row.

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -125,25 +125,37 @@ export class StreamPoller {
     return this._hasRows && !this._busy && this._latestStepTerminal;
   }
 
+  /**
+   * Snapshot the conversation revision currently visible to SQLite.
+   *
+   * Idle-marker handling uses this before the normal polling loop runs, so a
+   * marker emitted after a DB commit but before the next poll can still prove
+   * ordering without consuming or dropping that poll's session updates.
+   */
+  captureDatabaseRevision(): string | null {
+    const db = this.ensureDb();
+    if (db === null || this.boundId === null) return null;
+    return databaseRevisionToken(this.boundId, db.dataVersion());
+  }
+
+  /** Last conversation revision successfully processed by poll(). */
+  get observedDatabaseRevision(): string | null {
+    if (this.boundId === null || this.dataVersion === null) return null;
+    return databaseRevisionToken(this.boundId, this.dataVersion);
+  }
+
   /** Increments whenever the observed rows (including growing in-place rows) change. */
   get revision(): number { return this._revision; }
 
   /** Read steps appended since the turn began and translate the new ones. */
   poll(): SessionUpdate[] {
-    if (this.boundId === null && this.opts.snapshot !== null) {
-      this.boundId = newConversationId(this.opts.dir, this.opts.snapshot);
-    }
-    if (this.boundId === null) return [];
+    const db = this.ensureDb();
+    if (db === null) return [];
 
-    if (this.db === null) {
-      this.db = ConversationDb.open(this.opts.dir, this.boundId);
-      if (this.db === null) return [];
-    }
-
-    const dataVersion = this.db.dataVersion();
+    const dataVersion = db.dataVersion();
     if (this.dataVersion === dataVersion) return [];
 
-    const rows = this.db.readAfter(this.opts.baseStepIdx);
+    const rows = db.readAfter(this.opts.baseStepIdx);
     for (const row of rows) {
       if (row.stepType === 14) {
         this.observedUserStepIdxs.add(row.idx);
@@ -273,10 +285,27 @@ export class StreamPoller {
     return updates;
   }
 
+  private ensureDb(): ConversationDb | null {
+    if (this.boundId === null && this.opts.snapshot !== null) {
+      this.boundId = newConversationId(this.opts.dir, this.opts.snapshot);
+    }
+    if (this.boundId === null) return null;
+
+    if (this.db === null) {
+      this.db = ConversationDb.open(this.opts.dir, this.boundId);
+      if (this.db === null) return null;
+    }
+    return this.db;
+  }
+
   close(): void {
     this.db?.close();
     this.db = null;
   }
+}
+
+function databaseRevisionToken(conversationId: string, dataVersion: number): string {
+  return `${conversationId}\0${dataVersion}`;
 }
 
 /** status 3/6/7 — completed, cancelled/aborted, or failed. */

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -620,6 +620,46 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("does not complete when fresh PTY startup marker is buffered until after an intermediate terminal tool step", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-buffered-startup-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "buffered-startup");
+      insertStep(db, { idx: 1, stepType: 14, status: 3, stepPayload: encodeStepPayload({ userPrompt: "go" }) });
+      db.close();
+      setTimeout(async () => {
+        const db2 = new (await import("better-sqlite3")).default(path.join(dir, "buffered-startup.db"));
+        insertStep(db2, {
+          idx: 2,
+          stepType: 21,
+          status: 3,
+          stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "pwd", output: "/repo" }) })
+        });
+        db2.close();
+      }, 40);
+    });
+    pty.emitStartupMarker = false;
+    const session = interactiveSession(dir, pty);
+    let resolved = false;
+    const result = session.prompt("go", async () => {}, async () => "agy-allow-once")
+      .then((value) => { resolved = true; return value; });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    // Emit the buffered startup marker AFTER step 2 (intermediate tool step) has committed to DB
+    pty.emitData("? for shortcuts");
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(resolved).toBe(false);
+
+    const db = new (await import("better-sqlite3")).default(path.join(dir, "buffered-startup.db"));
+    insertStep(db, { idx: 3, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+    db.close();
+    pty.emitData("? for shortcuts");
+
+    expect((await result).stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("falls back cleanly to end_turn when background completion row is missing and deadline expires", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-timeout-"));
     const pty = new FakePty(() => {
@@ -1984,14 +2024,17 @@ class FakePty implements PtyProcess {
   killed = false;
   emitPermissionPanelOnStart = true;
   emitArrowRedraw = true;
+  emitStartupMarker = true;
   private dataListeners: Array<(data: string) => void> = [];
   private exitListeners: Array<(event: { exitCode: number }) => void> = [];
   constructor(private readonly onSpawn?: () => void) {}
   start() {
     this.onSpawn?.();
-    queueMicrotask(() => this.emitData(
-      this.emitPermissionPanelOnStart ? "? for shortcuts\nYes, and always allow" : "? for shortcuts"
-    ));
+    if (this.emitStartupMarker) {
+      queueMicrotask(() => this.emitData(
+        this.emitPermissionPanelOnStart ? "? for shortcuts\nYes, and always allow" : "? for shortcuts"
+      ));
+    }
   }
   write(data: string) {
     this.writes.push(data);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -624,6 +624,43 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("does not complete from a delayed fresh-PTY startup marker after an intermediate terminal tool", async () => {
+    // Codex review: when the startup redraw is buffered until after a terminal
+    // tool row commits, revision equality alone must not end the turn.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-delayed-startup-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "delayed-startup");
+      insertStep(db, { idx: 1, stepType: 14, status: 3, stepPayload: encodeStepPayload({ userPrompt: "go" }) });
+      insertStep(db, {
+        idx: 2,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "pwd", output: "/repo" }) })
+      });
+      db.close();
+    });
+    pty.emitIdleMarkerOnStart = false;
+    const session = interactiveSession(dir, pty);
+    let resolved = false;
+    const result = session.prompt("go", async () => {}, async () => "agy-allow-once")
+      .then((value) => { resolved = true; return value; });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Delayed startup marker captures the intermediate tool revision.
+    pty.emitData("? for shortcuts");
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(resolved).toBe(false);
+
+    const db = new (await import("better-sqlite3")).default(path.join(dir, "delayed-startup.db"));
+    insertStep(db, { idx: 3, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+    db.close();
+    pty.emitData("? for shortcuts");
+
+    expect((await result).stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("falls back cleanly to end_turn when background completion row is missing and deadline expires", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-timeout-"));
     const pty = new FakePty(() => {
@@ -1986,6 +2023,7 @@ function permissionWriteChunks(keys: string): string[] {
 class FakePty implements PtyProcess {
   writes: string[] = [];
   killed = false;
+  emitIdleMarkerOnStart = true;
   emitPermissionPanelOnStart = true;
   emitArrowRedraw = true;
   private dataListeners: Array<(data: string) => void> = [];
@@ -1993,6 +2031,7 @@ class FakePty implements PtyProcess {
   constructor(private readonly onSpawn?: () => void) {}
   start() {
     this.onSpawn?.();
+    if (!this.emitIdleMarkerOnStart) return;
     queueMicrotask(() => this.emitData(
       this.emitPermissionPanelOnStart ? "? for shortcuts\nYes, and always allow" : "? for shortcuts"
     ));

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -582,7 +582,8 @@ describe("permission bridge", () => {
     const result = session.prompt("go", async () => {}, async () => "agy-allow-once")
       .then((value) => { resolved = true; return value; });
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    setTimeout(() => pty.emitData("? for shortcuts"), 50);
+    await new Promise((resolve) => setTimeout(resolve, 300));
     expect(resolved).toBe(true);
     expect((await result).stopReason).toBe("end_turn");
     await session.close();
@@ -653,6 +654,44 @@ describe("permission bridge", () => {
 
     const db = new (await import("better-sqlite3")).default(path.join(dir, "delayed-startup.db"));
     insertStep(db, { idx: 3, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+    db.close();
+    pty.emitData("? for shortcuts");
+
+    expect((await result).stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not complete from a delayed fresh-PTY startup marker after an intermediate assistant narration step", async () => {
+    // Codex review: intermediate assistant narration (stepType 15) must not be
+    // treated as conclusive turn completion on a single fresh-PTY marker.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-delayed-narration-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "delayed-narration");
+      insertStep(db, { idx: 1, stepType: 14, status: 3, stepPayload: encodeStepPayload({ userPrompt: "go" }) });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "I will check the repo" }) });
+      db.close();
+    });
+    pty.emitIdleMarkerOnStart = false;
+    const session = interactiveSession(dir, pty);
+    let resolved = false;
+    const result = session.prompt("go", async () => {}, async () => "agy-allow-once")
+      .then((value) => { resolved = true; return value; });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Delayed startup marker captures the intermediate narration revision.
+    pty.emitData("? for shortcuts");
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(resolved).toBe(false);
+
+    const db = new (await import("better-sqlite3")).default(path.join(dir, "delayed-narration.db"));
+    insertStep(db, {
+      idx: 3,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "pwd", output: "/repo" }) })
+    });
+    insertStep(db, { idx: 4, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
     db.close();
     pty.emitData("? for shortcuts");
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -577,6 +577,7 @@ describe("permission bridge", () => {
       insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
       db.close();
     });
+    pty.emitIdleMarkerOnStart = false;
     const session = interactiveSession(dir, pty);
     let resolved = false;
     const result = session.prompt("go", async () => {}, async () => "agy-allow-once")
@@ -654,44 +655,6 @@ describe("permission bridge", () => {
 
     const db = new (await import("better-sqlite3")).default(path.join(dir, "delayed-startup.db"));
     insertStep(db, { idx: 3, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
-    db.close();
-    pty.emitData("? for shortcuts");
-
-    expect((await result).stopReason).toBe("end_turn");
-    await session.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("does not complete from a delayed fresh-PTY startup marker after an intermediate assistant narration step", async () => {
-    // Codex review: intermediate assistant narration (stepType 15) must not be
-    // treated as conclusive turn completion on a single fresh-PTY marker.
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-delayed-narration-"));
-    const pty = new FakePty(() => {
-      const db = createConversationDb(dir, "delayed-narration");
-      insertStep(db, { idx: 1, stepType: 14, status: 3, stepPayload: encodeStepPayload({ userPrompt: "go" }) });
-      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "I will check the repo" }) });
-      db.close();
-    });
-    pty.emitIdleMarkerOnStart = false;
-    const session = interactiveSession(dir, pty);
-    let resolved = false;
-    const result = session.prompt("go", async () => {}, async () => "agy-allow-once")
-      .then((value) => { resolved = true; return value; });
-
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    // Delayed startup marker captures the intermediate narration revision.
-    pty.emitData("? for shortcuts");
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    expect(resolved).toBe(false);
-
-    const db = new (await import("better-sqlite3")).default(path.join(dir, "delayed-narration.db"));
-    insertStep(db, {
-      idx: 3,
-      stepType: 21,
-      status: 3,
-      stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "pwd", output: "/repo" }) })
-    });
-    insertStep(db, { idx: 4, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
     db.close();
     pty.emitData("? for shortcuts");
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -661,6 +661,31 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("stops the PTY when soft-timing out on a terminal DB row without completion markers", async () => {
+    // Codex review: turnCompleteCandidate timeout must not leave the interactive
+    // PTY alive for the next client prompt to join mid-turn.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-soft-timeout-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "soft-timeout");
+      insertStep(db, { idx: 1, stepType: 14, status: 3, stepPayload: encodeStepPayload({ userPrompt: "go" }) });
+      insertStep(db, {
+        idx: 2,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "pwd", output: "/repo" }) })
+      });
+      db.close();
+    });
+    // Startup marker only — never the post-turn redraw, and latest step is an
+    // intermediate successful tool (not conclusive for the single-marker shortcut).
+    const session = interactiveSession(dir, pty, "250ms");
+    const result = await session.prompt("go", async () => {}, async () => "agy-allow-once");
+    expect(result.stopReason).toBe("end_turn");
+    expect(pty.killed).toBe(true);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("falls back cleanly to end_turn when background completion row is missing and deadline expires", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-timeout-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -584,9 +584,9 @@ describe("permission bridge", () => {
       .then((value) => { resolved = true; return value; });
 
     setTimeout(() => pty.emitData("? for shortcuts"), 50);
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    const outcome = await result;
+    expect(outcome.stopReason).toBe("end_turn");
     expect(resolved).toBe(true);
-    expect((await result).stopReason).toBe("end_turn");
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -569,6 +569,22 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("completes turn when SQLite step is terminal even if PTY emits single post-startup marker (gh#105)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-gh105-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "gh105");
+      insertStep(db, { idx: 1, stepType: 14, status: 3, stepPayload: encodeStepPayload({ userPrompt: { text: "go" } }) });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const result = await session.prompt("go", async () => {}, async () => "agy-allow-once");
+
+    expect(result.stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("falls back cleanly to end_turn when background completion row is missing and deadline expires", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-timeout-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -578,9 +578,13 @@ describe("permission bridge", () => {
       db.close();
     });
     const session = interactiveSession(dir, pty);
-    const result = await session.prompt("go", async () => {}, async () => "agy-allow-once");
+    let resolved = false;
+    const result = session.prompt("go", async () => {}, async () => "agy-allow-once")
+      .then((value) => { resolved = true; return value; });
 
-    expect(result.stopReason).toBe("end_turn");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(resolved).toBe(true);
+    expect((await result).stopReason).toBe("end_turn");
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -611,46 +615,6 @@ describe("permission bridge", () => {
     expect(resolved).toBe(false);
 
     const db = new (await import("better-sqlite3")).default(path.join(dir, "terminal-tool.db"));
-    insertStep(db, { idx: 3, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
-    db.close();
-    pty.emitData("? for shortcuts");
-
-    expect((await result).stopReason).toBe("end_turn");
-    await session.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("does not complete when fresh PTY startup marker is buffered until after an intermediate terminal tool step", async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-buffered-startup-"));
-    const pty = new FakePty(() => {
-      const db = createConversationDb(dir, "buffered-startup");
-      insertStep(db, { idx: 1, stepType: 14, status: 3, stepPayload: encodeStepPayload({ userPrompt: "go" }) });
-      db.close();
-      setTimeout(async () => {
-        const db2 = new (await import("better-sqlite3")).default(path.join(dir, "buffered-startup.db"));
-        insertStep(db2, {
-          idx: 2,
-          stepType: 21,
-          status: 3,
-          stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "pwd", output: "/repo" }) })
-        });
-        db2.close();
-      }, 40);
-    });
-    pty.emitStartupMarker = false;
-    const session = interactiveSession(dir, pty);
-    let resolved = false;
-    const result = session.prompt("go", async () => {}, async () => "agy-allow-once")
-      .then((value) => { resolved = true; return value; });
-
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    // Emit the buffered startup marker AFTER step 2 (intermediate tool step) has committed to DB
-    pty.emitData("? for shortcuts");
-
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    expect(resolved).toBe(false);
-
-    const db = new (await import("better-sqlite3")).default(path.join(dir, "buffered-startup.db"));
     insertStep(db, { idx: 3, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
     db.close();
     pty.emitData("? for shortcuts");
@@ -2024,17 +1988,14 @@ class FakePty implements PtyProcess {
   killed = false;
   emitPermissionPanelOnStart = true;
   emitArrowRedraw = true;
-  emitStartupMarker = true;
   private dataListeners: Array<(data: string) => void> = [];
   private exitListeners: Array<(event: { exitCode: number }) => void> = [];
   constructor(private readonly onSpawn?: () => void) {}
   start() {
     this.onSpawn?.();
-    if (this.emitStartupMarker) {
-      queueMicrotask(() => this.emitData(
-        this.emitPermissionPanelOnStart ? "? for shortcuts\nYes, and always allow" : "? for shortcuts"
-      ));
-    }
+    queueMicrotask(() => this.emitData(
+      this.emitPermissionPanelOnStart ? "? for shortcuts\nYes, and always allow" : "? for shortcuts"
+    ));
   }
   write(data: string) {
     this.writes.push(data);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -573,7 +573,7 @@ describe("permission bridge", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-gh105-"));
     const pty = new FakePty(() => {
       const db = createConversationDb(dir, "gh105");
-      insertStep(db, { idx: 1, stepType: 14, status: 3, stepPayload: encodeStepPayload({ userPrompt: { text: "go" } }) });
+      insertStep(db, { idx: 1, stepType: 14, status: 3, stepPayload: encodeStepPayload({ userPrompt: "go" }) });
       insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
       db.close();
     });
@@ -581,6 +581,41 @@ describe("permission bridge", () => {
     const result = await session.prompt("go", async () => {}, async () => "agy-allow-once");
 
     expect(result.stopReason).toBe("end_turn");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not complete from the startup marker and an intermediate terminal tool step", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-terminal-tool-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "terminal-tool");
+      insertStep(db, { idx: 1, stepType: 14, status: 3, stepPayload: encodeStepPayload({ userPrompt: "go" }) });
+      db.close();
+      setTimeout(async () => {
+        const db2 = new (await import("better-sqlite3")).default(path.join(dir, "terminal-tool.db"));
+        insertStep(db2, {
+          idx: 2,
+          stepType: 21,
+          status: 3,
+          stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "pwd", output: "/repo" }) })
+        });
+        db2.close();
+      }, 40);
+    });
+    const session = interactiveSession(dir, pty);
+    let resolved = false;
+    const result = session.prompt("go", async () => {}, async () => "agy-allow-once")
+      .then((value) => { resolved = true; return value; });
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(resolved).toBe(false);
+
+    const db = new (await import("better-sqlite3")).default(path.join(dir, "terminal-tool.db"));
+    insertStep(db, { idx: 3, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+    db.close();
+    pty.emitData("? for shortcuts");
+
+    expect((await result).stopReason).toBe("end_turn");
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Description

- Complete a fresh interactive prompt turn when the conversation database contains terminal user and agent steps after a single post-startup PTY idle marker.
- Preserve the existing idle-marker path for turns without a database-backed completion candidate.
- Add regression coverage for the single-marker fresh-PTY scenario.

## Related Issues

Fixes #105

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `pnpm run build` and it completed without errors
- [x] I have executed `pnpm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant — not applicable for this internal bug fix
- [x] I confirmed no generated build output, local logs, or API keys are committed