### PR TITLE
Early lifecycle / system message steps cause premature turn completion in StreamPoller

### DIFF
--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -9,6 +9,7 @@ import { isSystemMessage } from "./system-message.js";
 import { toolCallId } from "./tool-call-updates.js";
 import { Translator } from "./translator.js";
 import type { StepRow } from "./types.js";
+import { LIFECYCLE_STEP_TYPES } from "./updates.js";
 
 export interface PendingInteraction {
   update: SessionUpdate;
@@ -223,23 +224,21 @@ export class StreamPoller {
     if (snapshot !== this.rowSnapshot) { this.rowSnapshot = snapshot; this._revision++; }
     this._hasRows = rows.length > 0;
     const latest = rows.at(-1);
+    const latestMeaningful = findLastMeaningfulStep(rows);
     const isEmptyAgentText = latest !== undefined && isEmptyAgentTextStep(latest);
     this._busy = latest !== undefined && (!isTerminalStepStatus(latest.status) || isEmptyAgentText);
     // A turn can end on a completed agent message, but also on a terminal tool
     // step with no trailing message — most notably a denied/failed command
     // (status 7), after which agy returns to idle without emitting more text.
-    // Gate completion on "latest step is terminal" (3/6/7), not "latest is an
-    // agent message", so those turns don't hang until the deadline. Exclude
-    // stepType 14 (user prompt), which is inserted with status 3 as the turn
-    // opens before agy appends any assistant response steps, and exclude empty
-    // stepType 15 placeholders (text: "" and no thought), which agy inserts
-    // while preparing assistant text generation.
+    // Gate completion on "latest meaningful step is terminal" (3/6/7) while no
+    // subsequent step is currently busy, rather than naively checking rows.at(-1).
+    // This excludes early lifecycle rows (90, 98, 101), system message notices,
+    // and empty stepType 15 placeholders that agy inserts while preparing generation.
     this._latestStepTerminal =
       !rows.hasDecodeError &&
-      latest !== undefined &&
-      latest.stepType !== 14 &&
-      !isEmptyAgentText &&
-      isTerminalStepStatus(latest.status);
+      latestMeaningful !== undefined &&
+      !this._busy &&
+      isTerminalStepStatus(latestMeaningful.status);
     // readAfter(baseStepIdx) is a complete prompt-scoped snapshot on every DB
     // change. Rebuild derived file history from those rows so completed writes
     // from a prior poll cannot become the oldText of an earlier historical row.
@@ -282,6 +281,30 @@ export class StreamPoller {
 /** status 3/6/7 — completed, cancelled/aborted, or failed. */
 function isTerminalStepStatus(status: number): boolean {
   return status === 3 || status === 6 || status === 7;
+}
+
+/**
+ * Step types recorded by agy for its own bookkeeping, prompt framing, or notifications,
+ * which do not represent assistant tool execution or assistant response generation.
+ */
+function isIgnoredTurnStep(row: StepRow): boolean {
+  if (row.stepType === 14) return true;
+  if (row.stepType === 23) return true;
+  if (LIFECYCLE_STEP_TYPES.has(row.stepType)) return true;
+  if (row.stepType === 15) {
+    const text = row.stepPayload.agentText?.text ?? "";
+    if (isSystemMessage(text)) return true;
+    if (isEmptyAgentTextStep(row)) return true;
+  }
+  return false;
+}
+
+function findLastMeaningfulStep(rows: StepRow[]): StepRow | undefined {
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const row = rows[i]!;
+    if (!isIgnoredTurnStep(row)) return row;
+  }
+  return undefined;
 }
 
 /**

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -30,7 +30,7 @@ export type { UpdateContext } from "./tool-call-updates.js";
  *   98  conversation_history — prior-conversation summaries injected as context
  *   101 stop_hook            — termination/auto-proceed decisions
  */
-const LIFECYCLE_STEP_TYPES = new Set<number>([90, 98, 101]);
+export const LIFECYCLE_STEP_TYPES = new Set<number>([90, 98, 101]);
 
 function isFinalQuotaExhaustion(stepRow: StepRow): boolean {
   if (stepRow.status !== 3 && stepRow.status !== 6 && stepRow.status !== 7) return false;

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2873,6 +2873,88 @@ describe("StreamPoller", () => {
     db.close();
   });
 
+  it("does not treat early lifecycle steps (stepType 90, 98, 101, status 3) as turn completion candidates", () => {
+    const db = createConversationDb(dir, "conv-early-lifecycle");
+    insertStep(db, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Explain the problem" })
+    });
+    // agy appends an internal lifecycle step (e.g. stop_hook 101, ephemeral_message 90, or history 98)
+    insertStep(db, {
+      idx: 2,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({})
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-early-lifecycle",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    expect(poller.poll()).toEqual([]);
+    expect(poller.turnCompleteCandidate).toBe(false);
+
+    // When actual assistant response arrives, turnCompleteCandidate becomes true
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({ agentText: "Here is the explanation." })
+    });
+    expect(poller.poll()).toHaveLength(1);
+    expect(poller.turnCompleteCandidate).toBe(true);
+
+    poller.close();
+    db.close();
+  });
+
+  it("does not treat early system message notices as turn completion candidates when no background task was active", () => {
+    const db = createConversationDb(dir, "conv-early-sysmsg-notice");
+    insertStep(db, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Check system status" })
+    });
+    // Server restart or background notice arrives immediately after user prompt
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "<SYSTEM_MESSAGE>\n[Notice] All your subagents and background tasks have been stopped due to server restart."
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-early-sysmsg-notice",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    expect(poller.poll()).toEqual([]);
+    expect(poller.turnCompleteCandidate).toBe(false);
+
+    // Assistant response arrives subsequently
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({ agentText: "All background tasks were stopped after the restart." })
+    });
+    expect(poller.poll()).toHaveLength(1);
+    expect(poller.turnCompleteCandidate).toBe(true);
+
+    poller.close();
+    db.close();
+  });
+
   it("treats a terminal system message step as a turn completion candidate, not an empty placeholder", () => {
     const db = createConversationDb(dir, "conv-sysmsg-terminal");
     insertStep(db, {


### PR DESCRIPTION
## Description

When `agy` appends internal lifecycle steps (`stepType 90, 98, 101`) or system message notices (e.g. background task stopped notices) immediately after a user prompt (`stepType 14`), `StreamPoller` previously evaluated `_latestStepTerminal` against `rows.at(-1)`, prematurely marking the turn as completed before `agy` generated assistant tool calls or response text.

This change:
1. Exports `LIFECYCLE_STEP_TYPES` from `src/agy/db/updates.ts`.
2. Introduces `findLastMeaningfulStep` in `StreamPoller` to skip user prompts (`14`), conversation titles (`23`), lifecycle rows (`90, 98, 101`), system messages, and empty agent text placeholders when determining `_latestStepTerminal`.
3. Ensures prompt turns remain open while waiting for assistant response generation or tool execution.
4. Adds test cases covering early lifecycle rows, unsolicited system message notices, and subsequent completion.

## Related Issues

Fixes #97

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `pnpm run build` and it completed without errors
- [x] I have executed `pnpm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed