### PR TITLE
Fetch latest models from agy CLI on launch in background while applying cache immediately

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -123,7 +123,7 @@ const packageJson = require("../../package.json") as { version?: string };
 const REPLAY_CACHE_CAPACITY = 32;
 const MODEL_CACHE_TTL_MS = 5 * 60_000;
 const DEFAULT_MAX_ACTIVE_SESSIONS = 64;
-const inFlightModelRefreshes = new Map<string, Promise<void>>();
+const inFlightModelRefreshes = new Map<string, Promise<string[]>>();
 
 interface ModelCacheFile {
   entries: Record<string, { models: string[]; updatedAt: number }>;
@@ -594,22 +594,34 @@ export class AcpAgent {
 
   private refreshModelOptions(config: AgyCliConfig): Promise<void> {
     const key = config.agyPath;
+    const localInFlight = this.#modelRefreshes.get(key);
+    if (localInFlight) return localInFlight;
+
     const processKey = `${config.agyPath}:${this.#modelCacheFile}`;
-    const inFlight = inFlightModelRefreshes.get(processKey) ?? this.#modelRefreshes.get(key);
-    if (inFlight) return inFlight;
-    const refresh = (async () => {
-      await this.ensureAgyReady();
-      const models = await this.#backend.listModels(config);
-      if (models.length > 0) this.cacheModelOptions(key, models);
-    })()
-      .catch(() => {})
+    let sharedInFlight = inFlightModelRefreshes.get(processKey);
+    if (!sharedInFlight) {
+      sharedInFlight = (async () => {
+        await this.ensureAgyReady();
+        return this.#backend.listModels(config);
+      })()
+        .catch(() => [] as string[])
+        .finally(() => {
+          inFlightModelRefreshes.delete(processKey);
+        });
+      inFlightModelRefreshes.set(processKey, sharedInFlight);
+    }
+
+    const localRefresh = sharedInFlight
+      .then((models) => {
+        if (models.length > 0) {
+          this.cacheModelOptions(key, models);
+        }
+      })
       .finally(() => {
-        inFlightModelRefreshes.delete(processKey);
         this.#modelRefreshes.delete(key);
       });
-    inFlightModelRefreshes.set(processKey, refresh);
-    this.#modelRefreshes.set(key, refresh);
-    return refresh;
+    this.#modelRefreshes.set(key, localRefresh);
+    return localRefresh;
   }
 
   private buildSession(

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -90,6 +90,7 @@ import { handleLogout } from "./logout.js";
 import { handleLoginAuth } from "./auth/login.js";
 import { handleLogoutAuth } from "./auth/logout.js";
 import type { SessionState } from "./session/types.js";
+import { buildModelCatalog } from "../agy/model/catalog.js";
 import { applyConfigOption as applyConfigOptionHandler } from "./session/config-options.js";
 import { handleSetConfigOptionV1, handleSetConfigOptionV2 } from "./session/set-config-option.js";
 import {
@@ -175,10 +176,26 @@ export class AcpAgent {
         : DEFAULT_MAX_ACTIVE_SESSIONS;
     this.#conversationsDir = options.conversationsDir;
     this.loadModelCache();
+    if (this.#modelCacheEnabled) {
+      const config = this.authProbeConfig();
+      const key = config.agyPath;
+      const cached = this.#modelOptionsCache.get(key);
+      if (!cached || Date.now() - cached.updatedAt >= MODEL_CACHE_TTL_MS) {
+        this.refreshModelOptions(config);
+      }
+    }
   }
 
   async initializeV1(params: V1InitializeRequest): Promise<V1InitializeResponse> {
     await this.ensureAgyReady();
+    if (this.#modelCacheEnabled) {
+      const config = this.authProbeConfig();
+      const key = config.agyPath;
+      const cached = this.#modelOptionsCache.get(key);
+      if (!cached || Date.now() - cached.updatedAt >= MODEL_CACHE_TTL_MS) {
+        this.refreshModelOptions(config);
+      }
+    }
     const { response, clientFs, clientElicitation, clientToolCallName } = handleInitializeV1(params, packageJson.version ?? "0.0.0");
     this.#clientFs = clientFs;
     this.#clientElicitation = clientElicitation;
@@ -188,6 +205,14 @@ export class AcpAgent {
 
   async initializeV2(params: V2InitializeRequest): Promise<V2InitializeResponse> {
     await this.ensureAgyReady();
+    if (this.#modelCacheEnabled) {
+      const config = this.authProbeConfig();
+      const key = config.agyPath;
+      const cached = this.#modelOptionsCache.get(key);
+      if (!cached || Date.now() - cached.updatedAt >= MODEL_CACHE_TTL_MS) {
+        this.refreshModelOptions(config);
+      }
+    }
     const { response, clientElicitation, clientToolCallName } = handleInitializeV2(params, packageJson.version ?? "0.0.0");
     this.#clientElicitation = clientElicitation;
     this.#clientToolCallName = clientToolCallName;
@@ -485,12 +510,24 @@ export class AcpAgent {
       return cached.models;
     }
 
+    const inFlight = this.#modelRefreshes.get(key);
+    if (inFlight) {
+      try {
+        await inFlight;
+        const refreshed = this.#modelOptionsCache.get(key);
+        if (refreshed?.models.length) {
+          return refreshed.models;
+        }
+      } catch {}
+    }
+
     try {
-      const models = await this.#backend.listModels(config);
-      if (models.length > 0) {
-        this.cacheModelOptions(key, models);
+      await this.refreshModelOptions(config);
+      const refreshed = this.#modelOptionsCache.get(key);
+      if (refreshed?.models.length) {
+        return refreshed.models;
       }
-      return models;
+      return config.model ? [config.model] : [];
     } catch {
       return config.model ? [config.model] : [];
     }
@@ -515,6 +552,11 @@ export class AcpAgent {
   private cacheModelOptions(key: string, models: string[]): void {
     const normalized = [...new Set(models)];
     this.#modelOptionsCache.set(key, { models: normalized, updatedAt: Date.now() });
+    for (const session of this.#sessions.values()) {
+      if (session.agy.config.agyPath === key) {
+        session.catalog = buildModelCatalog(normalized);
+      }
+    }
     if (!this.#modelCacheEnabled) return;
 
     this.#modelCacheWrite = this.#modelCacheWrite
@@ -530,18 +572,21 @@ export class AcpAgent {
       });
   }
 
-  private refreshModelOptions(config: AgyCliConfig): void {
+  private refreshModelOptions(config: AgyCliConfig): Promise<void> {
     const key = config.agyPath;
-    if (this.#modelRefreshes.has(key)) return;
-    const refresh = this.#backend.listModels(config)
-      .then((models) => {
-        if (models.length > 0) this.cacheModelOptions(key, models);
-      })
+    const inFlight = this.#modelRefreshes.get(key);
+    if (inFlight) return inFlight;
+    const refresh = (async () => {
+      await this.ensureAgyReady();
+      const models = await this.#backend.listModels(config);
+      if (models.length > 0) this.cacheModelOptions(key, models);
+    })()
       .catch(() => {})
       .finally(() => {
         this.#modelRefreshes.delete(key);
       });
     this.#modelRefreshes.set(key, refresh);
+    return refresh;
   }
 
   private buildSession(

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -569,9 +569,15 @@ export class AcpAgent {
           session.selectedReasoningEffort,
           newCatalog
         );
+        const selectionChanged =
+          selection.baseModel !== session.selectedBaseModel ||
+          selection.reasoningEffort !== session.selectedReasoningEffort;
         session.selectedBaseModel = selection.baseModel;
         session.selectedReasoningEffort = selection.reasoningEffort;
         applyModelSelection(session.agy, selection.baseModel, selection.reasoningEffort, newCatalog);
+        if (selectionChanged && session.sessionId) {
+          this.persistSession(session.sessionId, session).catch(() => {});
+        }
         if (session.v1Client) {
           notifyConfigOptionUpdateV1(session.v1Client, session.sessionId, session).catch(() => {});
         } else if (session.v2Client) {
@@ -662,9 +668,15 @@ export class AcpAgent {
       session.selectedReasoningEffort,
       newCatalog
     );
+    const selectionChanged =
+      selection.baseModel !== session.selectedBaseModel ||
+      selection.reasoningEffort !== session.selectedReasoningEffort;
     session.selectedBaseModel = selection.baseModel;
     session.selectedReasoningEffort = selection.reasoningEffort;
     applyModelSelection(session.agy, selection.baseModel, selection.reasoningEffort, newCatalog);
+    if (selectionChanged && session.sessionId) {
+      this.persistSession(session.sessionId, session).catch(() => {});
+    }
   }
 
   private persistSession(sessionId: string, session: SessionState): Promise<void> {

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -91,6 +91,7 @@ import { handleLoginAuth } from "./auth/login.js";
 import { handleLogoutAuth } from "./auth/logout.js";
 import type { SessionState } from "./session/types.js";
 import { buildModelCatalog } from "../agy/model/catalog.js";
+import { applyModelSelection, restoredModelSelection } from "../agy/model/selection.js";
 import { applyConfigOption as applyConfigOptionHandler } from "./session/config-options.js";
 import { handleSetConfigOptionV1, handleSetConfigOptionV2 } from "./session/set-config-option.js";
 import {
@@ -552,9 +553,18 @@ export class AcpAgent {
   private cacheModelOptions(key: string, models: string[]): void {
     const normalized = [...new Set(models)];
     this.#modelOptionsCache.set(key, { models: normalized, updatedAt: Date.now() });
+    const newCatalog = buildModelCatalog(normalized);
     for (const session of this.#sessions.values()) {
       if (session.agy.config.agyPath === key) {
-        session.catalog = buildModelCatalog(normalized);
+        session.catalog = newCatalog;
+        const selection = restoredModelSelection(
+          session.selectedBaseModel,
+          session.selectedReasoningEffort,
+          newCatalog
+        );
+        session.selectedBaseModel = selection.baseModel;
+        session.selectedReasoningEffort = selection.reasoningEffort;
+        applyModelSelection(session.agy, selection.baseModel, selection.reasoningEffort, newCatalog);
       }
     }
     if (!this.#modelCacheEnabled) return;

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -444,16 +444,18 @@ export class AcpAgent {
     return handleDeleteSession(params, this.#sessions, this.#store);
   }
 
-  private createSession(
+  private async createSession(
     requestedCwd: string | undefined,
     requestedDirs: string[] | undefined
   ): Promise<SessionState> {
-    return createSession(requestedCwd, requestedDirs, {
+    const session = await createSession(requestedCwd, requestedDirs, {
       ...this.sessionBuildDeps(),
       sessions: this.#sessions,
       maxActiveSessions: this.#maxActiveSessions,
       persistSession: (sessionId, session) => this.persistSession(sessionId, session)
     });
+    this.reconcileSessionCatalog(session);
+    return session;
   }
 
   private applyConfigOption(sessionId: string, configId: string, value: unknown): Promise<void> {
@@ -634,17 +636,35 @@ export class AcpAgent {
 
   /** Shared reconstruction for `session/load` and `session/resume`: restore a
    *  persisted session binding and re-register it in memory. */
-  private reloadSession(
+  private async reloadSession(
     sessionId: string,
     requestedCwd: string | undefined,
     requestedDirs: string[] | undefined
   ): Promise<{ session: SessionState; cwd: string; stored: StoredSession }> {
-    return reloadSession(sessionId, requestedCwd, requestedDirs, {
+    const result = await reloadSession(sessionId, requestedCwd, requestedDirs, {
       ...this.sessionBuildDeps(),
       store: this.#store,
       sessions: this.#sessions,
       maxActiveSessions: this.#maxActiveSessions
     });
+    this.reconcileSessionCatalog(result.session);
+    return result;
+  }
+
+  private reconcileSessionCatalog(session: SessionState): void {
+    const key = session.agy.config.agyPath;
+    const cached = this.#modelOptionsCache.get(key);
+    if (!cached || cached.models.length === 0) return;
+    const newCatalog = buildModelCatalog(cached.models);
+    session.catalog = newCatalog;
+    const selection = restoredModelSelection(
+      session.selectedBaseModel,
+      session.selectedReasoningEffort,
+      newCatalog
+    );
+    session.selectedBaseModel = selection.baseModel;
+    session.selectedReasoningEffort = selection.reasoningEffort;
+    applyModelSelection(session.agy, selection.baseModel, selection.reasoningEffort, newCatalog);
   }
 
   private persistSession(sessionId: string, session: SessionState): Promise<void> {

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -142,7 +142,17 @@ function persistModelCache(
       } catch {
         // Missing or malformed caches will be overwritten.
       }
-      const mergedEntries = { ...existingEntries, ...entries };
+      const mergedEntries: Record<string, { models: string[]; updatedAt: number }> = { ...existingEntries };
+      for (const [key, entry] of Object.entries(entries)) {
+        const existing = mergedEntries[key];
+        if (
+          !existing ||
+          !Number.isFinite(existing.updatedAt) ||
+          (Number.isFinite(entry.updatedAt) && entry.updatedAt >= existing.updatedAt)
+        ) {
+          mergedEntries[key] = entry;
+        }
+      }
       await fs.promises.mkdir(path.dirname(cacheFile), { recursive: true });
       const tmp = `${cacheFile}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
       await fs.promises.writeFile(tmp, JSON.stringify({ entries: mergedEntries }, null, 2));

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -123,6 +123,7 @@ const packageJson = require("../../package.json") as { version?: string };
 const REPLAY_CACHE_CAPACITY = 32;
 const MODEL_CACHE_TTL_MS = 5 * 60_000;
 const DEFAULT_MAX_ACTIVE_SESSIONS = 64;
+const inFlightModelRefreshes = new Map<string, Promise<void>>();
 
 interface ModelCacheFile {
   entries: Record<string, { models: string[]; updatedAt: number }>;
@@ -593,7 +594,8 @@ export class AcpAgent {
 
   private refreshModelOptions(config: AgyCliConfig): Promise<void> {
     const key = config.agyPath;
-    const inFlight = this.#modelRefreshes.get(key);
+    const processKey = `${config.agyPath}:${this.#modelCacheFile}`;
+    const inFlight = inFlightModelRefreshes.get(processKey) ?? this.#modelRefreshes.get(key);
     if (inFlight) return inFlight;
     const refresh = (async () => {
       await this.ensureAgyReady();
@@ -602,8 +604,10 @@ export class AcpAgent {
     })()
       .catch(() => {})
       .finally(() => {
+        inFlightModelRefreshes.delete(processKey);
         this.#modelRefreshes.delete(key);
       });
+    inFlightModelRefreshes.set(processKey, refresh);
     this.#modelRefreshes.set(key, refresh);
     return refresh;
   }
@@ -640,8 +644,8 @@ export class AcpAgent {
 }
 
 /** ACP v1 agent app (stable protocol). */
-export function createAcpApp(options: AcpAgentOptions = {}): V1AgentApp {
-  const agent = new AcpAgent(options);
+export function createAcpApp(options: AcpAgentOptions | AcpAgent = {}): V1AgentApp {
+  const agent = options instanceof AcpAgent ? options : new AcpAgent(options);
   return v1
     .agent({ name: "agy-acp" })
     .onRequest(v1.methods.agent.initialize, (ctx) => agent.initializeV1(ctx.params))
@@ -665,8 +669,8 @@ export function createAcpApp(options: AcpAgentOptions = {}): V1AgentApp {
  * Experimental draft ACP v2 agent app.
  * Prefer {@link createDualAcpApp} / {@link runAcp} so v1 clients still work.
  */
-export function createAcpV2App(options: AcpAgentOptions = {}): V2AgentApp {
-  const agent = new AcpAgent(options);
+export function createAcpV2App(options: AcpAgentOptions | AcpAgent = {}): V2AgentApp {
+  const agent = options instanceof AcpAgent ? options : new AcpAgent(options);
   return v2
     .agent({ name: "agy-acp" })
     .onRequest(v2.methods.agent.initialize, (ctx) => agent.initializeV2(ctx.params))
@@ -686,8 +690,9 @@ export function createAcpV2App(options: AcpAgentOptions = {}): V2AgentApp {
  * Dual-version agent connector: negotiates ACP v1 or experimental draft v2 from
  * the client's `initialize.protocolVersion`.
  */
-export function createDualAcpApp(options: AcpAgentOptions = {}): v2.AgentProtocolRouter {
-  return v2.agentProtocolRouter().withV1(createAcpApp(options)).withV2(createAcpV2App(options));
+export function createDualAcpApp(options: AcpAgentOptions | AcpAgent = {}): v2.AgentProtocolRouter {
+  const agent = options instanceof AcpAgent ? options : new AcpAgent(options);
+  return v2.agentProtocolRouter().withV1(createAcpApp(agent)).withV2(createAcpV2App(agent));
 }
 
 export function runAcp(options: AcpAgentOptions = {}) {

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -609,6 +609,24 @@ export class AcpAgent {
     const localInFlight = this.#modelRefreshes.get(key);
     if (localInFlight) return localInFlight;
 
+    if (!this.#modelCacheEnabled) {
+      const localRefresh = (async () => {
+        await this.ensureAgyReady();
+        return this.#backend.listModels(config);
+      })()
+        .then((models) => {
+          if (models.length > 0) {
+            this.cacheModelOptions(key, models);
+          }
+        })
+        .catch(() => {})
+        .finally(() => {
+          this.#modelRefreshes.delete(key);
+        });
+      this.#modelRefreshes.set(key, localRefresh);
+      return localRefresh;
+    }
+
     const processKey = `${config.agyPath}:${this.#modelCacheFile}`;
     let sharedInFlight = inFlightModelRefreshes.get(processKey);
     if (!sharedInFlight) {

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -416,6 +416,8 @@ export class AcpAgent {
     client: V1AgentContext,
     signal?: AbortSignal
   ): Promise<V1PromptResponse> {
+    const session = this.#sessions.get(params.sessionId);
+    if (session) session.v1Client = client;
     return handlePromptV1(params, client, signal, this.promptV1Deps());
   }
 
@@ -424,6 +426,8 @@ export class AcpAgent {
    * progress and stopReason arrive as `state_update` notifications.
    */
   promptV2(params: V2PromptRequest, client: V2AgentContext): Promise<V2PromptResponse> {
+    const session = this.#sessions.get(params.sessionId);
+    if (session) session.v2Client = client;
     return handlePromptV2(params, client, this.promptV2Deps());
   }
 
@@ -565,6 +569,11 @@ export class AcpAgent {
         session.selectedBaseModel = selection.baseModel;
         session.selectedReasoningEffort = selection.reasoningEffort;
         applyModelSelection(session.agy, selection.baseModel, selection.reasoningEffort, newCatalog);
+        if (session.v1Client) {
+          notifyConfigOptionUpdateV1(session.v1Client, session.sessionId, session).catch(() => {});
+        } else if (session.v2Client) {
+          notifyConfigOptionUpdateV2(session.v2Client, session.sessionId, session).catch(() => {});
+        }
       }
     }
     if (!this.#modelCacheEnabled) return;

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -103,7 +103,7 @@ import {
   persistSession,
   type SessionBuildDeps
 } from "./session/setup.js";
-import { handleNewSessionV1, handleNewSessionV2, type NewSessionDeps } from "./session/new.js";
+import { deferAfterResponse, handleNewSessionV1, handleNewSessionV2, type NewSessionDeps } from "./session/new.js";
 import { handleLoadSession } from "./session/load.js";
 import { handleResumeSessionV1, handleResumeSessionV2 } from "./session/resume.js";
 import { handleSetSessionMode } from "./session/set-mode.js";
@@ -579,9 +579,13 @@ export class AcpAgent {
           this.persistSession(session.sessionId, session).catch(() => {});
         }
         if (session.v1Client) {
-          notifyConfigOptionUpdateV1(session.v1Client, session.sessionId, session).catch(() => {});
+          const client = session.v1Client;
+          const sessionId = session.sessionId;
+          deferAfterResponse(() => notifyConfigOptionUpdateV1(client, sessionId, session));
         } else if (session.v2Client) {
-          notifyConfigOptionUpdateV2(session.v2Client, session.sessionId, session).catch(() => {});
+          const client = session.v2Client;
+          const sessionId = session.sessionId;
+          deferAfterResponse(() => notifyConfigOptionUpdateV2(client, sessionId, session));
         }
       }
     }

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -124,6 +124,41 @@ const REPLAY_CACHE_CAPACITY = 32;
 const MODEL_CACHE_TTL_MS = 5 * 60_000;
 const DEFAULT_MAX_ACTIVE_SESSIONS = 64;
 const inFlightModelRefreshes = new Map<string, Promise<string[]>>();
+const modelCacheWrites = new Map<string, Promise<void>>();
+
+function persistModelCache(
+  cacheFile: string,
+  entries: Record<string, { models: string[]; updatedAt: number }>
+): Promise<void> {
+  const previousWrite = modelCacheWrites.get(cacheFile) ?? Promise.resolve();
+  const nextWrite = previousWrite
+    .then(async () => {
+      let existingEntries: Record<string, { models: string[]; updatedAt: number }> = {};
+      try {
+        const parsed = JSON.parse(await fs.promises.readFile(cacheFile, "utf-8")) as Partial<ModelCacheFile>;
+        if (parsed.entries && typeof parsed.entries === "object") {
+          existingEntries = parsed.entries;
+        }
+      } catch {
+        // Missing or malformed caches will be overwritten.
+      }
+      const mergedEntries = { ...existingEntries, ...entries };
+      await fs.promises.mkdir(path.dirname(cacheFile), { recursive: true });
+      const tmp = `${cacheFile}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+      await fs.promises.writeFile(tmp, JSON.stringify({ entries: mergedEntries }, null, 2));
+      await fs.promises.rename(tmp, cacheFile);
+    })
+    .catch((error) => {
+      console.error(`[agy-acp] WARN: failed to persist model cache: ${(error as Error).message}`);
+    })
+    .finally(() => {
+      if (modelCacheWrites.get(cacheFile) === nextWrite) {
+        modelCacheWrites.delete(cacheFile);
+      }
+    });
+  modelCacheWrites.set(cacheFile, nextWrite);
+  return nextWrite;
+}
 
 interface ModelCacheFile {
   entries: Record<string, { models: string[]; updatedAt: number }>;
@@ -591,17 +626,10 @@ export class AcpAgent {
     }
     if (!this.#modelCacheEnabled) return;
 
-    this.#modelCacheWrite = this.#modelCacheWrite
-      .then(async () => {
-        const entries = Object.fromEntries(this.#modelOptionsCache);
-        await fs.promises.mkdir(path.dirname(this.#modelCacheFile), { recursive: true });
-        const tmp = `${this.#modelCacheFile}.tmp`;
-        await fs.promises.writeFile(tmp, JSON.stringify({ entries }, null, 2));
-        await fs.promises.rename(tmp, this.#modelCacheFile);
-      })
-      .catch((error) => {
-        console.error(`[agy-acp] WARN: failed to persist model cache: ${(error as Error).message}`);
-      });
+    this.#modelCacheWrite = persistModelCache(
+      this.#modelCacheFile,
+      Object.fromEntries(this.#modelOptionsCache)
+    );
   }
 
   private refreshModelOptions(config: AgyCliConfig): Promise<void> {

--- a/src/acp/session/load.ts
+++ b/src/acp/session/load.ts
@@ -43,6 +43,7 @@ export async function handleLoadSession(
     params.cwd,
     params.additionalDirectories
   );
+  session.v1Client = client;
 
   if (stored.conversationId) {
     const tracker = createTerminalOutputTracker();

--- a/src/acp/session/new.ts
+++ b/src/acp/session/new.ts
@@ -21,7 +21,7 @@ import type { SessionState } from "./types.js";
  * `setImmediate` — which only fires once the microtask queue (including the
  * response's own send) has drained — is enough to guarantee it lands second.
  */
-function deferAfterResponse(fn: () => Promise<void>): void {
+export function deferAfterResponse(fn: () => Promise<void>): void {
   setImmediate(() => {
     fn().catch(() => {
       // Connection may already be closed by the time this fires (client

--- a/src/acp/session/new.ts
+++ b/src/acp/session/new.ts
@@ -45,6 +45,7 @@ export async function handleNewSessionV1(
   await deps.requireAuthenticated(params.cwd);
   const session = await deps.createSession(params.cwd, params.additionalDirectories);
   if (client) {
+    session.v1Client = client;
     // Clients (e.g. Zed) only learn this sessionId from the `session/new`
     // response and register it then; a notification sent earlier targets a
     // session the client doesn't recognize yet and gets silently dropped.
@@ -69,6 +70,7 @@ export async function handleNewSessionV2(
   const session = await deps.createSession(params.cwd, params.additionalDirectories);
   // Draft v2 has no native session/set_mode surface; mode is the config option only.
   if (client) {
+    session.v2Client = client;
     // See handleNewSessionV1: must not resolve before the response is sent, or
     // the client drops it as a notification for an unknown session.
     deferAfterResponse(() => deps.notifyAvailableCommandsV2(client, session.sessionId));

--- a/src/acp/session/resume.ts
+++ b/src/acp/session/resume.ts
@@ -50,6 +50,7 @@ export async function handleResumeSessionV1(
   await deps.requireAuthenticated(params.cwd);
   const { session } = await deps.reloadSession(params.sessionId, params.cwd, params.additionalDirectories);
   if (client) {
+    session.v1Client = client;
     await deps.notifyAvailableCommandsV1(client, params.sessionId);
   }
   return {
@@ -76,6 +77,7 @@ export async function handleResumeSessionV2(
     params.cwd,
     params.additionalDirectories
   );
+  session.v2Client = client;
 
   const replayFrom = params.replayFrom ?? null;
   if (replayFrom != null) {

--- a/src/acp/session/types.ts
+++ b/src/acp/session/types.ts
@@ -45,6 +45,8 @@ export interface SessionState {
   catalog: ModelCatalog;
   selectedBaseModel: string;
   selectedReasoningEffort: string;
+  v1Client?: import("@agentclientprotocol/sdk").AgentContext;
+  v2Client?: import("@agentclientprotocol/sdk/experimental/v2").AgentContext;
   /**
    * Owns the session's single turn slot: who is running, who has reserved the
    * next turn, and the abort controller for each. Created lazily via

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1392,6 +1392,69 @@ describe("model discovery cache", () => {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("preserves newest cache entry timestamps when merging disk cache writes", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-model-merge-ts-"));
+    const newerTime = Date.now() + 60_000;
+    const initialDiskCache = {
+      entries: {
+        "agy-a": {
+          models: ["newer-model-a\tNewer Model A"],
+          updatedAt: newerTime
+        }
+      }
+    };
+    fs.writeFileSync(path.join(stateDir, "models.json"), JSON.stringify(initialDiskCache));
+
+    const spawnProcess = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        return new FakeProcess(["refreshed-model-b\tRefreshed Model B\n"]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    type ModelCacheAgent = {
+      modelOptionsForConfig(config: AgyCliConfig): Promise<string[]>;
+      cacheModelOptions(key: string, models: string[]): void;
+    };
+
+    const configB: AgyCliConfig = {
+      ...configFromEnv({ cwd: "/repo" }),
+      agyPath: "agy-b"
+    };
+
+    try {
+      const agent = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess as unknown as SpawnFactory
+      });
+
+      // Manually simulate a stale in-memory snapshot for agy-a on this agent instance
+      (agent as unknown as ModelCacheAgent).cacheModelOptions("agy-a", ["stale-model-a\tStale Model A"]);
+
+      // Trigger refresh for agy-b
+      await (agent as unknown as ModelCacheAgent).modelOptionsForConfig(configB);
+
+      await waitFor(() => {
+        if (!fs.existsSync(path.join(stateDir, "models.json"))) return false;
+        try {
+          const cache = JSON.parse(fs.readFileSync(path.join(stateDir, "models.json"), "utf-8"));
+          return cache.entries?.["agy-b"] !== undefined;
+        } catch {
+          return false;
+        }
+      });
+
+      const cache = JSON.parse(fs.readFileSync(path.join(stateDir, "models.json"), "utf-8"));
+      // agy-a should still have newer-model-a from disk because its timestamp was newer than the stale in-memory snapshot
+      expect(cache.entries["agy-a"].models).toEqual(["newer-model-a\tNewer Model A"]);
+      expect(cache.entries["agy-a"].updatedAt).toBe(newerTime);
+      expect(cache.entries["agy-b"].models).toEqual(["refreshed-model-b\tRefreshed Model B"]);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("active session retention", () => {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1179,6 +1179,51 @@ describe("model discovery cache", () => {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("rechecks and reconciles session catalog with latest cache upon session registration", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-model-recheck-"));
+    const staleCache = {
+      entries: {
+        agy: {
+          models: ["deprecated-model-high\tDeprecated Model (High)"],
+          updatedAt: Date.now() - 10 * 60_000
+        }
+      }
+    };
+    fs.writeFileSync(path.join(stateDir, "models.json"), JSON.stringify(staleCache));
+
+    const spawnProcess = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        return new FakeProcess(["gemini-3.7-flash-high\tGemini 3.7 Flash (High)\n"]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    type SessionInspectorAgent = {
+      requireSession(id: string): {
+        selectedBaseModel: string;
+        catalog: { baseModels(): string[] };
+      };
+      newSessionV1(params: { cwd: string }): Promise<{ sessionId: string }>;
+    };
+
+    try {
+      const agent = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess as unknown as SpawnFactory
+      });
+
+      const { sessionId } = await (agent as unknown as SessionInspectorAgent).newSessionV1({ cwd: "/repo" });
+      const session = (agent as unknown as SessionInspectorAgent).requireSession(sessionId);
+
+      // Successfully reconciled to the latest refreshed catalog
+      expect(session.selectedBaseModel).toBe("gemini-3.7-flash");
+      expect(session.catalog.baseModels()).toEqual(["gemini-3.7-flash"]);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("active session retention", () => {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1224,6 +1224,55 @@ describe("model discovery cache", () => {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("persists updated model selection when catalog reconciliation changes session selection", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-model-persist-"));
+    const staleCache = {
+      entries: {
+        agy: {
+          models: ["deprecated-model-high\tDeprecated Model (High)"],
+          updatedAt: Date.now()
+        }
+      }
+    };
+    fs.writeFileSync(path.join(stateDir, "models.json"), JSON.stringify(staleCache));
+
+    const spawnProcess = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        return new FakeProcess(["gemini-3.7-flash-high\tGemini 3.7 Flash (High)\n"]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    type SessionInspectorAgent = {
+      newSessionV1(params: { cwd: string }): Promise<{ sessionId: string }>;
+      refreshModelOptions(config: AgyCliConfig): Promise<void>;
+      authProbeConfig(): AgyCliConfig;
+    };
+
+    try {
+      const agent = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess as unknown as SpawnFactory
+      });
+
+      const { sessionId } = await (agent as unknown as SessionInspectorAgent).newSessionV1({ cwd: "/repo" });
+
+      // Trigger background refresh that removes the deprecated model
+      await (agent as unknown as SessionInspectorAgent).refreshModelOptions(
+        (agent as unknown as SessionInspectorAgent).authProbeConfig()
+      );
+
+      // Verify sessions.json has the updated model
+      await waitFor(() => {
+        const persisted = JSON.parse(fs.readFileSync(path.join(stateDir, "sessions.json"), "utf-8"));
+        return persisted.sessions?.[sessionId]?.model === "gemini-3.7-flash";
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("active session retention", () => {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1327,6 +1327,71 @@ describe("model discovery cache", () => {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("serializes concurrent cache writes across multiple agents sharing the same stateDir", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-model-writes-"));
+
+    const spawnProcess1 = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        return new FakeProcess(["gemini-3.5-flash-high\tGemini 3.5 Flash (High)\n"]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    const spawnProcess2 = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        return new FakeProcess(["gemini-3.7-flash-high\tGemini 3.7 Flash (High)\n"]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    type ModelCacheAgent = {
+      modelOptionsForConfig(config: AgyCliConfig): Promise<string[]>;
+    };
+
+    const config1: AgyCliConfig = {
+      ...configFromEnv({ cwd: "/repo" }),
+      agyPath: "agy-custom-1"
+    };
+    const config2: AgyCliConfig = {
+      ...configFromEnv({ cwd: "/repo" }),
+      agyPath: "agy-custom-2"
+    };
+
+    try {
+      const agent1 = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess1 as unknown as SpawnFactory
+      });
+      const agent2 = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess2 as unknown as SpawnFactory
+      });
+
+      await Promise.all([
+        (agent1 as unknown as ModelCacheAgent).modelOptionsForConfig(config1),
+        (agent2 as unknown as ModelCacheAgent).modelOptionsForConfig(config2)
+      ]);
+
+      await waitFor(() => {
+        if (!fs.existsSync(path.join(stateDir, "models.json"))) return false;
+        try {
+          const cache = JSON.parse(fs.readFileSync(path.join(stateDir, "models.json"), "utf-8"));
+          return cache.entries?.["agy-custom-1"] !== undefined && cache.entries?.["agy-custom-2"] !== undefined;
+        } catch {
+          return false;
+        }
+      });
+
+      const cache = JSON.parse(fs.readFileSync(path.join(stateDir, "models.json"), "utf-8"));
+      expect(cache.entries["agy-custom-1"].models).toEqual(["gemini-3.5-flash-high\tGemini 3.5 Flash (High)"]);
+      expect(cache.entries["agy-custom-2"].models).toEqual(["gemini-3.7-flash-high\tGemini 3.7 Flash (High)"]);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("active session retention", () => {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1274,6 +1274,59 @@ describe("model discovery cache", () => {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("does not share model refresh probes across agents when modelCacheEnabled is false", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-model-unshared-"));
+    let agent1Calls = 0;
+    let agent2Calls = 0;
+
+    const spawnProcess1 = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        agent1Calls++;
+        return new FakeProcess(["gemini-3.5-flash-high\tGemini 3.5 Flash (High)\n"]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    const spawnProcess2 = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        agent2Calls++;
+        return new FakeProcess(["gemini-3.7-flash-high\tGemini 3.7 Flash (High)\n"]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    type ModelCacheAgent = {
+      modelOptionsForConfig(config: AgyCliConfig): Promise<string[]>;
+    };
+
+    const config = configFromEnv({ cwd: "/repo" });
+
+    try {
+      const agent1 = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: false,
+        spawnProcess: spawnProcess1 as unknown as SpawnFactory
+      });
+      const agent2 = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: false,
+        spawnProcess: spawnProcess2 as unknown as SpawnFactory
+      });
+
+      const [models1, models2] = await Promise.all([
+        (agent1 as unknown as ModelCacheAgent).modelOptionsForConfig(config),
+        (agent2 as unknown as ModelCacheAgent).modelOptionsForConfig(config)
+      ]);
+
+      expect(models1).toEqual(["gemini-3.5-flash-high\tGemini 3.5 Flash (High)"]);
+      expect(models2).toEqual(["gemini-3.7-flash-high\tGemini 3.7 Flash (High)"]);
+      expect(agent1Calls).toBe(1);
+      expect(agent2Calls).toBe(1);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("active session retention", () => {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -13,6 +13,7 @@ import {
   buildModelCatalog,
   createAcpApp,
   createAcpV2App,
+  createDualAcpApp,
   modelConfigOption,
   contentBlocksToText,
   reasoningEffortConfigOption,
@@ -1106,6 +1107,32 @@ describe("model discovery cache", () => {
         (n) => (n.params as { update?: { sessionUpdate?: string } }).update?.sessionUpdate === "config_option_update"
       );
       expect(updateNotification).toBeDefined();
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("createDualAcpApp shares a single AcpAgent instance and deduplicates launch refreshes", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-model-dual-"));
+    let modelCalls = 0;
+    const spawnProcess = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        modelCalls++;
+        return new FakeProcess(["gemini-3.7-flash-high\tGemini 3.7 Flash (High)\n"]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    try {
+      createDualAcpApp({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess as unknown as SpawnFactory
+      });
+
+      await waitFor(() => fs.existsSync(path.join(stateDir, "models.json")));
+      // Exactly 1 probe, not 2
+      expect(modelCalls).toBe(1);
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1103,10 +1103,11 @@ describe("model discovery cache", () => {
       expect(session.catalog.baseModels()).toEqual(["gemini-3.7-flash"]);
 
       // Verify client received config_option_update notification
-      const updateNotification = notifications.find(
-        (n) => (n.params as { update?: { sessionUpdate?: string } }).update?.sessionUpdate === "config_option_update"
-      );
-      expect(updateNotification).toBeDefined();
+      await waitFor(() => {
+        return notifications.some(
+          (n) => (n.params as { update?: { sessionUpdate?: string } }).update?.sessionUpdate === "config_option_update"
+        );
+      });
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1060,13 +1060,20 @@ describe("model discovery cache", () => {
       return new FakeProcess(["ok"]);
     };
 
+    const notifications: Array<{ method: string; params: unknown }> = [];
+    const fakeClient = {
+      notify: vi.fn(async (method: string, params: unknown) => {
+        notifications.push({ method, params });
+      })
+    } as unknown as import("@agentclientprotocol/sdk").AgentContext;
+
     type SessionInspectorAgent = {
       requireSession(id: string): {
         selectedBaseModel: string;
         selectedReasoningEffort: string;
         catalog: { baseModels(): string[] };
       };
-      newSessionV1(params: { cwd: string }): Promise<{ sessionId: string }>;
+      newSessionV1(params: { cwd: string }, client?: unknown): Promise<{ sessionId: string }>;
       refreshModelOptions(config: AgyCliConfig): Promise<void>;
       authProbeConfig(): AgyCliConfig;
     };
@@ -1078,7 +1085,10 @@ describe("model discovery cache", () => {
         spawnProcess: spawnProcess as unknown as SpawnFactory
       });
 
-      const { sessionId } = await (agent as unknown as SessionInspectorAgent).newSessionV1({ cwd: "/repo" });
+      const { sessionId } = await (agent as unknown as SessionInspectorAgent).newSessionV1(
+        { cwd: "/repo" },
+        fakeClient
+      );
       const session = (agent as unknown as SessionInspectorAgent).requireSession(sessionId);
       expect(session.selectedBaseModel).toBe("deprecated-model");
 
@@ -1090,6 +1100,12 @@ describe("model discovery cache", () => {
       // Reconciled to the new default model in new catalog
       expect(session.selectedBaseModel).toBe("gemini-3.7-flash");
       expect(session.catalog.baseModels()).toEqual(["gemini-3.7-flash"]);
+
+      // Verify client received config_option_update notification
+      const updateNotification = notifications.find(
+        (n) => (n.params as { update?: { sessionUpdate?: string } }).update?.sessionUpdate === "config_option_update"
+      );
+      expect(updateNotification).toBeDefined();
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Readable, Writable } from "node:stream";
+import { PassThrough, Readable, Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import * as installer from "../src/agy/installer.js";
 import { client as acpClient, methods, PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
@@ -839,6 +839,201 @@ describe("model discovery cache", () => {
         (restored as unknown as ModelCacheAgent).modelOptionsForConfig(config)
       ).resolves.toEqual(firstModels);
       expect(modelCalls).toBe(1);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("applies cached models immediately on launch and updates from background refresh when cache is stale", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-model-cache-stale-"));
+    const staleCache = {
+      entries: {
+        agy: {
+          models: ["gemini-3.5-flash-high\tGemini 3.5 Flash (High)"],
+          updatedAt: Date.now() - 10 * 60_000
+        }
+      }
+    };
+    fs.writeFileSync(path.join(stateDir, "models.json"), JSON.stringify(staleCache));
+
+    let modelCalls = 0;
+    const spawnProcess = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        modelCalls++;
+        return new FakeProcess([
+          "gemini-3.5-flash-high\tGemini 3.5 Flash (High)\ngemini-3.7-flash-high\tGemini 3.7 Flash (High)\n"
+        ]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    const config = configFromEnv({ cwd: "/repo" });
+    type ModelCacheAgent = {
+      modelOptionsForConfig(config: AgyCliConfig): Promise<string[]>;
+    };
+
+    try {
+      const agent = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess as unknown as SpawnFactory
+      });
+
+      const immediateModels = await (agent as unknown as ModelCacheAgent).modelOptionsForConfig(config);
+      expect(immediateModels).toEqual(["gemini-3.5-flash-high\tGemini 3.5 Flash (High)"]);
+
+      await waitFor(async () => {
+        const models = await (agent as unknown as ModelCacheAgent).modelOptionsForConfig(config);
+        return models.length === 2;
+      });
+      expect(modelCalls).toBe(1);
+
+      const updatedModels = await (agent as unknown as ModelCacheAgent).modelOptionsForConfig(config);
+      expect(updatedModels).toEqual([
+        "gemini-3.5-flash-high\tGemini 3.5 Flash (High)",
+        "gemini-3.7-flash-high\tGemini 3.7 Flash (High)"
+      ]);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("initializeV1 triggers background model refresh and updates active session catalog", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-model-cache-init-"));
+    const staleCache = {
+      entries: {
+        agy: {
+          models: ["gemini-3.5-flash-high\tGemini 3.5 Flash (High)"],
+          updatedAt: Date.now() - 10 * 60_000
+        }
+      }
+    };
+    fs.writeFileSync(path.join(stateDir, "models.json"), JSON.stringify(staleCache));
+
+    let modelCalls = 0;
+    const spawnProcess = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        modelCalls++;
+        return new FakeProcess([
+          "gemini-3.5-flash-high\tGemini 3.5 Flash (High)\ngemini-3.7-flash-high\tGemini 3.7 Flash (High)\n"
+        ]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    try {
+      const agent = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess as unknown as SpawnFactory
+      });
+
+      await agent.initializeV1({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      expect(modelCalls).toBe(1);
+      await waitFor(() => {
+        const parsed = JSON.parse(fs.readFileSync(path.join(stateDir, "models.json"), "utf-8"));
+        return parsed.entries?.agy?.models?.length === 2;
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("initializeV2 triggers background model refresh and updates active session catalog", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-model-cache-init-v2-"));
+    const staleCache = {
+      entries: {
+        agy: {
+          models: ["gemini-3.5-flash-high\tGemini 3.5 Flash (High)"],
+          updatedAt: Date.now() - 10 * 60_000
+        }
+      }
+    };
+    fs.writeFileSync(path.join(stateDir, "models.json"), JSON.stringify(staleCache));
+
+    let modelCalls = 0;
+    const spawnProcess = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        modelCalls++;
+        return new FakeProcess([
+          "gemini-3.5-flash-high\tGemini 3.5 Flash (High)\ngemini-3.7-flash-high\tGemini 3.7 Flash (High)\n"
+        ]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    try {
+      const agent = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess as unknown as SpawnFactory
+      });
+
+      await agent.initializeV2({
+        protocolVersion: 2,
+        info: { name: "test-client", version: "1.0.0" },
+        capabilities: {}
+      });
+
+      expect(modelCalls).toBe(1);
+      await waitFor(() => {
+        const parsed = JSON.parse(fs.readFileSync(path.join(stateDir, "models.json"), "utf-8"));
+        return parsed.entries?.agy?.models?.length === 2;
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("dynamically updates in-memory catalog of active sessions when background refresh completes", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-model-cache-active-session-"));
+    const staleCache = {
+      entries: {
+        agy: {
+          models: ["gemini-3.5-flash-high\tGemini 3.5 Flash (High)"],
+          updatedAt: Date.now()
+        }
+      }
+    };
+    fs.writeFileSync(path.join(stateDir, "models.json"), JSON.stringify(staleCache));
+
+    const spawnProcess = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        return new FakeProcess([
+          "gemini-3.5-flash-high\tGemini 3.5 Flash (High)\ngemini-3.7-flash-high\tGemini 3.7 Flash (High)\n"
+        ]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    type SessionInspectorAgent = {
+      requireSession(id: string): { catalog: { baseModels(): string[] } };
+      newSessionV1(params: { cwd: string }): Promise<{ sessionId: string }>;
+      refreshModelOptions(config: AgyCliConfig): Promise<void>;
+      authProbeConfig(): AgyCliConfig;
+    };
+
+    try {
+      const agent = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess as unknown as SpawnFactory
+      });
+
+      const { sessionId } = await (agent as unknown as SessionInspectorAgent).newSessionV1({ cwd: "/repo" });
+      const session = (agent as unknown as SessionInspectorAgent).requireSession(sessionId);
+      expect(session.catalog.baseModels()).toEqual(["gemini-3.5-flash"]);
+
+      // Trigger background refresh while session is active
+      await (agent as unknown as SessionInspectorAgent).refreshModelOptions(
+        (agent as unknown as SessionInspectorAgent).authProbeConfig()
+      );
+
+      expect(session.catalog.baseModels()).toEqual(["gemini-3.5-flash", "gemini-3.7-flash"]);
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
@@ -2294,9 +2489,9 @@ function printModeOptions(overrides: AcpAgentOptions = {}): AcpAgentOptions {
   };
 }
 
-export async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+export async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 2000): Promise<void> {
   const start = Date.now();
-  while (!predicate()) {
+  while (!(await predicate())) {
     if (Date.now() - start > timeoutMs) {
       throw new Error("waitFor timed out");
     }

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1137,6 +1137,48 @@ describe("model discovery cache", () => {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("populates each agent instance cache when model refresh is shared concurrently", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-model-concurrent-"));
+    let modelCalls = 0;
+    const spawnProcess = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        modelCalls++;
+        return new FakeProcess(["gemini-3.7-flash-high\tGemini 3.7 Flash (High)\n"]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    type ModelCacheAgent = {
+      modelOptionsForConfig(config: AgyCliConfig): Promise<string[]>;
+    };
+
+    const config = configFromEnv({ cwd: "/repo" });
+
+    try {
+      const agent1 = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess as unknown as SpawnFactory
+      });
+      const agent2 = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess as unknown as SpawnFactory
+      });
+
+      const [models1, models2] = await Promise.all([
+        (agent1 as unknown as ModelCacheAgent).modelOptionsForConfig(config),
+        (agent2 as unknown as ModelCacheAgent).modelOptionsForConfig(config)
+      ]);
+
+      expect(models1).toEqual(["gemini-3.7-flash-high\tGemini 3.7 Flash (High)"]);
+      expect(models2).toEqual(["gemini-3.7-flash-high\tGemini 3.7 Flash (High)"]);
+      expect(modelCalls).toBe(1);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("active session retention", () => {

--- a/tests/acp-server.test.ts
+++ b/tests/acp-server.test.ts
@@ -1038,6 +1038,62 @@ describe("model discovery cache", () => {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("reconciles model selection fallback when background refresh replaces catalog", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-model-reconcile-"));
+    const staleCache = {
+      entries: {
+        agy: {
+          models: ["deprecated-model-high\tDeprecated Model (High)"],
+          updatedAt: Date.now()
+        }
+      }
+    };
+    fs.writeFileSync(path.join(stateDir, "models.json"), JSON.stringify(staleCache));
+
+    const spawnProcess = (_command: string, args: string[]) => {
+      if (args[0] === "models") {
+        return new FakeProcess([
+          "gemini-3.7-flash-high\tGemini 3.7 Flash (High)\n"
+        ]);
+      }
+      return new FakeProcess(["ok"]);
+    };
+
+    type SessionInspectorAgent = {
+      requireSession(id: string): {
+        selectedBaseModel: string;
+        selectedReasoningEffort: string;
+        catalog: { baseModels(): string[] };
+      };
+      newSessionV1(params: { cwd: string }): Promise<{ sessionId: string }>;
+      refreshModelOptions(config: AgyCliConfig): Promise<void>;
+      authProbeConfig(): AgyCliConfig;
+    };
+
+    try {
+      const agent = new AcpAgent({
+        stateDir,
+        modelCacheEnabled: true,
+        spawnProcess: spawnProcess as unknown as SpawnFactory
+      });
+
+      const { sessionId } = await (agent as unknown as SessionInspectorAgent).newSessionV1({ cwd: "/repo" });
+      const session = (agent as unknown as SessionInspectorAgent).requireSession(sessionId);
+      expect(session.selectedBaseModel).toBe("deprecated-model");
+
+      // Trigger background refresh that replaces the catalog without the deprecated model
+      await (agent as unknown as SessionInspectorAgent).refreshModelOptions(
+        (agent as unknown as SessionInspectorAgent).authProbeConfig()
+      );
+
+      // Reconciled to the new default model in new catalog
+      expect(session.selectedBaseModel).toBe("gemini-3.7-flash");
+      expect(session.catalog.baseModels()).toEqual(["gemini-3.7-flash"]);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("active session retention", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],
-    pool: "forks"
+    pool: "forks",
+    testTimeout: 15_000
   }
 });


### PR DESCRIPTION
## Description

- Loads and applies disk-cached models (`models.json`) immediately on server startup so that session creation has zero initialization latency.
- Triggers an asynchronous background query to `agy models` on adapter launch and during `initialize` (ACP v1 & v2) whenever the cache is missing or stale (`MODEL_CACHE_TTL_MS = 5m`).
- Deduplicates in-flight `refreshModelOptions` promises so concurrent requests / cold starts share the single ongoing CLI subprocess.
- Dynamically updates the in-memory `catalog` of all active sessions once the background probe completes.

## Related Issues

- Fixes #107

## Type of Change

- [x] New feature (non-breaking change adding functionality)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `pnpm run build` and it completed without errors
- [x] I have executed `pnpm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed