### PR TITLE
Support agent-outbound image ContentBlocks in ACP v1 and v2

### DIFF
--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -213,21 +213,53 @@ export function tryReadImageContentBlock(
   }
 }
 
+function getCodeSpans(text: string): Array<[number, number]> {
+  const spans: Array<[number, number]> = [];
+
+  // Fenced code blocks: ```...``` or ~~~...~~~
+  const fencedRegex = /(?:^|\n)(```+|~~~+)[\s\S]*?(?:\n\1[^\n]*|$)/g;
+  let m: RegExpExecArray | null;
+  while ((m = fencedRegex.exec(text)) !== null) {
+    spans.push([m.index, m.index + m[0].length]);
+  }
+
+  // Inline code spans: `...` or ``...``
+  const inlineRegex = /(`+)(?:[\s\S]*?[^`])\1(?!`)/g;
+  while ((m = inlineRegex.exec(text)) !== null) {
+    spans.push([m.index, m.index + m[0].length]);
+  }
+
+  return spans;
+}
+
 /**
  * Splits agent markdown text into alternating text and image ContentBlocks
  * when local markdown image embeds (![caption](/path/to/img)) reference readable images on disk.
+ * Excludes escaped openers (\!) and markdown code contexts (inline spans, fenced blocks).
  */
 export function splitTextAndImages(text: string, cwd?: string): ContentBlock[] {
   if (!text || !text.includes("![")) {
     return [{ type: "text", text }];
   }
 
+  const codeSpans = getCodeSpans(text);
   const imageRegex = /!\[(.*?)\]\((?:<([^>]+)>|([^)\s]+))\)/g;
   const blocks: ContentBlock[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
   while ((match = imageRegex.exec(text)) !== null) {
+    // Exclude escaped openers: \![caption](...)
+    let backslashes = 0;
+    for (let i = match.index - 1; i >= 0 && text[i] === "\\"; i--) {
+      backslashes++;
+    }
+    if (backslashes % 2 === 1) continue;
+
+    // Exclude inline code spans and fenced code blocks
+    const matchIdx = match.index;
+    if (codeSpans.some(([start, end]) => matchIdx >= start && matchIdx < end)) continue;
+
     const rawPath = (match[2] ?? match[3])!;
     let unescaped = rawPath;
     if (!rawPath.startsWith("file://") && rawPath.includes("%")) {

--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -237,7 +237,7 @@ function getCodeSpans(text: string): Array<[number, number]> {
  * when local markdown image embeds (![caption](/path/to/img)) reference readable images on disk.
  * Excludes escaped openers (\!) and markdown code contexts (inline spans, fenced blocks).
  */
-export function splitTextAndImages(text: string, cwd?: string): ContentBlock[] {
+export function splitTextAndImages(text: string, cwd?: string, supersededPaths?: Set<string>): ContentBlock[] {
   if (!text || !text.includes("![")) {
     return [{ type: "text", text }];
   }
@@ -279,6 +279,9 @@ export function splitTextAndImages(text: string, cwd?: string): ContentBlock[] {
       : unescaped;
 
     if (!resolvedPath) continue;
+    // Do not reconstruct historical markdown images from disk if a later step modified that path
+    if (supersededPaths?.has(resolvedPath)) continue;
+
     const imgBlock = tryReadImageContentBlock(resolvedPath);
     if (imgBlock) {
       const preceding = text.slice(lastIndex, match.index);

--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -46,7 +46,12 @@ export async function contentBlocksToPrompt(blocks: ContentBlock[], cwd: string)
 
     if (block.type === "resource_link") {
       if (isImageMimeType(block.mimeType) && block.uri) {
-        parts.push(agyAttachmentReference(filePathFromUri(block.uri)));
+        const filePath = filePathFromUri(block.uri);
+        if (filePath) {
+          parts.push(agyAttachmentReference(filePath));
+        } else {
+          parts.push(block.uri);
+        }
       } else if (block.uri) {
         // Client-supplied URI only — no adapter prose.
         parts.push(block.uri);
@@ -173,12 +178,12 @@ export function isImageMimeType(mimeType: string | null | undefined): boolean {
   return typeof mimeType === "string" && mimeType.toLowerCase().startsWith("image/");
 }
 
-export function filePathFromUri(uri: string): string {
+export function filePathFromUri(uri: string): string | null {
   if (uri.startsWith("file://")) {
     try {
       return fileURLToPath(uri);
     } catch {
-      return uri;
+      return null;
     }
   }
   return uri;
@@ -196,6 +201,7 @@ export function tryReadImageContentBlock(
 ): { type: "image"; data: string; mimeType: string } | null {
   try {
     const resolved = filePathFromUri(filePath);
+    if (!resolved) return null;
     const mimeType = mimeTypeForPath(resolved);
     if (!mimeType) return null;
     const stat = fs.statSync(resolved);
@@ -231,6 +237,7 @@ export function splitTextAndImages(text: string, cwd?: string): ContentBlock[] {
       ? path.resolve(cwd, rawPath)
       : rawPath;
 
+    if (!resolvedPath) continue;
     const imgBlock = tryReadImageContentBlock(resolvedPath);
     if (imgBlock) {
       const preceding = text.slice(lastIndex, match.index);

--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -216,7 +216,7 @@ export function splitTextAndImages(text: string, cwd?: string): ContentBlock[] {
     return [{ type: "text", text }];
   }
 
-  const imageRegex = /!\[(.*?)\]\(((?:file:\/\/|\/|\.{1,2}\/)[^)\s]+)\)/g;
+  const imageRegex = /!\[(.*?)\]\(([^)\s]+)\)/g;
   const blocks: ContentBlock[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;

--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -7,6 +7,7 @@
 // follow-ups ("continue"), or framing prose around client data.
 
 import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -123,7 +124,7 @@ async function writeImageAttachment(
   return filePath;
 }
 
-function extensionForMimeType(mimeType: string): string {
+export function extensionForMimeType(mimeType: string): string {
   switch (mimeType.toLowerCase()) {
     case "image/png":
       return ".png";
@@ -138,18 +139,113 @@ function extensionForMimeType(mimeType: string): string {
       return ".bmp";
     case "image/avif":
       return ".avif";
+    case "image/svg+xml":
+      return ".svg";
     default:
       return ".img";
   }
 }
 
-function isImageMimeType(mimeType: string | null | undefined): boolean {
+export function mimeTypeForPath(filePath: string): string | null {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".gif":
+      return "image/gif";
+    case ".webp":
+      return "image/webp";
+    case ".svg":
+      return "image/svg+xml";
+    case ".bmp":
+      return "image/bmp";
+    case ".avif":
+      return "image/avif";
+    default:
+      return null;
+  }
+}
+
+export function isImageMimeType(mimeType: string | null | undefined): boolean {
   return typeof mimeType === "string" && mimeType.toLowerCase().startsWith("image/");
 }
 
-function filePathFromUri(uri: string): string {
+export function filePathFromUri(uri: string): string {
   if (uri.startsWith("file://")) {
     return fileURLToPath(uri);
   }
   return uri;
+}
+
+const MAX_IMAGE_READ_BYTES = 10 * 1024 * 1024; // 10MB
+
+/**
+ * Attempt to read a local image file and return an ACP image ContentBlock.
+ * Returns null if the file does not exist, is not an image, or exceeds maxBytes.
+ */
+export function tryReadImageContentBlock(
+  filePath: string,
+  maxBytes = MAX_IMAGE_READ_BYTES
+): { type: "image"; data: string; mimeType: string } | null {
+  try {
+    const resolved = filePathFromUri(filePath);
+    const mimeType = mimeTypeForPath(resolved);
+    if (!mimeType) return null;
+    const stat = fs.statSync(resolved);
+    if (!stat.isFile() || stat.size > maxBytes) return null;
+    const data = fs.readFileSync(resolved).toString("base64");
+    return { type: "image", data, mimeType };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Splits agent markdown text into alternating text and image ContentBlocks
+ * when local markdown image embeds (![caption](/path/to/img)) reference readable images on disk.
+ */
+export function splitTextAndImages(text: string, cwd?: string): ContentBlock[] {
+  if (!text || !text.includes("![")) {
+    return [{ type: "text", text }];
+  }
+
+  const imageRegex = /!\[(.*?)\]\(((?:file:\/\/|\/|\.{1,2}\/)[^)\s]+)\)/g;
+  const blocks: ContentBlock[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = imageRegex.exec(text)) !== null) {
+    const rawPath = match[2]!;
+    const resolvedPath = rawPath.startsWith("file://")
+      ? filePathFromUri(rawPath)
+      : path.isAbsolute(rawPath)
+      ? rawPath
+      : cwd
+      ? path.resolve(cwd, rawPath)
+      : rawPath;
+
+    const imgBlock = tryReadImageContentBlock(resolvedPath);
+    if (imgBlock) {
+      const preceding = text.slice(lastIndex, match.index);
+      if (preceding.length > 0) {
+        blocks.push({ type: "text", text: preceding });
+      }
+      blocks.push(imgBlock);
+      lastIndex = match.index + match[0].length;
+    }
+  }
+
+  if (lastIndex === 0) {
+    return [{ type: "text", text }];
+  }
+
+  const trailing = text.slice(lastIndex);
+  if (trailing.length > 0) {
+    blocks.push({ type: "text", text: trailing });
+  }
+
+  return blocks;
 }

--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -222,13 +222,13 @@ export function splitTextAndImages(text: string, cwd?: string): ContentBlock[] {
     return [{ type: "text", text }];
   }
 
-  const imageRegex = /!\[(.*?)\]\(([^)\s]+)\)/g;
+  const imageRegex = /!\[(.*?)\]\((?:<([^>]+)>|([^)\s]+))\)/g;
   const blocks: ContentBlock[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
   while ((match = imageRegex.exec(text)) !== null) {
-    const rawPath = match[2]!;
+    const rawPath = (match[2] ?? match[3])!;
     const resolvedPath = rawPath.startsWith("file://")
       ? filePathFromUri(rawPath)
       : path.isAbsolute(rawPath)

--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -229,13 +229,22 @@ export function splitTextAndImages(text: string, cwd?: string): ContentBlock[] {
 
   while ((match = imageRegex.exec(text)) !== null) {
     const rawPath = (match[2] ?? match[3])!;
-    const resolvedPath = rawPath.startsWith("file://")
-      ? filePathFromUri(rawPath)
-      : path.isAbsolute(rawPath)
-      ? rawPath
+    let unescaped = rawPath;
+    if (!rawPath.startsWith("file://") && rawPath.includes("%")) {
+      try {
+        unescaped = decodeURIComponent(rawPath);
+      } catch {
+        continue;
+      }
+    }
+
+    const resolvedPath = unescaped.startsWith("file://")
+      ? filePathFromUri(unescaped)
+      : path.isAbsolute(unescaped)
+      ? unescaped
       : cwd
-      ? path.resolve(cwd, rawPath)
-      : rawPath;
+      ? path.resolve(cwd, unescaped)
+      : unescaped;
 
     if (!resolvedPath) continue;
     const imgBlock = tryReadImageContentBlock(resolvedPath);

--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -232,19 +232,29 @@ function getCodeSpans(text: string): Array<[number, number]> {
   return spans;
 }
 
+export interface SpannedContentBlock {
+  block: ContentBlock;
+  start: number;
+  end: number;
+}
+
 /**
- * Splits agent markdown text into alternating text and image ContentBlocks
- * when local markdown image embeds (![caption](/path/to/img)) reference readable images on disk.
+ * Splits agent markdown text into spanned alternating text and image ContentBlocks with their
+ * character offset ranges [start, end] within the input text.
  * Excludes escaped openers (\!) and markdown code contexts (inline spans, fenced blocks).
  */
-export function splitTextAndImages(text: string, cwd?: string, supersededPaths?: Set<string>): ContentBlock[] {
+export function splitTextAndImagesWithRanges(
+  text: string,
+  cwd?: string,
+  supersededPaths?: Set<string>
+): SpannedContentBlock[] {
   if (!text || !text.includes("![")) {
-    return [{ type: "text", text }];
+    return [{ block: { type: "text", text }, start: 0, end: text.length }];
   }
 
   const codeSpans = getCodeSpans(text);
   const imageRegex = /!\[(.*?)\]\((?:<([^>]+)>|([^)\s]+))\)/g;
-  const blocks: ContentBlock[] = [];
+  const spans: SpannedContentBlock[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
@@ -284,23 +294,42 @@ export function splitTextAndImages(text: string, cwd?: string, supersededPaths?:
 
     const imgBlock = tryReadImageContentBlock(resolvedPath);
     if (imgBlock) {
-      const preceding = text.slice(lastIndex, match.index);
-      if (preceding.length > 0) {
-        blocks.push({ type: "text", text: preceding });
+      if (match.index > lastIndex) {
+        spans.push({
+          block: { type: "text", text: text.slice(lastIndex, match.index) },
+          start: lastIndex,
+          end: match.index
+        });
       }
-      blocks.push(imgBlock);
+      spans.push({
+        block: imgBlock,
+        start: match.index,
+        end: match.index + match[0].length
+      });
       lastIndex = match.index + match[0].length;
     }
   }
 
   if (lastIndex === 0) {
-    return [{ type: "text", text }];
+    return [{ block: { type: "text", text }, start: 0, end: text.length }];
   }
 
-  const trailing = text.slice(lastIndex);
-  if (trailing.length > 0) {
-    blocks.push({ type: "text", text: trailing });
+  if (lastIndex < text.length) {
+    spans.push({
+      block: { type: "text", text: text.slice(lastIndex) },
+      start: lastIndex,
+      end: text.length
+    });
   }
 
-  return blocks;
+  return spans;
+}
+
+/**
+ * Splits agent markdown text into alternating text and image ContentBlocks
+ * when local markdown image embeds (![caption](/path/to/img)) reference readable images on disk.
+ * Excludes escaped openers (\!) and markdown code contexts (inline spans, fenced blocks).
+ */
+export function splitTextAndImages(text: string, cwd?: string, supersededPaths?: Set<string>): ContentBlock[] {
+  return splitTextAndImagesWithRanges(text, cwd, supersededPaths).map((s) => s.block);
 }

--- a/src/acp/content/index.ts
+++ b/src/acp/content/index.ts
@@ -175,7 +175,11 @@ export function isImageMimeType(mimeType: string | null | undefined): boolean {
 
 export function filePathFromUri(uri: string): string {
   if (uri.startsWith("file://")) {
-    return fileURLToPath(uri);
+    try {
+      return fileURLToPath(uri);
+    } catch {
+      return uri;
+    }
   }
   return uri;
 }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -869,6 +869,71 @@ function getImageCandidatePaths(imageName: string): string[] {
   return candidates;
 }
 
+/**
+ * Extract target file paths mutated by a run_command execution.
+ * Distinguishes output/destination operands from read-only sources (e.g. `cp src dest`, `cat file`).
+ */
+function extractCommandMutationTargets(cmd: string, cwd?: string): string[] {
+  const displayCwd = fsPath(cwd) ?? undefined;
+  const targets: string[] = [];
+
+  // 1. Redirections: > out.png, >> out.png, 1> out.png, 2> out.png
+  const redirRegex = /(?:>>?|[12]>)\s*(?:<([^>]+)>|"([^"]*)"|'([^']*)'|([^\s|&;]+))/g;
+  let redirMatch: RegExpExecArray | null;
+  while ((redirMatch = redirRegex.exec(cmd)) !== null) {
+    const raw = (redirMatch[1] ?? redirMatch[2] ?? redirMatch[3] ?? redirMatch[4])?.trim();
+    if (raw) {
+      const r = resolvePath(raw, displayCwd);
+      if (r) targets.push(r);
+    }
+  }
+
+  // 2. Output flags: -o file, -O file, --output file, --output=file, --out file
+  const outFlagRegex = /(?:-o|-O|--output|--out)(?:=|\s+)(?:<([^>]+)>|"([^"]*)"|'([^']*)'|([^\s|&;]+))/g;
+  let outMatch: RegExpExecArray | null;
+  while ((outMatch = outFlagRegex.exec(cmd)) !== null) {
+    const raw = (outMatch[1] ?? outMatch[2] ?? outMatch[3] ?? outMatch[4])?.trim();
+    if (raw) {
+      const r = resolvePath(raw, displayCwd);
+      if (r) targets.push(r);
+    }
+  }
+
+  // 3. Command segments split by ;, &&, ||, |
+  const subCommands = cmd.split(/[;&|]+/);
+  for (const sub of subCommands) {
+    const tokens = sub.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? [];
+    if (tokens.length === 0) continue;
+    const cleanTokens = tokens.map((t) => t.replace(/^['"]|['"]$/g, "").trim()).filter(Boolean);
+    if (cleanTokens.length === 0) continue;
+
+    const bin = path.basename(cleanTokens[0]);
+    const positionalArgs = cleanTokens.slice(1).filter((t) => !t.startsWith("-"));
+
+    if (bin === "cp") {
+      // In `cp [opts] src... dest`, dest is the last positional argument
+      if (positionalArgs.length >= 2) {
+        const dest = positionalArgs[positionalArgs.length - 1];
+        const r = resolvePath(dest, displayCwd);
+        if (r) targets.push(r);
+      }
+    } else if (bin === "mv") {
+      // In `mv [opts] src... dest`, both src (removed) and dest (overwritten) are mutated
+      for (const arg of positionalArgs) {
+        const r = resolvePath(arg, displayCwd);
+        if (r) targets.push(r);
+      }
+    } else if (bin === "rm" || bin === "touch" || bin === "tee") {
+      for (const arg of positionalArgs) {
+        const r = resolvePath(arg, displayCwd);
+        if (r) targets.push(r);
+      }
+    }
+  }
+
+  return targets;
+}
+
 /** Extract candidate file paths modified by a completed step (status === 3). */
 export function getCompletedStepTargetPaths(stepRow: StepRow, cwd?: string): string[] {
   if (stepRow.status !== 3) return [];
@@ -898,19 +963,11 @@ export function getCompletedStepTargetPaths(stepRow: StepRow, cwd?: string): str
     }
   }
 
-  // When run_command is executed, scan command tokens for potentially modified file targets (e.g. cp/mv replacement.png mockup.png)
+  // When run_command is executed, identify output destination operands (e.g. cp src dest, redirects, -o out)
   if (stepRow.stepType === 21 || name === "run_command") {
     const cmd = asStr(pick(rawInput, "CommandLine", "commandLine", "command", "cmd"))?.trim();
     if (cmd) {
-      const tokens = cmd.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? [];
-      const resolvedPaths: string[] = [];
-      for (const token of tokens) {
-        const cleaned = token.replace(/^['"]|['"]$/g, "").trim();
-        if (!cleaned || cleaned.startsWith("-")) continue;
-        const r = resolvePath(cleaned, displayCwd);
-        if (r) resolvedPaths.push(r);
-      }
-      return resolvedPaths;
+      return extractCommandMutationTargets(cmd, displayCwd);
     }
   }
 

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -871,38 +871,43 @@ function getImageCandidatePaths(imageName: string): string[] {
 
 /**
  * Extract target file paths mutated by a run_command execution.
- * Distinguishes output/destination operands from read-only sources (e.g. `cp src dest`, `cat file`).
+ * Distinguishes output/destination operands from read-only sources (e.g. `cp src dest`, `cat file`),
+ * tracking directory changes (e.g. `cd dir && ...`) across sequential command segments.
  */
 function extractCommandMutationTargets(cmd: string, cwd?: string): string[] {
-  const displayCwd = fsPath(cwd) ?? undefined;
+  let currentCwd = fsPath(cwd) ?? undefined;
   const targets: string[] = [];
 
-  // 1. Redirections: > out.png, >> out.png, 1> out.png, 2> out.png
   const redirRegex = /(?:>>?|[12]>)\s*(?:<([^>]+)>|"([^"]*)"|'([^']*)'|([^\s|&;]+))/g;
-  let redirMatch: RegExpExecArray | null;
-  while ((redirMatch = redirRegex.exec(cmd)) !== null) {
-    const raw = (redirMatch[1] ?? redirMatch[2] ?? redirMatch[3] ?? redirMatch[4])?.trim();
-    if (raw) {
-      const r = resolvePath(raw, displayCwd);
-      if (r) targets.push(r);
-    }
-  }
-
-  // 2. Output flags: -o file, -O file, --output file, --output=file, --out file
   const outFlagRegex = /(?:-o|-O|--output|--out)(?:=|\s+)(?:<([^>]+)>|"([^"]*)"|'([^']*)'|([^\s|&;]+))/g;
-  let outMatch: RegExpExecArray | null;
-  while ((outMatch = outFlagRegex.exec(cmd)) !== null) {
-    const raw = (outMatch[1] ?? outMatch[2] ?? outMatch[3] ?? outMatch[4])?.trim();
-    if (raw) {
-      const r = resolvePath(raw, displayCwd);
-      if (r) targets.push(r);
-    }
-  }
 
-  // 3. Command segments split by ;, &&, ||, |
+  // Split into sequential command segments
   const subCommands = cmd.split(/[;&|]+/);
   for (const sub of subCommands) {
-    const tokens = sub.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? [];
+    const trimmedSub = sub.trim();
+    if (!trimmedSub) continue;
+
+    // Check segment redirections resolved against current segment cwd
+    let redirMatch: RegExpExecArray | null;
+    while ((redirMatch = redirRegex.exec(trimmedSub)) !== null) {
+      const raw = (redirMatch[1] ?? redirMatch[2] ?? redirMatch[3] ?? redirMatch[4])?.trim();
+      if (raw) {
+        const r = resolvePath(raw, currentCwd);
+        if (r) targets.push(r);
+      }
+    }
+
+    // Check segment output flags resolved against current segment cwd
+    let outMatch: RegExpExecArray | null;
+    while ((outMatch = outFlagRegex.exec(trimmedSub)) !== null) {
+      const raw = (outMatch[1] ?? outMatch[2] ?? outMatch[3] ?? outMatch[4])?.trim();
+      if (raw) {
+        const r = resolvePath(raw, currentCwd);
+        if (r) targets.push(r);
+      }
+    }
+
+    const tokens = trimmedSub.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? [];
     if (tokens.length === 0) continue;
     const cleanTokens = tokens.map((t) => t.replace(/^['"]|['"]$/g, "").trim()).filter(Boolean);
     if (cleanTokens.length === 0) continue;
@@ -910,22 +915,27 @@ function extractCommandMutationTargets(cmd: string, cwd?: string): string[] {
     const bin = path.basename(cleanTokens[0]);
     const positionalArgs = cleanTokens.slice(1).filter((t) => !t.startsWith("-"));
 
-    if (bin === "cp") {
+    if (bin === "cd") {
+      if (positionalArgs.length > 0) {
+        const nextDir = resolvePath(positionalArgs[0], currentCwd);
+        if (nextDir) currentCwd = nextDir;
+      }
+    } else if (bin === "cp") {
       // In `cp [opts] src... dest`, dest is the last positional argument
       if (positionalArgs.length >= 2) {
         const dest = positionalArgs[positionalArgs.length - 1];
-        const r = resolvePath(dest, displayCwd);
+        const r = resolvePath(dest, currentCwd);
         if (r) targets.push(r);
       }
     } else if (bin === "mv") {
       // In `mv [opts] src... dest`, both src (removed) and dest (overwritten) are mutated
       for (const arg of positionalArgs) {
-        const r = resolvePath(arg, displayCwd);
+        const r = resolvePath(arg, currentCwd);
         if (r) targets.push(r);
       }
     } else if (bin === "rm" || bin === "touch" || bin === "tee") {
       for (const arg of positionalArgs) {
-        const r = resolvePath(arg, displayCwd);
+        const r = resolvePath(arg, currentCwd);
         if (r) targets.push(r);
       }
     }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -870,20 +870,10 @@ export function imageGenerationUpdate(stepRow: StepRow, ctx?: UpdateContext): Se
 
   // Only attach the generated output artifact once the step has completed successfully (status === 3).
   // Avoid presenting pre-existing files while pending (9), running (1/2), cancelled (6), or failed (7).
-  if (stepRow.status === 3) {
-    // Prioritize newly generated output candidate paths (ImageName) before reference inputs.
-    const candidatePaths: string[] = [];
-    if (imageName) {
-      candidatePaths.push(imageName);
-      if (!imageName.includes(".")) {
-        candidatePaths.push(`${imageName}.png`, `${imageName}.jpg`, `${imageName}.webp`);
-      }
-    }
-    const imagePathsRaw = pick(rawInput, "ImagePaths", "imagePaths");
-    if (Array.isArray(imagePathsRaw)) {
-      for (const p of imagePathsRaw) {
-        if (typeof p === "string" && p) candidatePaths.push(p);
-      }
+  if (stepRow.status === 3 && imageName) {
+    const candidatePaths: string[] = [imageName];
+    if (!imageName.includes(".")) {
+      candidatePaths.push(`${imageName}.png`, `${imageName}.jpg`, `${imageName}.webp`);
     }
 
     for (const candidate of candidatePaths) {

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -38,6 +38,8 @@ export interface UpdateContext {
   locationReadability?: Map<string, boolean>;
   /** Completed generate_image artifacts cached per tool call (freezes output across file mutations). */
   imageArtifacts?: ImageArtifactCache;
+  /** Normalized absolute paths modified by later completed steps in the translated batch. */
+  supersededPaths?: Set<string>;
 }
 
 /** Cap on fetched URL / large tool bodies surfaced in session updates. */
@@ -857,6 +859,37 @@ export function subagentUpdate(stepRow: StepRow): SessionUpdate {
   return toolCallUpdate({ stepRow, title, kind: "other", name, content });
 }
 
+/** Extract candidate file paths modified by a completed step (status === 3). */
+export function getCompletedStepTargetPaths(stepRow: StepRow, cwd?: string): string[] {
+  if (stepRow.status !== 3) return [];
+  const rawInput = parseRawInput(stepRow);
+  const name = decodedToolName(stepRow);
+  const displayCwd = fsPath(cwd) ?? undefined;
+
+  if (name === "generate_image") {
+    const imageName = asStr(pick(rawInput, "ImageName", "imageName"))?.trim();
+    if (!imageName) return [];
+    const candidates: string[] = [imageName];
+    if (!imageName.includes(".")) {
+      candidates.push(`${imageName}.png`, `${imageName}.jpg`, `${imageName}.webp`);
+    }
+    const resolved: string[] = [];
+    for (const c of candidates) {
+      const r = resolvePath(c, displayCwd);
+      if (r) resolved.push(r);
+    }
+    return resolved;
+  }
+
+  const targetFile = fsPath(asStr(pick(rawInput, "TargetFile", "targetFile", "FilePath", "filePath", "path")))?.trim();
+  if (targetFile) {
+    const r = resolvePath(targetFile, displayCwd);
+    if (r) return [r];
+  }
+
+  return [];
+}
+
 /** Tool call for generate_image (image creation / manipulation tool). */
 export function imageGenerationUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate {
   const cwd = ctx?.cwd;
@@ -899,6 +932,9 @@ export function imageGenerationUpdate(stepRow: StepRow, ctx?: UpdateContext): Se
       for (const candidate of candidatePaths) {
         const resolved = resolvePath(candidate, displayCwd);
         if (!resolved) continue;
+        // Do not reconstruct historical outputs from the current file if a later step overwrote it.
+        if (ctx?.supersededPaths?.has(resolved)) continue;
+
         const imgBlock = tryReadImageContentBlock(resolved);
         if (imgBlock) {
           content.push({ type: "content", content: imgBlock });

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -915,23 +915,58 @@ function extractCommandMutationTargets(cmd: string, cwd?: string): string[] {
     const bin = path.basename(cleanTokens[0]);
     const positionalArgs = cleanTokens.slice(1).filter((t) => !t.startsWith("-"));
 
+    const targetDirMatch = trimmedSub.match(/(?:-t|--target-directory)(?:=|\s+)(?:<([^>]+)>|"([^"]*)"|'([^']*)'|([^\s|&;]+))/);
+    const targetDir = targetDirMatch ? (targetDirMatch[1] ?? targetDirMatch[2] ?? targetDirMatch[3] ?? targetDirMatch[4])?.trim() : undefined;
+
     if (bin === "cd") {
       if (positionalArgs.length > 0) {
         const nextDir = resolvePath(positionalArgs[0], currentCwd);
         if (nextDir) currentCwd = nextDir;
       }
     } else if (bin === "cp") {
-      // In `cp [opts] src... dest`, dest is the last positional argument
-      if (positionalArgs.length >= 2) {
+      if (targetDir) {
+        const dirResolved = resolvePath(targetDir, currentCwd);
+        if (dirResolved) targets.push(dirResolved);
+        for (const src of positionalArgs) {
+          const r = resolvePath(path.join(targetDir, path.basename(src)), currentCwd);
+          if (r) targets.push(r);
+        }
+      } else if (positionalArgs.length >= 2) {
         const dest = positionalArgs[positionalArgs.length - 1];
-        const r = resolvePath(dest, currentCwd);
-        if (r) targets.push(r);
+        const sources = positionalArgs.slice(0, positionalArgs.length - 1);
+        const destResolved = resolvePath(dest, currentCwd);
+        if (destResolved) targets.push(destResolved);
+        for (const src of sources) {
+          const r = resolvePath(path.join(dest, path.basename(src)), currentCwd);
+          if (r) targets.push(r);
+        }
       }
     } else if (bin === "mv") {
-      // In `mv [opts] src... dest`, both src (removed) and dest (overwritten) are mutated
-      for (const arg of positionalArgs) {
-        const r = resolvePath(arg, currentCwd);
-        if (r) targets.push(r);
+      if (targetDir) {
+        const dirResolved = resolvePath(targetDir, currentCwd);
+        if (dirResolved) targets.push(dirResolved);
+        for (const src of positionalArgs) {
+          const rSrc = resolvePath(src, currentCwd);
+          if (rSrc) targets.push(rSrc);
+          const rDest = resolvePath(path.join(targetDir, path.basename(src)), currentCwd);
+          if (rDest) targets.push(rDest);
+        }
+      } else if (positionalArgs.length >= 2) {
+        const dest = positionalArgs[positionalArgs.length - 1];
+        const sources = positionalArgs.slice(0, positionalArgs.length - 1);
+        const destResolved = resolvePath(dest, currentCwd);
+        if (destResolved) targets.push(destResolved);
+        for (const src of sources) {
+          const rSrc = resolvePath(src, currentCwd);
+          if (rSrc) targets.push(rSrc);
+          const rDest = resolvePath(path.join(dest, path.basename(src)), currentCwd);
+          if (rDest) targets.push(rDest);
+        }
+      } else {
+        for (const arg of positionalArgs) {
+          const r = resolvePath(arg, currentCwd);
+          if (r) targets.push(r);
+        }
       }
     } else if (bin === "rm" || bin === "touch" || bin === "tee") {
       for (const arg of positionalArgs) {

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -859,6 +859,16 @@ export function subagentUpdate(stepRow: StepRow): SessionUpdate {
   return toolCallUpdate({ stepRow, title, kind: "other", name, content });
 }
 
+function getImageCandidatePaths(imageName: string): string[] {
+  const trimmed = imageName.trim();
+  if (!trimmed) return [];
+  const candidates: string[] = [trimmed];
+  if (!path.extname(trimmed)) {
+    candidates.push(`${trimmed}.png`, `${trimmed}.jpg`, `${trimmed}.webp`);
+  }
+  return candidates;
+}
+
 /** Extract candidate file paths modified by a completed step (status === 3). */
 export function getCompletedStepTargetPaths(stepRow: StepRow, cwd?: string): string[] {
   if (stepRow.status !== 3) return [];
@@ -869,10 +879,7 @@ export function getCompletedStepTargetPaths(stepRow: StepRow, cwd?: string): str
   if (name === "generate_image") {
     const imageName = asStr(pick(rawInput, "ImageName", "imageName"))?.trim();
     if (!imageName) return [];
-    const candidates: string[] = [imageName];
-    if (!imageName.includes(".")) {
-      candidates.push(`${imageName}.png`, `${imageName}.jpg`, `${imageName}.webp`);
-    }
+    const candidates = getImageCandidatePaths(imageName);
     const resolved: string[] = [];
     for (const c of candidates) {
       const r = resolvePath(c, displayCwd);
@@ -925,10 +932,7 @@ export function imageGenerationUpdate(stepRow: StepRow, ctx?: UpdateContext): Se
         locations.push({ path: cached.path });
       }
     } else {
-      const candidatePaths: string[] = [imageName];
-      if (!imageName.includes(".")) {
-        candidatePaths.push(`${imageName}.png`, `${imageName}.jpg`, `${imageName}.webp`);
-      }
+      const candidatePaths = getImageCandidatePaths(imageName);
 
       for (const candidate of candidatePaths) {
         const resolved = resolvePath(candidate, displayCwd);

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -21,10 +21,10 @@ import type { StepRow } from "./types.js";
 /** Absolute path -> last known file body from prior view_file / write steps. */
 export type FileContentCache = Map<string, string>;
 
-/** Cached image artifact for a completed tool call (callKey -> image block + path or null). */
+/** Cached image artifact for a completed tool call (callKey -> image block + path). */
 export type ImageArtifactCache = Map<
   string,
-  { block: { type: "image"; data: string; mimeType: string }; path: string } | null
+  { block: { type: "image"; data: string; mimeType: string }; path: string }
 >;
 
 /** Options shared by tool builders that need project context. */
@@ -915,12 +915,10 @@ export function imageGenerationUpdate(stepRow: StepRow, ctx?: UpdateContext): Se
     const callKey = stepRow.stepPayload.toolRun?.call?.callId || String(stepRow.idx);
     const cached = ctx?.imageArtifacts?.get(callKey);
 
-    if (cached !== undefined) {
-      if (cached) {
-        content.push({ type: "content", content: cached.block });
-        if (isReadableLocation(cached.path, ctx)) {
-          locations.push({ path: cached.path });
-        }
+    if (cached) {
+      content.push({ type: "content", content: cached.block });
+      if (isReadableLocation(cached.path, ctx)) {
+        locations.push({ path: cached.path });
       }
     } else {
       const candidatePaths: string[] = [imageName];
@@ -928,7 +926,6 @@ export function imageGenerationUpdate(stepRow: StepRow, ctx?: UpdateContext): Se
         candidatePaths.push(`${imageName}.png`, `${imageName}.jpg`, `${imageName}.webp`);
       }
 
-      let attached = false;
       for (const candidate of candidatePaths) {
         const resolved = resolvePath(candidate, displayCwd);
         if (!resolved) continue;
@@ -942,12 +939,8 @@ export function imageGenerationUpdate(stepRow: StepRow, ctx?: UpdateContext): Se
             locations.push({ path: resolved });
           }
           ctx?.imageArtifacts?.set(callKey, { block: imgBlock, path: resolved });
-          attached = true;
           break;
         }
-      }
-      if (!attached && ctx?.imageArtifacts) {
-        ctx.imageArtifacts.set(callKey, null);
       }
     }
   }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -979,14 +979,16 @@ function extractCommandMutationTargets(cmd: string, cwd?: string): string[] {
   return targets;
 }
 
-/** Extract candidate file paths modified by a completed step (status === 3). */
+/** Extract candidate file paths modified by a terminal step (status === 3, 6, 7). */
 export function getCompletedStepTargetPaths(stepRow: StepRow, cwd?: string): string[] {
-  if (stepRow.status !== 3) return [];
+  const isTerminal = stepRow.status === 3 || stepRow.status === 6 || stepRow.status === 7;
+  if (!isTerminal) return [];
   const rawInput = parseRawInput(stepRow);
   const name = decodedToolName(stepRow);
   const displayCwd = fsPath(cwd) ?? undefined;
 
   if (name === "generate_image") {
+    if (stepRow.status !== 3) return [];
     const imageName = asStr(pick(rawInput, "ImageName", "imageName"))?.trim();
     if (!imageName) return [];
     const candidates = getImageCandidatePaths(imageName);

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -21,6 +21,12 @@ import type { StepRow } from "./types.js";
 /** Absolute path -> last known file body from prior view_file / write steps. */
 export type FileContentCache = Map<string, string>;
 
+/** Cached image artifact for a completed tool call (callKey -> image block + path or null). */
+export type ImageArtifactCache = Map<
+  string,
+  { block: { type: "image"; data: string; mimeType: string }; path: string } | null
+>;
+
 /** Options shared by tool builders that need project context. */
 export interface UpdateContext {
   cwd?: string;
@@ -30,6 +36,8 @@ export interface UpdateContext {
   planEntries?: Map<string, PlanEntry[]>;
   /** Candidate location path -> readability observed while translating. */
   locationReadability?: Map<string, boolean>;
+  /** Completed generate_image artifacts cached per tool call (freezes output across file mutations). */
+  imageArtifacts?: ImageArtifactCache;
 }
 
 /** Cap on fetched URL / large tool bodies surfaced in session updates. */
@@ -871,21 +879,39 @@ export function imageGenerationUpdate(stepRow: StepRow, ctx?: UpdateContext): Se
   // Only attach the generated output artifact once the step has completed successfully (status === 3).
   // Avoid presenting pre-existing files while pending (9), running (1/2), cancelled (6), or failed (7).
   if (stepRow.status === 3 && imageName) {
-    const candidatePaths: string[] = [imageName];
-    if (!imageName.includes(".")) {
-      candidatePaths.push(`${imageName}.png`, `${imageName}.jpg`, `${imageName}.webp`);
-    }
+    const callKey = stepRow.stepPayload.toolRun?.call?.callId || String(stepRow.idx);
+    const cached = ctx?.imageArtifacts?.get(callKey);
 
-    for (const candidate of candidatePaths) {
-      const resolved = resolvePath(candidate, displayCwd);
-      if (!resolved) continue;
-      const imgBlock = tryReadImageContentBlock(resolved);
-      if (imgBlock) {
-        content.push({ type: "content", content: imgBlock });
-        if (isReadableLocation(resolved, ctx)) {
-          locations.push({ path: resolved });
+    if (cached !== undefined) {
+      if (cached) {
+        content.push({ type: "content", content: cached.block });
+        if (isReadableLocation(cached.path, ctx)) {
+          locations.push({ path: cached.path });
         }
-        break;
+      }
+    } else {
+      const candidatePaths: string[] = [imageName];
+      if (!imageName.includes(".")) {
+        candidatePaths.push(`${imageName}.png`, `${imageName}.jpg`, `${imageName}.webp`);
+      }
+
+      let attached = false;
+      for (const candidate of candidatePaths) {
+        const resolved = resolvePath(candidate, displayCwd);
+        if (!resolved) continue;
+        const imgBlock = tryReadImageContentBlock(resolved);
+        if (imgBlock) {
+          content.push({ type: "content", content: imgBlock });
+          if (isReadableLocation(resolved, ctx)) {
+            locations.push({ path: resolved });
+          }
+          ctx?.imageArtifacts?.set(callKey, { block: imgBlock, path: resolved });
+          attached = true;
+          break;
+        }
+      }
+      if (!attached && ctx?.imageArtifacts) {
+        ctx.imageArtifacts.set(callKey, null);
       }
     }
   }

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -888,13 +888,29 @@ export function getCompletedStepTargetPaths(stepRow: StepRow, cwd?: string): str
     return resolved;
   }
 
-  // Only consider tools that mutate files (step type 5 or write/replace/edit/patch tools).
+  // Mutating file edit tools (step type 5 or write/replace/edit/patch tools).
   // Read-only tools (view_file, list_dir, grep_search, etc.) must not mark paths as superseded.
   if (stepRow.stepType === 5 || (name && /write|replace|edit|patch/.test(name))) {
     const targetFile = fsPath(asStr(pick(rawInput, "TargetFile", "targetFile", "FilePath", "filePath", "path")))?.trim();
     if (targetFile) {
       const r = resolvePath(targetFile, displayCwd);
       if (r) return [r];
+    }
+  }
+
+  // When run_command is executed, scan command tokens for potentially modified file targets (e.g. cp/mv replacement.png mockup.png)
+  if (stepRow.stepType === 21 || name === "run_command") {
+    const cmd = asStr(pick(rawInput, "CommandLine", "commandLine", "command", "cmd"))?.trim();
+    if (cmd) {
+      const tokens = cmd.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? [];
+      const resolvedPaths: string[] = [];
+      for (const token of tokens) {
+        const cleaned = token.replace(/^['"]|['"]$/g, "").trim();
+        if (!cleaned || cleaned.startsWith("-")) continue;
+        const r = resolvePath(cleaned, displayCwd);
+        if (r) resolvedPaths.push(r);
+      }
+      return resolvedPaths;
     }
   }
 

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -868,31 +868,35 @@ export function imageGenerationUpdate(stepRow: StepRow, ctx?: UpdateContext): Se
     content.push(textBlock(`Prompt: ${prompt}${aspectRatio ? ` (${aspectRatio})` : ""}`));
   }
 
-  // Look for generated image candidate paths
-  const candidatePaths: string[] = [];
-  const imagePathsRaw = pick(rawInput, "ImagePaths", "imagePaths");
-  if (Array.isArray(imagePathsRaw)) {
-    for (const p of imagePathsRaw) {
-      if (typeof p === "string" && p) candidatePaths.push(p);
-    }
-  }
-  if (imageName) {
-    candidatePaths.push(imageName);
-    if (!imageName.includes(".")) {
-      candidatePaths.push(`${imageName}.png`, `${imageName}.jpg`, `${imageName}.webp`);
-    }
-  }
-
-  for (const candidate of candidatePaths) {
-    const resolved = resolvePath(candidate, displayCwd);
-    if (!resolved) continue;
-    const imgBlock = tryReadImageContentBlock(resolved);
-    if (imgBlock) {
-      content.push({ type: "content", content: imgBlock });
-      if (isReadableLocation(resolved, ctx)) {
-        locations.push({ path: resolved });
+  // Only attach the generated output artifact once the step has completed successfully (status === 3).
+  // Avoid presenting pre-existing files while pending (9), running (1/2), cancelled (6), or failed (7).
+  if (stepRow.status === 3) {
+    // Prioritize newly generated output candidate paths (ImageName) before reference inputs.
+    const candidatePaths: string[] = [];
+    if (imageName) {
+      candidatePaths.push(imageName);
+      if (!imageName.includes(".")) {
+        candidatePaths.push(`${imageName}.png`, `${imageName}.jpg`, `${imageName}.webp`);
       }
-      break;
+    }
+    const imagePathsRaw = pick(rawInput, "ImagePaths", "imagePaths");
+    if (Array.isArray(imagePathsRaw)) {
+      for (const p of imagePathsRaw) {
+        if (typeof p === "string" && p) candidatePaths.push(p);
+      }
+    }
+
+    for (const candidate of candidatePaths) {
+      const resolved = resolvePath(candidate, displayCwd);
+      if (!resolved) continue;
+      const imgBlock = tryReadImageContentBlock(resolved);
+      if (imgBlock) {
+        content.push({ type: "content", content: imgBlock });
+        if (isReadableLocation(resolved, ctx)) {
+          locations.push({ path: resolved });
+        }
+        break;
+      }
     }
   }
 

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -869,6 +869,53 @@ function getImageCandidatePaths(imageName: string): string[] {
   return candidates;
 }
 
+function unwrapLauncherTokens(tokens: string[]): string[] {
+  let idx = 0;
+  while (idx < tokens.length) {
+    const bin = path.basename(tokens[idx]);
+    if (bin === "env") {
+      idx++;
+      while (idx < tokens.length) {
+        const tok = tokens[idx];
+        if (tok === "-u" || tok === "--unset" || tok === "-C" || tok === "--chdir") {
+          idx += 2;
+        } else if (tok.startsWith("-")) {
+          idx++;
+        } else if (tok.includes("=")) {
+          idx++;
+        } else {
+          break;
+        }
+      }
+    } else if (
+      bin === "sudo" ||
+      bin === "doas" ||
+      bin === "nohup" ||
+      bin === "setsid" ||
+      bin === "time" ||
+      bin === "nice" ||
+      bin === "ionice" ||
+      bin === "exec" ||
+      bin === "chroot"
+    ) {
+      idx++;
+      while (idx < tokens.length) {
+        const tok = tokens[idx];
+        if (tok === "-u" || tok === "-g" || tok === "-n" || tok === "-C" || tok === "-a") {
+          idx += 2;
+        } else if (tok.startsWith("-")) {
+          idx++;
+        } else {
+          break;
+        }
+      }
+    } else {
+      break;
+    }
+  }
+  return tokens.slice(idx);
+}
+
 /**
  * Extract target file paths mutated by a run_command execution.
  * Distinguishes output/destination operands from read-only sources (e.g. `cp src dest`, `cat file`),
@@ -909,7 +956,9 @@ function extractCommandMutationTargets(cmd: string, cwd?: string): string[] {
 
     const tokens = trimmedSub.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? [];
     if (tokens.length === 0) continue;
-    const cleanTokens = tokens.map((t) => t.replace(/^['"]|['"]$/g, "").trim()).filter(Boolean);
+    const rawTokens = tokens.map((t) => t.replace(/^['"]|['"]$/g, "").trim()).filter(Boolean);
+    if (rawTokens.length === 0) continue;
+    const cleanTokens = unwrapLauncherTokens(rawTokens);
     if (cleanTokens.length === 0) continue;
 
     const bin = path.basename(cleanTokens[0]);

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -923,7 +923,7 @@ function extractCommandMutationTargets(cmd: string, cwd?: string): string[] {
         const nextDir = resolvePath(positionalArgs[0], currentCwd);
         if (nextDir) currentCwd = nextDir;
       }
-    } else if (bin === "cp") {
+    } else if (bin === "cp" || bin === "install" || bin === "rsync" || bin === "ln" || bin === "link" || bin === "scp") {
       if (targetDir) {
         const dirResolved = resolvePath(targetDir, currentCwd);
         if (dirResolved) targets.push(dirResolved);
@@ -968,7 +968,7 @@ function extractCommandMutationTargets(cmd: string, cwd?: string): string[] {
           if (r) targets.push(r);
         }
       }
-    } else if (bin === "rm" || bin === "touch" || bin === "tee") {
+    } else if (bin === "rm" || bin === "touch" || bin === "tee" || bin === "truncate" || bin === "unlink") {
       for (const arg of positionalArgs) {
         const r = resolvePath(arg, currentCwd);
         if (r) targets.push(r);

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -881,10 +881,14 @@ export function getCompletedStepTargetPaths(stepRow: StepRow, cwd?: string): str
     return resolved;
   }
 
-  const targetFile = fsPath(asStr(pick(rawInput, "TargetFile", "targetFile", "FilePath", "filePath", "path")))?.trim();
-  if (targetFile) {
-    const r = resolvePath(targetFile, displayCwd);
-    if (r) return [r];
+  // Only consider tools that mutate files (step type 5 or write/replace/edit/patch tools).
+  // Read-only tools (view_file, list_dir, grep_search, etc.) must not mark paths as superseded.
+  if (stepRow.stepType === 5 || (name && /write|replace|edit|patch/.test(name))) {
+    const targetFile = fsPath(asStr(pick(rawInput, "TargetFile", "targetFile", "FilePath", "filePath", "path")))?.trim();
+    if (targetFile) {
+      const r = resolvePath(targetFile, displayCwd);
+      if (r) return [r];
+    }
   }
 
   return [];

--- a/src/agy/db/tool-call-updates.ts
+++ b/src/agy/db/tool-call-updates.ts
@@ -14,6 +14,7 @@ import {
   planUpdateFromMarkdown,
   type PlanEntry
 } from "../../acp/agent-plan/index.js";
+import { tryReadImageContentBlock } from "../../acp/content/index.js";
 import type { SearchHit } from "./step-payload.js";
 import type { StepRow } from "./types.js";
 
@@ -846,6 +847,57 @@ export function subagentUpdate(stepRow: StepRow): SessionUpdate {
   const name = decodedToolName(stepRow) || "invoke_subagent";
 
   return toolCallUpdate({ stepRow, title, kind: "other", name, content });
+}
+
+/** Tool call for generate_image (image creation / manipulation tool). */
+export function imageGenerationUpdate(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate {
+  const cwd = ctx?.cwd;
+  const rawInput = parseRawInput(stepRow);
+  const prompt = asStr(pick(rawInput, "Prompt", "prompt"))?.trim();
+  const imageName = asStr(pick(rawInput, "ImageName", "imageName"))?.trim();
+  const aspectRatio = asStr(pick(rawInput, "AspectRatio", "aspectRatio"))?.trim();
+  const displayCwd = fsPath(cwd) ?? undefined;
+
+  const defaultTitle = imageName ? `Generate image ${imageName}` : "Generate image";
+  const title = resolveToolTitle(stepRow, defaultTitle);
+
+  const content: Record<string, unknown>[] = [];
+  const locations: Record<string, unknown>[] = [];
+
+  if (prompt) {
+    content.push(textBlock(`Prompt: ${prompt}${aspectRatio ? ` (${aspectRatio})` : ""}`));
+  }
+
+  // Look for generated image candidate paths
+  const candidatePaths: string[] = [];
+  const imagePathsRaw = pick(rawInput, "ImagePaths", "imagePaths");
+  if (Array.isArray(imagePathsRaw)) {
+    for (const p of imagePathsRaw) {
+      if (typeof p === "string" && p) candidatePaths.push(p);
+    }
+  }
+  if (imageName) {
+    candidatePaths.push(imageName);
+    if (!imageName.includes(".")) {
+      candidatePaths.push(`${imageName}.png`, `${imageName}.jpg`, `${imageName}.webp`);
+    }
+  }
+
+  for (const candidate of candidatePaths) {
+    const resolved = resolvePath(candidate, displayCwd);
+    if (!resolved) continue;
+    const imgBlock = tryReadImageContentBlock(resolved);
+    if (imgBlock) {
+      content.push({ type: "content", content: imgBlock });
+      if (isReadableLocation(resolved, ctx)) {
+        locations.push({ path: resolved });
+      }
+      break;
+    }
+  }
+
+  const name = decodedToolName(stepRow) || "generate_image";
+  return toolCallUpdate({ stepRow, title, kind: "other", name, content, locations });
 }
 
 /**

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -400,8 +400,13 @@ export class Translator {
         limit = text.length - 1;
       }
       const lastOpen = text.lastIndexOf("![");
-      if (lastOpen >= 0 && !text.slice(lastOpen).includes(")")) {
-        limit = Math.min(limit, lastOpen);
+      if (lastOpen >= 0) {
+        const tail = text.slice(lastOpen);
+        const destStart = tail.lastIndexOf("](");
+        const isClosed = destStart >= 0 && tail.slice(destStart + 2).includes(")");
+        if (!isClosed) {
+          limit = Math.min(limit, lastOpen);
+        }
       }
     }
     if (limit <= emitted) return;

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -361,9 +361,22 @@ export class Translator {
     // Chunks for the same step share one messageId (required by ACP v2).
     const emitted = this.agentTextLengths.get(row.idx) ?? 0;
     if (text.length <= emitted) return;
-    this.agentTextLengths.set(row.idx, text.length);
+
+    // When the row is actively streaming (canGrow: true), do not cut an incomplete
+    // markdown image embed in half (e.g. `![plot](path/to` without the closing `)`).
+    // Buffer from the opening `![` until the closing `)` arrives or the step finishes.
+    let limit = text.length;
+    if (canGrow) {
+      const lastOpen = text.lastIndexOf("![");
+      if (lastOpen >= emitted && !text.slice(lastOpen).includes(")")) {
+        limit = lastOpen;
+      }
+    }
+    if (limit <= emitted) return;
+
+    this.agentTextLengths.set(row.idx, limit);
     if (this.opts.skipNarration && isNarration(text)) return;
-    const delta = text.slice(emitted);
+    const delta = text.slice(emitted, limit);
     if (delta.length > 0) {
       const formatted = emitted === 0 && streamingNeedsSeparator ? `\n${delta}` : delta;
       const blocks = splitTextAndImages(formatted, this.opts.cwd);

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -14,8 +14,9 @@
 // This class owns the one row loop; the two modes are just small branches
 // inside it.
 
-import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import type { ContentBlock, SessionUpdate } from "@agentclientprotocol/sdk";
 import type { PlanEntry } from "../../acp/agent-plan/index.js";
+import { splitTextAndImages } from "../../acp/content/index.js";
 import { filterNarration, isNarration } from "./narration.js";
 import { isSystemMessage, isSystemMessagePrefix } from "./system-message.js";
 import type { FileContentCache } from "./tool-call-updates.js";
@@ -36,6 +37,14 @@ function agentChunk(text: string, messageId: string): SessionUpdate {
     sessionUpdate: "agent_message_chunk",
     messageId,
     content: { type: "text", text }
+  };
+}
+
+function agentContentBlockChunk(content: ContentBlock, messageId: string): SessionUpdate {
+  return {
+    sessionUpdate: "agent_message_chunk",
+    messageId,
+    content
   };
 }
 
@@ -356,7 +365,11 @@ export class Translator {
     if (this.opts.skipNarration && isNarration(text)) return;
     const delta = text.slice(emitted);
     if (delta.length > 0) {
-      out.push(agentChunk(emitted === 0 && streamingNeedsSeparator ? `\n${delta}` : delta, messageId));
+      const formatted = emitted === 0 && streamingNeedsSeparator ? `\n${delta}` : delta;
+      const blocks = splitTextAndImages(formatted, this.opts.cwd);
+      for (const block of blocks) {
+        out.push(agentContentBlockChunk(block, messageId));
+      }
     }
   }
 
@@ -373,15 +386,18 @@ export class Translator {
     this.pendingAgentStartStepIdx = null;
     this.pendingAgentEndStepIdx = null;
     if (text && text.length > 0) {
-      const chunk = agentChunk(text, messageId);
-      if (startStepIdx != null) {
-        const stamped = withStepMeta(chunk, startStepIdx);
-        if (endStepIdx != null && endStepIdx > startStepIdx) {
-          ((stamped as unknown as Record<string, unknown>)._meta as Record<string, unknown>).endStepIdx = endStepIdx;
+      const blocks = splitTextAndImages(text, this.opts.cwd);
+      for (const block of blocks) {
+        const chunk = agentContentBlockChunk(block, messageId);
+        if (startStepIdx != null) {
+          const stamped = withStepMeta(chunk, startStepIdx);
+          if (endStepIdx != null && endStepIdx > startStepIdx) {
+            ((stamped as unknown as Record<string, unknown>)._meta as Record<string, unknown>).endStepIdx = endStepIdx;
+          }
+          out.push(stamped);
+        } else {
+          out.push(chunk);
         }
-        out.push(stamped);
-      } else {
-        out.push(chunk);
       }
     }
   }

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -363,13 +363,16 @@ export class Translator {
     if (text.length <= emitted) return;
 
     // When the row is actively streaming (canGrow: true), do not cut an incomplete
-    // markdown image embed in half (e.g. `![plot](path/to` without the closing `)`).
-    // Buffer from the opening `![` until the closing `)` arrives or the step finishes.
+    // markdown image embed in half (e.g. trailing `!` or `![plot](path/to` without the closing `)`).
+    // Buffer from the opening `!` or `![` until the closing `)` arrives or the step finishes.
     let limit = text.length;
     if (canGrow) {
+      if (text.endsWith("!")) {
+        limit = text.length - 1;
+      }
       const lastOpen = text.lastIndexOf("![");
-      if (lastOpen >= emitted && !text.slice(lastOpen).includes(")")) {
-        limit = lastOpen;
+      if (lastOpen >= 0 && !text.slice(lastOpen).includes(")")) {
+        limit = Math.min(limit, lastOpen);
       }
     }
     if (limit <= emitted) return;

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -19,7 +19,7 @@ import type { PlanEntry } from "../../acp/agent-plan/index.js";
 import { splitTextAndImages } from "../../acp/content/index.js";
 import { filterNarration, isNarration } from "./narration.js";
 import { isSystemMessage, isSystemMessagePrefix } from "./system-message.js";
-import type { FileContentCache } from "./tool-call-updates.js";
+import type { FileContentCache, ImageArtifactCache } from "./tool-call-updates.js";
 import type { StepRow } from "./types.js";
 import { sessionUpdateFromStep } from "./updates.js";
 
@@ -110,6 +110,8 @@ export class Translator {
   private readonly fileContents: FileContentCache = new Map();
   // Stream + replay: previous plan entries keyed by plan id (stable entry-id reconciliation).
   private readonly planEntries: Map<string, PlanEntry[]> = new Map();
+  // Stream + replay: completed generate_image artifacts cached per tool call.
+  private readonly imageArtifacts: ImageArtifactCache = new Map();
   // Candidate ACP location paths and their readability during the latest translation.
   readonly locationReadability = new Map<string, boolean>();
   // Replay: buffered consecutive agent-text parts, flushed at boundaries.
@@ -218,7 +220,8 @@ export class Translator {
       cwd: this.opts.cwd,
       fileContents: this.fileContents,
       planEntries: this.planEntries,
-      locationReadability: this.locationReadability
+      locationReadability: this.locationReadability,
+      imageArtifacts: this.imageArtifacts
     });
     if (Array.isArray(update)) {
       for (const item of update) this.emitProgressive(row.idx, item, out);

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -439,7 +439,15 @@ export class Translator {
       if (lastOpen >= 0) {
         const tail = text.slice(lastOpen);
         const destStart = tail.lastIndexOf("](");
-        const isClosed = destStart >= 0 && tail.slice(destStart + 2).includes(")");
+        let isClosed = false;
+        if (destStart >= 0) {
+          const destBody = tail.slice(destStart + 2);
+          if (destBody.startsWith("<")) {
+            isClosed = destBody.includes(">)");
+          } else {
+            isClosed = destBody.includes(")");
+          }
+        }
         if (!isClosed) {
           limit = Math.min(limit, lastOpen);
         }

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -134,6 +134,7 @@ export class Translator {
   private pendingAgentMessageId: string | null = null;
   private pendingAgentStartStepIdx: number | null = null;
   private pendingAgentEndStepIdx: number | null = null;
+  private pendingAgentSupersededPaths: Set<string> | undefined;
 
   private _lastTitle: string | null = null;
   private _lastStepIdx = -1;
@@ -250,7 +251,7 @@ export class Translator {
 
     switch (row.stepType) {
       case 15: // agent text chunk
-        this.handleAgentText(row, out, streamingAgentMessageId, streamingNeedsSeparator, canGrow);
+        this.handleAgentText(row, out, streamingAgentMessageId, streamingNeedsSeparator, canGrow, supersededPaths);
         return;
 
       case 23: // conversation title (+ optional think narration)
@@ -397,7 +398,8 @@ export class Translator {
     out: SessionUpdate[],
     streamingAgentMessageId: string | null,
     streamingNeedsSeparator: boolean,
-    canGrow: boolean
+    canGrow: boolean,
+    supersededPaths?: Set<string>
   ): void {
     const thought = row.stepPayload.agentText?.thought;
     if (thought) {
@@ -415,6 +417,7 @@ export class Translator {
         if (this.pendingAgentMessageId === null) {
           this.pendingAgentMessageId = messageId;
           this.pendingAgentStartStepIdx = row.idx;
+          this.pendingAgentSupersededPaths = supersededPaths;
         }
         this.pendingAgentEndStepIdx = row.idx;
         this.pendingAgentParts.push(text);
@@ -475,12 +478,14 @@ export class Translator {
     const messageId = this.pendingAgentMessageId ?? "agent";
     const startStepIdx = this.pendingAgentStartStepIdx;
     const endStepIdx = this.pendingAgentEndStepIdx;
+    const superseded = this.pendingAgentSupersededPaths;
     this.pendingAgentParts.length = 0;
     this.pendingAgentMessageId = null;
     this.pendingAgentStartStepIdx = null;
     this.pendingAgentEndStepIdx = null;
+    this.pendingAgentSupersededPaths = undefined;
     if (text && text.length > 0) {
-      const blocks = splitTextAndImages(text, this.opts.cwd);
+      const blocks = splitTextAndImages(text, this.opts.cwd, superseded);
       for (const block of blocks) {
         const chunk = agentContentBlockChunk(block, messageId);
         if (startStepIdx != null) {

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -19,7 +19,7 @@ import type { PlanEntry } from "../../acp/agent-plan/index.js";
 import { splitTextAndImages } from "../../acp/content/index.js";
 import { filterNarration, isNarration } from "./narration.js";
 import { isSystemMessage, isSystemMessagePrefix } from "./system-message.js";
-import type { FileContentCache, ImageArtifactCache } from "./tool-call-updates.js";
+import { getCompletedStepTargetPaths, type FileContentCache, type ImageArtifactCache } from "./tool-call-updates.js";
 import type { StepRow } from "./types.js";
 import { sessionUpdateFromStep } from "./updates.js";
 
@@ -152,6 +152,23 @@ export class Translator {
     const out: SessionUpdate[] = [];
     let streamingAgentMessageId: string | null = null;
     let streamingHasVisibleText = false;
+
+    // Precompute paths modified by later completed steps in this batch.
+    // A historical step cannot reliably attribute the current file on disk if a
+    // later completed step in the batch overwrote that target path.
+    const supersededPaths = new Set<string>();
+    const supersededByRowIndex: Set<string>[] = new Array(rows.length);
+    for (let i = rows.length - 1; i >= 0; i--) {
+      supersededByRowIndex[i] = new Set(supersededPaths);
+      const row = rows[i];
+      if (row.status === 3) {
+        const modified = getCompletedStepTargetPaths(row, this.opts.cwd);
+        for (const p of modified) {
+          supersededPaths.add(p);
+        }
+      }
+    }
+
     for (const [rowIndex, row] of rows.entries()) {
       let streamingNeedsSeparator = false;
       const canGrow = rowIndex === rows.length - 1 && row.status !== 3 && row.status !== 6 && row.status !== 7;
@@ -170,7 +187,14 @@ export class Translator {
           streamingHasVisibleText = false;
         }
       }
-      this.translateRow(row, out, streamingAgentMessageId, streamingNeedsSeparator, canGrow);
+      this.translateRow(
+        row,
+        out,
+        streamingAgentMessageId,
+        streamingNeedsSeparator,
+        canGrow,
+        supersededByRowIndex[rowIndex]
+      );
     }
     // Replay groups agent text per batch; a batch ends a message boundary.
     if (this.opts.mode === "replay") this.flushAgentBuffer(out);
@@ -183,7 +207,8 @@ export class Translator {
     out: SessionUpdate[],
     streamingAgentMessageId: string | null,
     streamingNeedsSeparator: boolean,
-    canGrow: boolean
+    canGrow: boolean,
+    supersededPaths?: Set<string>
   ): void {
     this._lastStepIdx = Math.max(this._lastStepIdx, row.idx);
 
@@ -200,7 +225,7 @@ export class Translator {
         // The streaming client already has its own prompt; only replay re-emits it.
         if (this.opts.mode === "stream") return;
         this.flushAgentBuffer(out);
-        this.pushDispatched(row, out);
+        this.pushDispatched(row, out, supersededPaths);
         return;
 
       default: {
@@ -210,18 +235,19 @@ export class Translator {
         if (this.opts.mode === "replay") {
           this.flushAgentBuffer(out);
         }
-        this.pushDispatched(row, out);
+        this.pushDispatched(row, out, supersededPaths);
       }
     }
   }
 
-  private pushDispatched(row: StepRow, out: SessionUpdate[]): void {
+  private pushDispatched(row: StepRow, out: SessionUpdate[], supersededPaths?: Set<string>): void {
     const update = sessionUpdateFromStep(row, {
       cwd: this.opts.cwd,
       fileContents: this.fileContents,
       planEntries: this.planEntries,
       locationReadability: this.locationReadability,
-      imageArtifacts: this.imageArtifacts
+      imageArtifacts: this.imageArtifacts,
+      supersededPaths
     });
     if (Array.isArray(update)) {
       for (const item of update) this.emitProgressive(row.idx, item, out);

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -16,7 +16,7 @@
 
 import type { ContentBlock, SessionUpdate } from "@agentclientprotocol/sdk";
 import type { PlanEntry } from "../../acp/agent-plan/index.js";
-import { splitTextAndImages } from "../../acp/content/index.js";
+import { splitTextAndImages, splitTextAndImagesWithRanges } from "../../acp/content/index.js";
 import type { GenMetadataUsage } from "./gen-metadata.js";
 import { filterNarration, isNarration } from "./narration.js";
 import { isSystemMessage, isSystemMessagePrefix } from "./system-message.js";
@@ -462,10 +462,20 @@ export class Translator {
     if (this.opts.skipNarration && isNarration(text)) return;
     const delta = text.slice(emitted, limit);
     if (delta.length > 0) {
-      const formatted = emitted === 0 && streamingNeedsSeparator ? `\n${delta}` : delta;
-      const blocks = splitTextAndImages(formatted, this.opts.cwd);
-      for (const block of blocks) {
-        out.push(agentContentBlockChunk(block, messageId));
+      const fullText = text.slice(0, limit);
+      const spanned = splitTextAndImagesWithRanges(fullText, this.opts.cwd);
+      let isFirstEmitted = true;
+      for (const { block, start, end } of spanned) {
+        if (end <= emitted) continue;
+        let b = block;
+        if (start < emitted && b.type === "text") {
+          b = { type: "text", text: b.text.slice(emitted - start) };
+        }
+        if (emitted === 0 && isFirstEmitted && streamingNeedsSeparator && b.type === "text") {
+          b = { type: "text", text: `\n${b.text}` };
+        }
+        isFirstEmitted = false;
+        out.push(agentContentBlockChunk(b, messageId));
       }
     }
   }

--- a/src/agy/db/translator.ts
+++ b/src/agy/db/translator.ts
@@ -176,7 +176,7 @@ export class Translator {
     for (let i = rows.length - 1; i >= 0; i--) {
       supersededByRowIndex[i] = new Set(supersededPaths);
       const row = rows[i];
-      if (row.status === 3) {
+      if (row.status === 3 || row.status === 6 || row.status === 7) {
         const modified = getCompletedStepTargetPaths(row, this.opts.cwd);
         for (const p of modified) {
           supersededPaths.add(p);

--- a/src/agy/db/updates.ts
+++ b/src/agy/db/updates.ts
@@ -9,6 +9,7 @@ import {
   editUpdate,
   executeUpdate,
   fetchUpdate,
+  imageGenerationUpdate,
   isThoughtToolName,
   otherUpdate,
   questionUpdate,
@@ -191,6 +192,7 @@ function buildByToolName(stepRow: StepRow, ctx?: UpdateContext): SessionUpdate |
   if (name === "read_url_content") return fetchUpdate(stepRow);
   if (name === "invoke_subagent") return subagentUpdate(stepRow);
   if (name === "ask_question") return questionUpdate(stepRow);
+  if (name === "generate_image") return imageGenerationUpdate(stepRow, ctx);
   if (/write|replace|edit|patch/.test(name)) return editUpdate(stepRow, ctx);
   return otherUpdate(stepRow);
 }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4806,6 +4806,66 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("accounts for mutations from failed or cancelled terminal steps when precomputing superseded paths on replay", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-failed-"));
+    try {
+      const imgPath = path.join(testDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-failed");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Version 1 of mockup",
+                ImageName: "mockup.png"
+              })
+            })
+          })
+        })
+      });
+      // Step 2 failed (status 7), but modified mockup.png during execution
+      insertStep(db, {
+        idx: 2,
+        stepType: 21,
+        status: 7,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "run-cmd-call-2",
+              namePrimary: "run_command",
+              rawInputJson: JSON.stringify({
+                CommandLine: "cp replacement.png mockup.png; false"
+              })
+            })
+          })
+        })
+      });
+
+      const replayTranslator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = replayTranslator.translate(ConversationDb.open(testDir, "conv-gen-img-failed")!.readAfter(-1));
+
+      expect(updates).toHaveLength(2);
+      const update1 = updates[0] as any;
+
+      // Call 1 image must not be reconstructed because failed command in step 2 overwrote mockup.png
+      expect(update1.sessionUpdate).toBe("tool_call");
+      expect(update1.toolCallId).toBe("gen-img-call-1");
+      expect(update1.content).toHaveLength(1);
+      expect(update1.locations).toBeUndefined();
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("retries image reads on subsequent streaming polls after a transient miss", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-retry-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4866,6 +4866,66 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("recognizes install command destinations when determining superseded paths on replay", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-install-"));
+    try {
+      const imgPath = path.join(testDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-install");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Version 1 of mockup",
+                ImageName: "mockup.png"
+              })
+            })
+          })
+        })
+      });
+      // Step 2 uses install command to write replacement to mockup.png
+      insertStep(db, {
+        idx: 2,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "run-cmd-call-2",
+              namePrimary: "run_command",
+              rawInputJson: JSON.stringify({
+                CommandLine: "install replacement.png mockup.png"
+              })
+            })
+          })
+        })
+      });
+
+      const replayTranslator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = replayTranslator.translate(ConversationDb.open(testDir, "conv-gen-img-install")!.readAfter(-1));
+
+      expect(updates).toHaveLength(2);
+      const update1 = updates[0] as any;
+
+      // Call 1 image must not be reconstructed because install command in step 2 overwrote mockup.png
+      expect(update1.sessionUpdate).toBe("tool_call");
+      expect(update1.toolCallId).toBe("gen-img-call-1");
+      expect(update1.content).toHaveLength(1);
+      expect(update1.locations).toBeUndefined();
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("retries image reads on subsequent streaming polls after a transient miss", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-retry-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -5040,6 +5040,58 @@ describe("agent outbound image ContentBlocks", () => {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
   });
+
+  it("buffers incomplete angle-bracket markdown image syntax when destination contains parentheses", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-stream-angle-paren-"));
+    try {
+      const imgPath = path.join(testDir, "plot (Q1).png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-stream-angle-paren");
+      // Step is active (status 1) and splits inside angle-bracket destination right after internal parenthesis
+      insertStep(db, {
+        idx: 1,
+        stepType: 15,
+        status: 1,
+        stepPayload: encodeStepPayload({
+          agentText: `Here is the plot:\n![plot](<${imgPath.slice(0, imgPath.indexOf(")"))}`
+        })
+      });
+
+      const translator = new Translator({ mode: "stream", skipNarration: false, cwd: testDir });
+      // Poll 1: must stay buffered because >) has not arrived yet
+      const updates1 = translator.translate(ConversationDb.open(testDir, "conv-stream-angle-paren")!.readAfter(-1));
+
+      expect(updates1).toHaveLength(1);
+      expect(updates1[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Here is the plot:\n" }
+      });
+
+      // Poll 2: full angle-bracket markdown image arrives and step completes
+      updateStep(db, 1, {
+        status: 3,
+        stepPayload: encodeStepPayload({
+          agentText: `Here is the plot:\n![plot](<${imgPath}>)\nAll done!`
+        })
+      });
+      const updates2 = translator.translate(ConversationDb.open(testDir, "conv-stream-angle-paren")!.readAfter(-1));
+
+      expect(updates2).toHaveLength(2);
+      expect(updates2[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "image", data: PNG_PIXEL, mimeType: "image/png" }
+      });
+      expect(updates2[1]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "\nAll done!" }
+      });
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("ConversationDb gen_metadata & token usage", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4422,6 +4422,73 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("marks prior image generation outputs as superseded on replay when a later run_command targets that path", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-cmd-"));
+    try {
+      const imgPath = path.join(testDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-cmd");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Version 1 of mockup",
+                ImageName: "mockup.png"
+              })
+            })
+          })
+        })
+      });
+      // Step 2 is a completed run_command overwriting mockup.png
+      insertStep(db, {
+        idx: 2,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "run-cmd-call-2",
+              namePrimary: "run_command",
+              rawInputJson: JSON.stringify({
+                CommandLine: "cp replacement.png mockup.png"
+              })
+            })
+          })
+        })
+      });
+
+      const replayTranslator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = replayTranslator.translate(ConversationDb.open(testDir, "conv-gen-img-cmd")!.readAfter(-1));
+
+      expect(updates).toHaveLength(2);
+      const update1 = updates[0] as any;
+
+      // Call 1 image must not be reconstructed from the overwritten file on replay
+      expect(update1.sessionUpdate).toBe("tool_call");
+      expect(update1.toolCallId).toBe("gen-img-call-1");
+      expect(update1.content).toHaveLength(1);
+      expect(update1.content[0]).toEqual({
+        type: "content",
+        content: {
+          type: "text",
+          text: "Prompt: Version 1 of mockup"
+        }
+      });
+      expect(update1.locations).toBeUndefined();
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("retries image reads on subsequent streaming polls after a transient miss", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-retry-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4354,6 +4354,81 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("retries image reads on subsequent streaming polls after a transient miss", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-retry-"));
+    try {
+      const imgPath = path.join(testDir, "output.png");
+
+      const db = createConversationDb(testDir, "conv-gen-img-retry");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-retry-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Create logo",
+                ImageName: "output.png"
+              })
+            })
+          })
+        })
+      });
+
+      const translator = new Translator({ mode: "stream", skipNarration: false, cwd: testDir });
+
+      // Poll 1: step is status 3, but file is not on disk yet (transient miss)
+      const poll1 = translator.translate(ConversationDb.open(testDir, "conv-gen-img-retry")!.readAfter(-1));
+      expect(poll1).toHaveLength(1);
+      const update1 = poll1[0] as any;
+      expect(update1.sessionUpdate).toBe("tool_call");
+      expect(update1.content).toEqual([
+        {
+          type: "content",
+          content: {
+            type: "text",
+            text: "Prompt: Create logo"
+          }
+        }
+      ]);
+      expect(update1.locations).toBeUndefined();
+
+      // File is now written to disk
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      // Poll 2: full snapshot re-read in StreamPoller retries reading output.png and emits tool_call_update
+      const poll2 = translator.translate(ConversationDb.open(testDir, "conv-gen-img-retry")!.readAfter(-1));
+      expect(poll2).toHaveLength(1);
+      const update2 = poll2[0] as any;
+      expect(update2.sessionUpdate).toBe("tool_call_update");
+      expect(update2.content).toEqual([
+        {
+          type: "content",
+          content: {
+            type: "text",
+            text: "Prompt: Create logo"
+          }
+        },
+        {
+          type: "content",
+          content: {
+            type: "image",
+            data: PNG_PIXEL,
+            mimeType: "image/png"
+          }
+        }
+      ]);
+      expect(update2.locations).toEqual([{ path: imgPath }]);
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("replays agent responses containing markdown images as segmented text and image ContentBlocks", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-replay-img-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4489,6 +4489,134 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("does not mark image as superseded when later command only reads from it (e.g. cp source dest)", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-cp-read-"));
+    try {
+      const imgPath = path.join(testDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-cp-read");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Version 1 of mockup",
+                ImageName: "mockup.png"
+              })
+            })
+          })
+        })
+      });
+      // Step 2 copies mockup.png to backup.png (mockup.png is read, not overwritten)
+      insertStep(db, {
+        idx: 2,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "run-cmd-call-2",
+              namePrimary: "run_command",
+              rawInputJson: JSON.stringify({
+                CommandLine: "cp mockup.png backup.png"
+              })
+            })
+          })
+        })
+      });
+
+      const replayTranslator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = replayTranslator.translate(ConversationDb.open(testDir, "conv-gen-img-cp-read")!.readAfter(-1));
+
+      expect(updates).toHaveLength(2);
+      const update1 = updates[0] as any;
+
+      // Call 1 image must remain attached since mockup.png was not overwritten
+      expect(update1.sessionUpdate).toBe("tool_call");
+      expect(update1.toolCallId).toBe("gen-img-call-1");
+      expect(update1.content).toHaveLength(2);
+      expect(update1.content[1]).toEqual({
+        type: "content",
+        content: {
+          type: "image",
+          data: PNG_PIXEL,
+          mimeType: "image/png"
+        }
+      });
+      expect(update1.locations).toEqual([{ path: imgPath }]);
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks image as superseded when later command redirects output to it", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-redir-"));
+    try {
+      const imgPath = path.join(testDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-redir");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Version 1 of mockup",
+                ImageName: "mockup.png"
+              })
+            })
+          })
+        })
+      });
+      // Step 2 redirects output to mockup.png
+      insertStep(db, {
+        idx: 2,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "run-cmd-call-2",
+              namePrimary: "run_command",
+              rawInputJson: JSON.stringify({
+                CommandLine: "echo 'overwritten' > mockup.png"
+              })
+            })
+          })
+        })
+      });
+
+      const replayTranslator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = replayTranslator.translate(ConversationDb.open(testDir, "conv-gen-img-redir")!.readAfter(-1));
+
+      expect(updates).toHaveLength(2);
+      const update1 = updates[0] as any;
+
+      // Call 1 image must not be reconstructed
+      expect(update1.sessionUpdate).toBe("tool_call");
+      expect(update1.toolCallId).toBe("gen-img-call-1");
+      expect(update1.content).toHaveLength(1);
+      expect(update1.locations).toBeUndefined();
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("retries image reads on subsequent streaming polls after a transient miss", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-retry-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4354,6 +4354,74 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("does not classify read-only steps as superseding prior image generation outputs on replay", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-readonly-"));
+    try {
+      const imgPath = path.join(testDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-readonly");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Version of mockup",
+                ImageName: "mockup.png"
+              })
+            })
+          })
+        })
+      });
+      // Step 2 is a completed view_file on the same path
+      insertStep(db, {
+        idx: 2,
+        stepType: 8,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "view-file-call-2",
+              namePrimary: "view_file",
+              rawInputJson: JSON.stringify({
+                FilePath: "mockup.png"
+              })
+            })
+          })
+        })
+      });
+
+      const replayTranslator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = replayTranslator.translate(ConversationDb.open(testDir, "conv-gen-img-readonly")!.readAfter(-1));
+
+      expect(updates).toHaveLength(2);
+      const update1 = updates[0] as any;
+
+      // Call 1 image must not be marked superseded by the read-only view_file step
+      expect(update1.sessionUpdate).toBe("tool_call");
+      expect(update1.toolCallId).toBe("gen-img-call-1");
+      expect(update1.content).toHaveLength(2);
+      expect(update1.content[1]).toEqual({
+        type: "content",
+        content: {
+          type: "image",
+          data: PNG_PIXEL,
+          mimeType: "image/png"
+        }
+      });
+      expect(update1.locations).toEqual([{ path: imgPath }]);
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("retries image reads on subsequent streaming polls after a transient miss", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-retry-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4115,12 +4115,12 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
-  it("prioritizes newly generated output ImageName over input reference ImagePaths", () => {
+  it("attaches newly generated output ImageName and does not fall back to input reference ImagePaths", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-prio-"));
     try {
       const refImgPath = path.join(testDir, "reference.png");
       const outImgPath = path.join(testDir, "output.png");
-      fs.writeFileSync(refImgPath, "REFERENCE_BYTES");
+      fs.writeFileSync(refImgPath, Buffer.from(PNG_PIXEL, "base64"));
       fs.writeFileSync(outImgPath, Buffer.from(PNG_PIXEL, "base64"));
 
       const db = createConversationDb(testDir, "conv-gen-img-prio");
@@ -4158,7 +4158,42 @@ describe("agent outbound image ContentBlocks", () => {
         }
       });
 
+      // When output ImageName is unreadable/missing, reference image must NOT be attached
+      const db2 = createConversationDb(testDir, "conv-gen-img-no-out");
+      insertStep(db2, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-no-out-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Failed generation with reference image",
+                ImageName: "missing-output.png",
+                ImagePaths: ["reference.png"]
+              })
+            })
+          })
+        })
+      });
+
+      const updates2 = translator.translate(ConversationDb.open(testDir, "conv-gen-img-no-out")!.readAfter(-1));
+      expect(updates2).toHaveLength(1);
+      const update2 = updates2[0] as any;
+      expect(update2.locations).toBeUndefined();
+      expect(update2.content).toHaveLength(1);
+      expect(update2.content[0]).toEqual({
+        type: "content",
+        content: {
+          type: "text",
+          text: "Prompt: Failed generation with reference image"
+        }
+      });
+
       db.close();
+      db2.close();
     } finally {
       fs.rmSync(testDir, { recursive: true, force: true });
     }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4978,6 +4978,66 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("unwraps sudo and env command launchers when detecting write targets on replay", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-launcher-"));
+    try {
+      const imgPath = path.join(testDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-launcher");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Version 1 of mockup",
+                ImageName: "mockup.png"
+              })
+            })
+          })
+        })
+      });
+      // Step 2 wraps cp under sudo and env
+      insertStep(db, {
+        idx: 2,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "run-cmd-call-2",
+              namePrimary: "run_command",
+              rawInputJson: JSON.stringify({
+                CommandLine: "sudo -u root env MODE=x cp replacement.png mockup.png"
+              })
+            })
+          })
+        })
+      });
+
+      const replayTranslator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = replayTranslator.translate(ConversationDb.open(testDir, "conv-gen-img-launcher")!.readAfter(-1));
+
+      expect(updates).toHaveLength(2);
+      const update1 = updates[0] as any;
+
+      // Call 1 image must not be reconstructed because sudo/env wrapped command in step 2 overwrote mockup.png
+      expect(update1.sessionUpdate).toBe("tool_call");
+      expect(update1.toolCallId).toBe("gen-img-call-1");
+      expect(update1.content).toHaveLength(1);
+      expect(update1.locations).toBeUndefined();
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("retries image reads on subsequent streaming polls after a transient miss", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-retry-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4617,6 +4617,68 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("tracks working directory changes across command segments when resolving superseded paths on replay", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-cd-"));
+    try {
+      const outDir = path.join(testDir, "out");
+      fs.mkdirSync(outDir, { recursive: true });
+      const imgPath = path.join(outDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-cd");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Version 1 of mockup in out",
+                ImageName: "out/mockup.png"
+              })
+            })
+          })
+        })
+      });
+      // Step 2 changes directory into out and overwrites mockup.png
+      insertStep(db, {
+        idx: 2,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "run-cmd-call-2",
+              namePrimary: "run_command",
+              rawInputJson: JSON.stringify({
+                CommandLine: "cd out && cp ../replacement.png mockup.png"
+              })
+            })
+          })
+        })
+      });
+
+      const replayTranslator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = replayTranslator.translate(ConversationDb.open(testDir, "conv-gen-img-cd")!.readAfter(-1));
+
+      expect(updates).toHaveLength(2);
+      const update1 = updates[0] as any;
+
+      // Call 1 image must not be reconstructed because cd out && cp ... mockup.png targeted out/mockup.png
+      expect(update1.sessionUpdate).toBe("tool_call");
+      expect(update1.toolCallId).toBe("gen-img-call-1");
+      expect(update1.content).toHaveLength(1);
+      expect(update1.locations).toBeUndefined();
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("retries image reads on subsequent streaming polls after a transient miss", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-retry-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4328,4 +4328,56 @@ describe("agent outbound image ContentBlocks", () => {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
   });
+
+  it("buffers a split exclamation prefix across streaming polls", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-stream-excl-"));
+    try {
+      const imgPath = path.join(testDir, "plot.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-stream-excl");
+      // Step is active (status 1) and ends immediately after '!'
+      insertStep(db, {
+        idx: 1,
+        stepType: 15,
+        status: 1,
+        stepPayload: encodeStepPayload({
+          agentText: "Here is the plot:\n!" // ends right after !
+        })
+      });
+
+      const translator = new Translator({ mode: "stream", skipNarration: false, cwd: testDir });
+      // Poll 1: '!' must stay buffered, only 'Here is the plot:\n' is emitted
+      const updates1 = translator.translate(ConversationDb.open(testDir, "conv-stream-excl")!.readAfter(-1));
+
+      expect(updates1).toHaveLength(1);
+      expect(updates1[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Here is the plot:\n" }
+      });
+
+      // Poll 2: remainder arrives completing the image embed
+      updateStep(db, 1, {
+        status: 3,
+        stepPayload: encodeStepPayload({
+          agentText: `Here is the plot:\n![plot](${imgPath})\nAll done!`
+        })
+      });
+      const updates2 = translator.translate(ConversationDb.open(testDir, "conv-stream-excl")!.readAfter(-1));
+
+      expect(updates2).toHaveLength(2);
+      expect(updates2[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "image", data: PNG_PIXEL, mimeType: "image/png" }
+      });
+      expect(updates2[1]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "\nAll done!" }
+      });
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4682,6 +4682,130 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("resolves directory-form copy destination paths when determining superseded paths on replay", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-cpdir-"));
+    try {
+      const outDir = path.join(testDir, "out");
+      fs.mkdirSync(outDir, { recursive: true });
+      const imgPath = path.join(outDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-cpdir");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Version 1 of mockup in out",
+                ImageName: "out/mockup.png"
+              })
+            })
+          })
+        })
+      });
+      // Step 2 uses directory form cp replacements/mockup.png out/
+      insertStep(db, {
+        idx: 2,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "run-cmd-call-2",
+              namePrimary: "run_command",
+              rawInputJson: JSON.stringify({
+                CommandLine: "cp replacements/mockup.png out/"
+              })
+            })
+          })
+        })
+      });
+
+      const replayTranslator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = replayTranslator.translate(ConversationDb.open(testDir, "conv-gen-img-cpdir")!.readAfter(-1));
+
+      expect(updates).toHaveLength(2);
+      const update1 = updates[0] as any;
+
+      // Call 1 image must not be reconstructed because cp ... out/ overwrote out/mockup.png
+      expect(update1.sessionUpdate).toBe("tool_call");
+      expect(update1.toolCallId).toBe("gen-img-call-1");
+      expect(update1.content).toHaveLength(1);
+      expect(update1.locations).toBeUndefined();
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves target-directory -t copy destination paths when determining superseded paths on replay", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-cptarget-"));
+    try {
+      const outDir = path.join(testDir, "out");
+      fs.mkdirSync(outDir, { recursive: true });
+      const imgPath = path.join(outDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-cptarget");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Version 1 of mockup in out",
+                ImageName: "out/mockup.png"
+              })
+            })
+          })
+        })
+      });
+      // Step 2 uses -t target-directory form cp -t out replacements/mockup.png
+      insertStep(db, {
+        idx: 2,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "run-cmd-call-2",
+              namePrimary: "run_command",
+              rawInputJson: JSON.stringify({
+                CommandLine: "cp -t out replacements/mockup.png"
+              })
+            })
+          })
+        })
+      });
+
+      const replayTranslator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = replayTranslator.translate(ConversationDb.open(testDir, "conv-gen-img-cptarget")!.readAfter(-1));
+
+      expect(updates).toHaveLength(2);
+      const update1 = updates[0] as any;
+
+      // Call 1 image must not be reconstructed because cp -t out ... overwrote out/mockup.png
+      expect(update1.sessionUpdate).toBe("tool_call");
+      expect(update1.toolCallId).toBe("gen-img-call-1");
+      expect(update1.content).toHaveLength(1);
+      expect(update1.locations).toBeUndefined();
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("retries image reads on subsequent streaming polls after a transient miss", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-retry-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4241,4 +4241,56 @@ describe("agent outbound image ContentBlocks", () => {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
   });
+
+  it("buffers incomplete markdown image syntax while streaming until closing parenthesis arrives", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-stream-buf-"));
+    try {
+      const imgPath = path.join(testDir, "plot.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-stream-buf");
+      // Step is currently active/in-progress (status 1) and growing
+      insertStep(db, {
+        idx: 1,
+        stepType: 15,
+        status: 1,
+        stepPayload: encodeStepPayload({
+          agentText: `Here is the plot:\n![plot](${imgPath.slice(0, 10)}` // unclosed markdown image embed
+        })
+      });
+
+      const translator = new Translator({ mode: "stream", skipNarration: false, cwd: testDir });
+      // Poll 1: only the prefix before ![plot] should be emitted, buffering the incomplete image embed
+      const updates1 = translator.translate(ConversationDb.open(testDir, "conv-stream-buf")!.readAfter(-1));
+
+      expect(updates1).toHaveLength(1);
+      expect(updates1[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Here is the plot:\n" }
+      });
+
+      // Poll 2: full markdown image arrives and step completes (status 3)
+      updateStep(db, 1, {
+        status: 3,
+        stepPayload: encodeStepPayload({
+          agentText: `Here is the plot:\n![plot](${imgPath})\nAll done!`
+        })
+      });
+      const updates2 = translator.translate(ConversationDb.open(testDir, "conv-stream-buf")!.readAfter(-1));
+
+      expect(updates2).toHaveLength(2);
+      expect(updates2[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "image", data: PNG_PIXEL, mimeType: "image/png" }
+      });
+      expect(updates2[1]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "\nAll done!" }
+      });
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4065,6 +4065,105 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("does not attach pre-existing images when generate_image step is not completed (status 1, 7, 9)", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-pending-"));
+    try {
+      const imgPath = path.join(testDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-pending");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 1, // running / in-progress
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-pending-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "A futuristic login interface",
+                ImageName: "mockup.png"
+              })
+            })
+          })
+        })
+      });
+
+      const translator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = translator.translate(ConversationDb.open(testDir, "conv-gen-img-pending")!.readAfter(-1));
+
+      expect(updates).toHaveLength(1);
+      const update = updates[0] as any;
+      expect(update.sessionUpdate).toBe("tool_call");
+      expect(update.name).toBe("generate_image");
+      // Only text prompt should be present, not the pre-existing image
+      expect(update.content).toEqual([
+        {
+          type: "content",
+          content: {
+            type: "text",
+            text: "Prompt: A futuristic login interface"
+          }
+        }
+      ]);
+      expect(update.locations).toBeUndefined();
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it("prioritizes newly generated output ImageName over input reference ImagePaths", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-prio-"));
+    try {
+      const refImgPath = path.join(testDir, "reference.png");
+      const outImgPath = path.join(testDir, "output.png");
+      fs.writeFileSync(refImgPath, "REFERENCE_BYTES");
+      fs.writeFileSync(outImgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-prio");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-prio-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Edit this reference image",
+                ImageName: "output.png",
+                ImagePaths: ["reference.png"]
+              })
+            })
+          })
+        })
+      });
+
+      const translator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = translator.translate(ConversationDb.open(testDir, "conv-gen-img-prio")!.readAfter(-1));
+
+      expect(updates).toHaveLength(1);
+      const update = updates[0] as any;
+      expect(update.locations).toEqual([{ path: outImgPath }]);
+      expect(update.content[1]).toEqual({
+        type: "content",
+        content: {
+          type: "image",
+          data: PNG_PIXEL,
+          mimeType: "image/png"
+        }
+      });
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("replays agent responses containing markdown images as segmented text and image ContentBlocks", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-replay-img-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4795,4 +4795,56 @@ describe("agent outbound image ContentBlocks", () => {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
   });
+
+  it("buffers incomplete markdown image syntax when caption contains parentheses", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-stream-paren-"));
+    try {
+      const imgPath = path.join(testDir, "plot.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-stream-paren");
+      // Step is active (status 1) and splits before destination closes, with caption containing ()
+      insertStep(db, {
+        idx: 1,
+        stepType: 15,
+        status: 1,
+        stepPayload: encodeStepPayload({
+          agentText: `Here is the plot:\n![Chart (Q1)](${imgPath.slice(0, 10)}`
+        })
+      });
+
+      const translator = new Translator({ mode: "stream", skipNarration: false, cwd: testDir });
+      // Poll 1: '![Chart (Q1)](' must stay buffered because destination is not closed
+      const updates1 = translator.translate(ConversationDb.open(testDir, "conv-stream-paren")!.readAfter(-1));
+
+      expect(updates1).toHaveLength(1);
+      expect(updates1[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Here is the plot:\n" }
+      });
+
+      // Poll 2: full markdown image arrives and step completes
+      updateStep(db, 1, {
+        status: 3,
+        stepPayload: encodeStepPayload({
+          agentText: `Here is the plot:\n![Chart (Q1)](${imgPath})\nAll done!`
+        })
+      });
+      const updates2 = translator.translate(ConversationDb.open(testDir, "conv-stream-paren")!.readAfter(-1));
+
+      expect(updates2).toHaveLength(2);
+      expect(updates2[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "image", data: PNG_PIXEL, mimeType: "image/png" }
+      });
+      expect(updates2[1]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "\nAll done!" }
+      });
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4003,3 +4003,143 @@ describe("isSystemMessage & isSystemMessagePrefix", () => {
     expect(isSystemMessage("Regular text")).toBe(false);
   });
 });
+
+describe("agent outbound image ContentBlocks", () => {
+  const PNG_PIXEL = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+  it("translates generate_image tool calls with input prompt and embedded image block when artifact exists", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-"));
+    try {
+      const imgPath = path.join(testDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "A futuristic login interface",
+                ImageName: "mockup.png",
+                AspectRatio: "16:9"
+              })
+            })
+          })
+        })
+      });
+
+      const translator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = translator.translate(ConversationDb.open(testDir, "conv-gen-img")!.readAfter(-1));
+
+      expect(updates).toHaveLength(1);
+      const update = updates[0] as any;
+      expect(update.sessionUpdate).toBe("tool_call");
+      expect(update.name).toBe("generate_image");
+      expect(update.content).toEqual([
+        {
+          type: "content",
+          content: {
+            type: "text",
+            text: "Prompt: A futuristic login interface (16:9)"
+          }
+        },
+        {
+          type: "content",
+          content: {
+            type: "image",
+            data: PNG_PIXEL,
+            mimeType: "image/png"
+          }
+        }
+      ]);
+      expect(update.locations).toEqual([{ path: imgPath }]);
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it("replays agent responses containing markdown images as segmented text and image ContentBlocks", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-replay-img-"));
+    try {
+      const imgPath = path.join(testDir, "diagram.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-replay-img");
+      insertStep(db, {
+        idx: 1,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          agentText: `Here is the architecture:\n![Architecture Diagram](${imgPath})\nAny questions?`
+        })
+      });
+
+      const translator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = translator.translate(ConversationDb.open(testDir, "conv-replay-img")!.readAfter(-1));
+
+      expect(updates).toHaveLength(3);
+      expect(updates[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Here is the architecture:\n" }
+      });
+      expect(updates[1]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "image", data: PNG_PIXEL, mimeType: "image/png" }
+      });
+      expect(updates[2]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "\nAny questions?" }
+      });
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it("streams agent responses containing markdown images as segmented ContentBlocks", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-stream-img-"));
+    try {
+      const imgPath = path.join(testDir, "sample.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-stream-img");
+      insertStep(db, {
+        idx: 1,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          agentText: `Preview:\n![sample](${imgPath})\nFinished!`
+        })
+      });
+
+      const translator = new Translator({ mode: "stream", skipNarration: false, cwd: testDir });
+      const updates = translator.translate(ConversationDb.open(testDir, "conv-stream-img")!.readAfter(-1));
+
+      expect(updates).toHaveLength(3);
+      expect(updates[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Preview:\n" }
+      });
+      expect(updates[1]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "image", data: PNG_PIXEL, mimeType: "image/png" }
+      });
+      expect(updates[2]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "\nFinished!" }
+      });
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4926,6 +4926,58 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("does not reconstruct historical markdown images in agent messages when superseded by later tools on replay", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-agent-img-superseded-"));
+    try {
+      const imgPath = path.join(testDir, "mockup.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-agent-img-superseded");
+      insertStep(db, {
+        idx: 1,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          agentText: "Here is the mockup:\n![mockup](mockup.png)\nEnd of mockup."
+        })
+      });
+      // Step 2 overwrites mockup.png via cp
+      insertStep(db, {
+        idx: 2,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "run-cmd-call-2",
+              namePrimary: "run_command",
+              rawInputJson: JSON.stringify({
+                CommandLine: "cp replacement.png mockup.png"
+              })
+            })
+          })
+        })
+      });
+
+      const replayTranslator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = replayTranslator.translate(ConversationDb.open(testDir, "conv-agent-img-superseded")!.readAfter(-1));
+
+      expect(updates).toHaveLength(2);
+      const update1 = updates[0] as any;
+
+      // Agent message in step 1 must remain plain text instead of attaching the superseded replacement image
+      expect(update1.sessionUpdate).toBe("agent_message_chunk");
+      expect(update1.content).toEqual({
+        type: "text",
+        text: "Here is the mockup:\n![mockup](mockup.png)\nEnd of mockup."
+      });
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("retries image reads on subsequent streaming polls after a transient miss", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-retry-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -5053,6 +5053,54 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("preserves code span context across multi-poll streaming chunks", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-stream-codespan-"));
+    try {
+      const imgPath = path.join(testDir, "plot.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-stream-codespan");
+      // Poll 1: step is active (status 1) and ends right after opening backtick
+      insertStep(db, {
+        idx: 1,
+        stepType: 15,
+        status: 1,
+        stepPayload: encodeStepPayload({
+          agentText: "Here is example code: `"
+        })
+      });
+
+      const translator = new Translator({ mode: "stream", skipNarration: false, cwd: testDir });
+      const updates1 = translator.translate(ConversationDb.open(testDir, "conv-stream-codespan")!.readAfter(-1));
+
+      expect(updates1).toHaveLength(1);
+      expect(updates1[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Here is example code: `" }
+      });
+
+      // Poll 2: markdown image syntax arrives inside the code span
+      updateStep(db, 1, {
+        status: 3,
+        stepPayload: encodeStepPayload({
+          agentText: "Here is example code: `![plot](plot.png)` finished."
+        })
+      });
+      const updates2 = translator.translate(ConversationDb.open(testDir, "conv-stream-codespan")!.readAfter(-1));
+
+      // Must be emitted as text only, not converted to an image block
+      expect(updates2).toHaveLength(1);
+      expect(updates2[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "![plot](plot.png)` finished." }
+      });
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("resolves image fallback extensions when extensionless imageName is inside a dotted directory", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-dotdir-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4497,6 +4497,56 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("resolves image fallback extensions when extensionless imageName is inside a dotted directory", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-dotdir-"));
+    try {
+      const artDir = path.join(testDir, ".artifacts");
+      fs.mkdirSync(artDir, { recursive: true });
+      const imgPath = path.join(artDir, "output.png");
+      fs.writeFileSync(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const db = createConversationDb(testDir, "conv-gen-img-dotdir");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-dotdir",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Create icon",
+                ImageName: ".artifacts/output"
+              })
+            })
+          })
+        })
+      });
+
+      const translator = new Translator({ mode: "stream", skipNarration: false, cwd: testDir });
+      const updates = translator.translate(ConversationDb.open(testDir, "conv-gen-img-dotdir")!.readAfter(-1));
+
+      expect(updates).toHaveLength(1);
+      const update = updates[0] as any;
+      expect(update.sessionUpdate).toBe("tool_call");
+      expect(update.content).toHaveLength(2);
+      expect(update.content[1]).toEqual({
+        type: "content",
+        content: {
+          type: "image",
+          data: PNG_PIXEL,
+          mimeType: "image/png"
+        }
+      });
+      expect(update.locations).toEqual([{ path: imgPath }]);
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("replays agent responses containing markdown images as segmented text and image ContentBlocks", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-replay-img-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4265,6 +4265,95 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("does not reconstruct historical outputs from overwritten files on replay when imageName is reused", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-replay-superseded-"));
+    try {
+      const imgPath = path.join(testDir, "mockup.png");
+      const secondImageBytes = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkWPjfDwAEfQG3X5T30QAAAABJRU5ErkJggg==",
+        "base64"
+      );
+      // Disk currently holds second image bytes (written by call 2)
+      fs.writeFileSync(imgPath, secondImageBytes);
+
+      const db = createConversationDb(testDir, "conv-gen-img-replay-superseded");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "First version of mockup",
+                ImageName: "mockup.png"
+              })
+            })
+          })
+        })
+      });
+      insertStep(db, {
+        idx: 2,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-2",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "Second version of mockup",
+                ImageName: "mockup.png"
+              })
+            })
+          })
+        })
+      });
+
+      // Replay from scratch: call 1 was superseded by call 2, so it must not read the overwritten file
+      const replayTranslator = new Translator({ mode: "replay", skipNarration: false, cwd: testDir });
+      const updates = replayTranslator.translate(ConversationDb.open(testDir, "conv-gen-img-replay-superseded")!.readAfter(-1));
+
+      expect(updates).toHaveLength(2);
+      const update1 = updates[0] as any;
+      const update2 = updates[1] as any;
+
+      // Call 1 has prompt text but no image block or location
+      expect(update1.sessionUpdate).toBe("tool_call");
+      expect(update1.toolCallId).toBe("gen-img-call-1");
+      expect(update1.content).toEqual([
+        {
+          type: "content",
+          content: {
+            type: "text",
+            text: "Prompt: First version of mockup"
+          }
+        }
+      ]);
+      expect(update1.locations).toBeUndefined();
+
+      // Call 2 is the latest step that targeted mockup.png, so it gets the image
+      expect(update2.sessionUpdate).toBe("tool_call");
+      expect(update2.toolCallId).toBe("gen-img-call-2");
+      expect(update2.content).toHaveLength(2);
+      expect(update2.content[1]).toEqual({
+        type: "content",
+        content: {
+          type: "image",
+          data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkWPjfDwAEfQG3X5T30QAAAABJRU5ErkJggg==",
+          mimeType: "image/png"
+        }
+      });
+      expect(update2.locations).toEqual([{ path: imgPath }]);
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("replays agent responses containing markdown images as segmented text and image ContentBlocks", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-replay-img-"));
     try {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4199,6 +4199,72 @@ describe("agent outbound image ContentBlocks", () => {
     }
   });
 
+  it("freezes completed image artifact and retains it when a later step overwrites the file on disk", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-gen-img-freeze-"));
+    try {
+      const imgPath = path.join(testDir, "mockup.png");
+      const firstImageBytes = Buffer.from(PNG_PIXEL, "base64");
+      fs.writeFileSync(imgPath, firstImageBytes);
+
+      const db = createConversationDb(testDir, "conv-gen-img-freeze");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "gen-img-call-1",
+              namePrimary: "generate_image",
+              rawInputJson: JSON.stringify({
+                Prompt: "First version of mockup",
+                ImageName: "mockup.png"
+              })
+            })
+          })
+        })
+      });
+
+      const translator = new Translator({ mode: "stream", skipNarration: false, cwd: testDir });
+      // Poll 1: captures first image
+      const updates1 = translator.translate(ConversationDb.open(testDir, "conv-gen-img-freeze")!.readAfter(-1));
+      expect(updates1).toHaveLength(1);
+      const update1 = updates1[0] as any;
+      expect(update1.content[1].content.data).toBe(PNG_PIXEL);
+
+      // A later step overwrites mockup.png with different bytes
+      const modifiedPng = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkWPjfDwAEfQG3X5T30QAAAABJRU5ErkJggg==",
+        "base64"
+      );
+      fs.writeFileSync(imgPath, modifiedPng);
+
+      // A new row is appended (simulating full prompt-scoped replay in StreamPoller)
+      insertStep(db, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          agentText: "I updated the design."
+        })
+      });
+
+      // Poll 2: Translator reads all rows from the beginning; call 1 must keep its frozen first image
+      const allRows = ConversationDb.open(testDir, "conv-gen-img-freeze")!.readAfter(-1);
+      // Tool 1 snapshot is unchanged, so only row 2 produces a new update
+      const updates2 = translator.translate(allRows);
+      expect(updates2).toHaveLength(1);
+      expect(updates2[0]).toMatchObject({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "I updated the design." }
+      });
+
+      db.close();
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it("replays agent responses containing markdown images as segmented text and image ContentBlocks", () => {
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-replay-img-"));
     try {

--- a/tests/prompt-content.test.ts
+++ b/tests/prompt-content.test.ts
@@ -282,8 +282,35 @@ describe("outbound image ContentBlocks", () => {
     }
   });
 
+  it("splits text containing URL-escaped relative markdown image destinations", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "agy-acp-img-"));
+    try {
+      const artDir = path.join(tmpDir, "artifacts");
+      await mkdir(artDir, { recursive: true });
+      const imgPath = path.join(artDir, "my plot.png");
+      await writeFile(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const text = "Generated artifact:\n![plot](artifacts/my%20plot.png)\nDone.";
+      const blocks = splitTextAndImages(text, tmpDir);
+
+      expect(blocks).toHaveLength(3);
+      expect(blocks[0]).toEqual({ type: "text", text: "Generated artifact:\n" });
+      expect(blocks[1]).toEqual({ type: "image", data: PNG_PIXEL, mimeType: "image/png" });
+      expect(blocks[2]).toEqual({ type: "text", text: "\nDone." });
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("safely handles malformed file URIs without throwing and leaves markdown as text", () => {
     const text = "Broken file URL:\n![invalid](file:///tmp/bad%ZZ.png)\nContinuing...";
+    expect(() => splitTextAndImages(text)).not.toThrow();
+    const blocks = splitTextAndImages(text);
+    expect(blocks).toEqual([{ type: "text", text }]);
+  });
+
+  it("safely handles malformed URL-escaped destinations without throwing and leaves markdown as text", () => {
+    const text = "Broken escape destination:\n![invalid](artifacts/bad%ZZplot.png)\nContinuing...";
     expect(() => splitTextAndImages(text)).not.toThrow();
     const blocks = splitTextAndImages(text);
     expect(blocks).toEqual([{ type: "text", text }]);

--- a/tests/prompt-content.test.ts
+++ b/tests/prompt-content.test.ts
@@ -96,6 +96,21 @@ describe("contentBlocksToPrompt", () => {
     }
   });
 
+  it("does not synthesize an agy attachment path for malformed file URIs in resource_link", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "agy-acp-prompt-"));
+    try {
+      const prompt = await contentBlocksToPrompt([
+        { type: "text", text: "inspect" },
+        { type: "resource_link", uri: "file:///tmp/bad%ZZ.png", mimeType: "image/png" }
+      ], cwd);
+
+      expect(prompt).toBe("inspect\nfile:///tmp/bad%ZZ.png");
+      assertNoInjectedProse(prompt);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("forwards embedded resource text body without URI labels", async () => {
     const cwd = await mkdtemp(path.join(os.tmpdir(), "agy-acp-prompt-"));
     try {

--- a/tests/prompt-content.test.ts
+++ b/tests/prompt-content.test.ts
@@ -211,6 +211,24 @@ describe("outbound image ContentBlocks", () => {
     }
   });
 
+  it("splits text containing bare project-relative markdown image paths", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "agy-acp-img-"));
+    try {
+      const imgPath = path.join(tmpDir, "plot.png");
+      await writeFile(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const text = "Generated artifact:\n![plot](plot.png)\nEnd of message.";
+      const blocks = splitTextAndImages(text, tmpDir);
+
+      expect(blocks).toHaveLength(3);
+      expect(blocks[0]).toEqual({ type: "text", text: "Generated artifact:\n" });
+      expect(blocks[1]).toEqual({ type: "image", data: PNG_PIXEL, mimeType: "image/png" });
+      expect(blocks[2]).toEqual({ type: "text", text: "\nEnd of message." });
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("safely handles malformed file URIs without throwing and leaves markdown as text", () => {
     const text = "Broken file URL:\n![invalid](file:///tmp/bad%ZZ.png)\nContinuing...";
     expect(() => splitTextAndImages(text)).not.toThrow();

--- a/tests/prompt-content.test.ts
+++ b/tests/prompt-content.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -239,6 +239,44 @@ describe("outbound image ContentBlocks", () => {
       expect(blocks[0]).toEqual({ type: "text", text: "Generated artifact:\n" });
       expect(blocks[1]).toEqual({ type: "image", data: PNG_PIXEL, mimeType: "image/png" });
       expect(blocks[2]).toEqual({ type: "text", text: "\nEnd of message." });
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("splits text containing angle-bracket markdown image destinations with spaces", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "agy-acp-img-"));
+    try {
+      const artDir = path.join(tmpDir, "artifacts");
+      await mkdir(artDir, { recursive: true });
+      const imgPath = path.join(artDir, "my plot.png");
+      await writeFile(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const text = "Generated artifact:\n![plot](<artifacts/my plot.png>)\nDone.";
+      const blocks = splitTextAndImages(text, tmpDir);
+
+      expect(blocks).toHaveLength(3);
+      expect(blocks[0]).toEqual({ type: "text", text: "Generated artifact:\n" });
+      expect(blocks[1]).toEqual({ type: "image", data: PNG_PIXEL, mimeType: "image/png" });
+      expect(blocks[2]).toEqual({ type: "text", text: "\nDone." });
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("splits text containing angle-bracket markdown image destinations without spaces", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "agy-acp-img-"));
+    try {
+      const imgPath = path.join(tmpDir, "plot.png");
+      await writeFile(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const text = "Artifact:\n![plot](<plot.png>)\nFinished.";
+      const blocks = splitTextAndImages(text, tmpDir);
+
+      expect(blocks).toHaveLength(3);
+      expect(blocks[0]).toEqual({ type: "text", text: "Artifact:\n" });
+      expect(blocks[1]).toEqual({ type: "image", data: PNG_PIXEL, mimeType: "image/png" });
+      expect(blocks[2]).toEqual({ type: "text", text: "\nFinished." });
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }

--- a/tests/prompt-content.test.ts
+++ b/tests/prompt-content.test.ts
@@ -1,8 +1,13 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { contentBlocksToPrompt, contentBlocksToText } from "../src/acp/content/index.js";
+import {
+  contentBlocksToPrompt,
+  contentBlocksToText,
+  splitTextAndImages,
+  tryReadImageContentBlock
+} from "../src/acp/content/index.js";
 
 const PNG_PIXEL = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
 
@@ -155,5 +160,60 @@ describe("contentBlocksToText", () => {
     ]);
     expect(text).toBe("file:///x.ts\nexport {}");
     assertNoInjectedProse(text);
+  });
+});
+
+describe("outbound image ContentBlocks", () => {
+  it("reads local image file and returns base64 image block", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "agy-acp-img-"));
+    try {
+      const imgPath = path.join(tmpDir, "test.png");
+      await writeFile(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const block = tryReadImageContentBlock(imgPath);
+      expect(block).toEqual({
+        type: "image",
+        data: PNG_PIXEL,
+        mimeType: "image/png"
+      });
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null for non-existent image or non-image files", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "agy-acp-img-"));
+    try {
+      expect(tryReadImageContentBlock(path.join(tmpDir, "missing.png"))).toBeNull();
+      const txtPath = path.join(tmpDir, "not-image.txt");
+      await writeFile(txtPath, "hello");
+      expect(tryReadImageContentBlock(txtPath)).toBeNull();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("splits text containing markdown images into text and image ContentBlocks", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "agy-acp-img-"));
+    try {
+      const imgPath = path.join(tmpDir, "chart.png");
+      await writeFile(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      const text = `Here is the chart:\n![chart](${imgPath})\nLooks good!`;
+      const blocks = splitTextAndImages(text, tmpDir);
+
+      expect(blocks).toHaveLength(3);
+      expect(blocks[0]).toEqual({ type: "text", text: "Here is the chart:\n" });
+      expect(blocks[1]).toEqual({ type: "image", data: PNG_PIXEL, mimeType: "image/png" });
+      expect(blocks[2]).toEqual({ type: "text", text: "\nLooks good!" });
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves plain text when markdown images do not exist on disk", () => {
+    const text = "Here is an external image:\n![remote](https://example.com/img.png)\nDone.";
+    const blocks = splitTextAndImages(text);
+    expect(blocks).toEqual([{ type: "text", text }]);
   });
 });

--- a/tests/prompt-content.test.ts
+++ b/tests/prompt-content.test.ts
@@ -316,6 +316,28 @@ describe("outbound image ContentBlocks", () => {
     expect(blocks).toEqual([{ type: "text", text }]);
   });
 
+  it("ignores image-like syntax inside escaped markdown, inline code, and fenced code blocks", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "agy-acp-code-img-"));
+    try {
+      const imgPath = path.join(tmpDir, "plot.png");
+      await writeFile(imgPath, Buffer.from(PNG_PIXEL, "base64"));
+
+      // 1. Escaped opener
+      const escapedText = "Escaped image embed: \\![plot](plot.png) should not render.";
+      expect(splitTextAndImages(escapedText, tmpDir)).toEqual([{ type: "text", text: escapedText }]);
+
+      // 2. Inline code span
+      const inlineCodeText = "Here is the code: `![plot](plot.png)` in inline span.";
+      expect(splitTextAndImages(inlineCodeText, tmpDir)).toEqual([{ type: "text", text: inlineCodeText }]);
+
+      // 3. Fenced code block
+      const fencedCodeText = "Example code:\n```markdown\n![plot](plot.png)\n```\nEnd of example.";
+      expect(splitTextAndImages(fencedCodeText, tmpDir)).toEqual([{ type: "text", text: fencedCodeText }]);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("preserves plain text when markdown images do not exist on disk", () => {
     const text = "Here is an external image:\n![remote](https://example.com/img.png)\nDone.";
     const blocks = splitTextAndImages(text);

--- a/tests/prompt-content.test.ts
+++ b/tests/prompt-content.test.ts
@@ -211,6 +211,13 @@ describe("outbound image ContentBlocks", () => {
     }
   });
 
+  it("safely handles malformed file URIs without throwing and leaves markdown as text", () => {
+    const text = "Broken file URL:\n![invalid](file:///tmp/bad%ZZ.png)\nContinuing...";
+    expect(() => splitTextAndImages(text)).not.toThrow();
+    const blocks = splitTextAndImages(text);
+    expect(blocks).toEqual([{ type: "text", text }]);
+  });
+
   it("preserves plain text when markdown images do not exist on disk", () => {
     const text = "Here is an external image:\n![remote](https://example.com/img.png)\nDone.";
     const blocks = splitTextAndImages(text);

--- a/tests/prompt-content.test.ts
+++ b/tests/prompt-content.test.ts
@@ -101,7 +101,7 @@ describe("contentBlocksToPrompt", () => {
     try {
       const prompt = await contentBlocksToPrompt([
         { type: "text", text: "inspect" },
-        { type: "resource_link", uri: "file:///tmp/bad%ZZ.png", mimeType: "image/png" }
+        { type: "resource_link", uri: "file:///tmp/bad%ZZ.png", name: "bad.png", mimeType: "image/png" }
       ], cwd);
 
       expect(prompt).toBe("inspect\nfile:///tmp/bad%ZZ.png");


### PR DESCRIPTION
## Description

This PR adds support for agent-outbound image `ContentBlock`s in both ACP v1 and v2:
1. Adds image detection, MIME type resolution, and disk-backed image loading (`tryReadImageContentBlock`, `splitTextAndImages`) in `src/acp/content/index.ts`.
2. Implements `imageGenerationUpdate` in `src/agy/db/tool-call-updates.ts` and routes `generate_image` tool steps with prompt details and embedded image content blocks when image artifacts exist on disk.
3. Updates `Translator` in `src/agy/db/translator.ts` to parse markdown image embeds in agent responses and emit alternating text and base64 image `ContentBlock`s under `agent_message_chunk` updates for both replay and streaming modes.
4. Adds automated unit tests in `tests/prompt-content.test.ts` and `tests/db.test.ts`.

## Related Issues

Fixes #59

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `pnpm run build` and it completed without errors
- [x] I have executed `pnpm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed