### PR TITLE
Permission panel detection timeout throws unobserved error on slow TUI redraws

### DIFF
--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -44,7 +44,20 @@ const POLL_INTERVAL_MS = 200;
 const TRAILING_POLL_ATTEMPTS = 3;
 const TRAILING_POLL_DELAY_MS = 100;
 const PERMISSION_RENDER_SETTLE_MS = 20;
-const PERMISSION_REDRAW_TIMEOUT_MS = 500;
+const PERMISSION_REDRAW_TIMEOUT_MS = 2_500;
+
+const ANSI_REGEX = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\].*?(?:\x07|\x1B\\))/g;
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_REGEX, "");
+}
+
+const PERMISSION_MARKERS = [
+  "Yes, and always allow",
+  "Always allow",
+  "Allow this tool",
+  "Allow this command",
+  "Yes, allow"
+];
 
 /** Signature of the permission decision agy has recorded for a gated step.
  *  A re-armed status-9 prompt (e.g. the next segment of `a && b`) changes this
@@ -1174,10 +1187,10 @@ export class AgyCliSession {
   }
 
   private flushPermissionRender(): void {
-    const marker = "Yes, and always allow";
-    const output = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
-    const visible = output.includes(marker);
-    this.#ptyPermissionMarkerTail = markerPrefixTail(output, marker);
+    const rawOutput = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
+    const cleanOutput = stripAnsi(rawOutput);
+    const visible = PERMISSION_MARKERS.some((marker) => cleanOutput.includes(marker));
+    this.#ptyPermissionMarkerTail = permissionMarkerPrefixTail(cleanOutput);
     if (visible) {
       this.#ptyPermissionMarkerCount++;
       this.#ptyPermissionPanelVisible = true;
@@ -1218,19 +1231,46 @@ export class AgyCliSession {
   private async waitForPermissionPanel(deadline: number): Promise<boolean> {
     const expires = Math.min(deadline, Date.now() + PERMISSION_REDRAW_TIMEOUT_MS);
     while (
-      (!this.#ptyPermissionPanelVisible || this.#ptyPermissionRenderTimer !== undefined) &&
+      !this.#ptyPermissionPanelVisible &&
       !this.#cancelled &&
       Date.now() < expires
     ) {
+      if (this.#ptyPermissionRenderTimer !== undefined && this.#ptyPermissionRender.length > 0) {
+        const rawOutput = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
+        const cleanOutput = stripAnsi(rawOutput);
+        if (PERMISSION_MARKERS.some((marker) => cleanOutput.includes(marker))) {
+          if (this.#ptyPermissionRenderTimer) clearTimeout(this.#ptyPermissionRenderTimer);
+          this.flushPermissionRender();
+          break;
+        }
+      }
       await sleep(5);
     }
-    return this.#ptyPermissionPanelVisible && this.#ptyPermissionRenderTimer === undefined;
+    if (this.#ptyPermissionRenderTimer !== undefined) {
+      clearTimeout(this.#ptyPermissionRenderTimer);
+      this.flushPermissionRender();
+    }
+    return this.#ptyPermissionPanelVisible;
   }
 
   private async waitForPermissionRenderAfter(renderCount: number, deadline: number): Promise<boolean> {
     const expires = Math.min(deadline, Date.now() + PERMISSION_REDRAW_TIMEOUT_MS);
     while (this.#ptyPermissionMarkerCount <= renderCount && !this.#cancelled && Date.now() < expires) {
+      if (this.#ptyPermissionRenderTimer !== undefined && this.#ptyPermissionRender.length > 0) {
+        const rawOutput = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
+        const cleanOutput = stripAnsi(rawOutput);
+        if (PERMISSION_MARKERS.some((marker) => cleanOutput.includes(marker))) {
+          if (this.#ptyPermissionRenderTimer) clearTimeout(this.#ptyPermissionRenderTimer);
+          this.flushPermissionRender();
+          if (this.#ptyPermissionMarkerCount > renderCount) break;
+        }
+      }
       await sleep(5);
+    }
+    if (this.#cancelled) return false;
+    if (this.#ptyPermissionRenderTimer !== undefined) {
+      clearTimeout(this.#ptyPermissionRenderTimer);
+      this.flushPermissionRender();
     }
     return this.#ptyPermissionMarkerCount > renderCount;
   }
@@ -1238,6 +1278,21 @@ export class AgyCliSession {
   async close(): Promise<void> {
     await this.cancel();
   }
+}
+
+function permissionMarkerPrefixTail(output: string): string {
+  let longest = "";
+  for (const marker of PERMISSION_MARKERS) {
+    const max = Math.min(output.length, marker.length - 1);
+    for (let length = max; length > longest.length; length--) {
+      const suffix = output.slice(-length);
+      if (marker.startsWith(suffix)) {
+        longest = suffix;
+        break;
+      }
+    }
+  }
+  return longest;
 }
 
 function markerPrefixTail(output: string, marker: string): string {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -1177,31 +1177,6 @@ export class AgyCliSession {
     return true;
   }
 
-  private async waitForPermissionPanel(deadline: number): Promise<boolean> {
-    const expires = Math.min(deadline, Date.now() + PERMISSION_REDRAW_TIMEOUT_MS);
-    while (
-      !this.#ptyPermissionPanelVisible &&
-      !this.#cancelled &&
-      Date.now() < expires
-    ) {
-      if (this.#ptyPermissionRenderTimer !== undefined && this.#ptyPermissionRender.length > 0) {
-        const rawOutput = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
-        const cleanOutput = stripAnsi(rawOutput);
-        if (PERMISSION_MARKERS.some((marker) => cleanOutput.includes(marker))) {
-          if (this.#ptyPermissionRenderTimer) clearTimeout(this.#ptyPermissionRenderTimer);
-          this.flushPermissionRender();
-          break;
-        }
-      }
-      await sleep(5);
-    }
-    if (this.#ptyPermissionRenderTimer !== undefined) {
-      clearTimeout(this.#ptyPermissionRenderTimer);
-      this.flushPermissionRender();
-    }
-    return this.#ptyPermissionPanelVisible;
-  }
-
   private async waitForPermissionRenderAfter(renderCount: number, deadline: number): Promise<boolean> {
     const expires = Math.min(deadline, Date.now() + PERMISSION_REDRAW_TIMEOUT_MS);
     while (this.#ptyPermissionMarkerCount <= renderCount && !this.#cancelled && Date.now() < expires) {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -596,16 +596,6 @@ export class AgyCliSession {
               }
             }
 
-            if (interaction.toolName !== "ask_question" && !await this.waitForPermissionPanel(deadline)) {
-              if (this.#cancelled) break;
-              throw new AgyCliError(
-                "agy permission panel was not observed before requesting permission",
-                [this.config.agyPath],
-                null,
-                this.#ptyOutput
-              );
-            }
-
             if (interaction.toolName === "ask_question") {
               const ask = parseAskQuestion(toolCall);
               const count = ask?.questions.length ?? 1;
@@ -1197,15 +1187,13 @@ export class AgyCliSession {
   }
 
   private async writePermissionKeys(keys: string, deadline: number): Promise<boolean> {
-    if (!await this.waitForPermissionPanel(deadline)) {
-      if (this.#cancelled) return false;
-      throw new AgyCliError(
-        "agy permission panel did not settle before applying the permission response",
-        [this.config.agyPath],
-        null,
-        this.#ptyOutput
-      );
+    if (this.#cancelled) return false;
+
+    // Allow in-flight panel renders to settle before capturing marker count
+    while (this.#ptyPermissionRenderTimer !== undefined && !this.#cancelled) {
+      await sleep(10);
     }
+    if (this.#cancelled) return false;
 
     const down = "\x1b[B";
     let offset = 0;

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -1423,6 +1423,7 @@ export async function defaultPtyFactory(): Promise<PtyFactory> {
       }
     }
   }
+  // @ts-ignore optional runtime dependency
   const pty = await import("node-pty");
   return { spawn: (command, args, options) => pty.spawn(command, args, { ...options, name: "xterm-256color" }) };
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -980,6 +980,64 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("handles ANSI styling sequences splitting permission panel markers", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "ansi-permission");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    pty.emitPermissionPanelOnStart = false;
+    const session = interactiveSession(dir, pty);
+    let calls = 0;
+    const result = session.prompt("go", async () => {}, async () => {
+      calls++;
+      // Emit ANSI styled permission marker
+      pty.emitData("\x1b[1m\x1b[32mYes, and always allow\x1b[0m in this conversation\r\n");
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "ansi-permission.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 100);
+      return "agy-allow-conversation";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    expect(calls).toBe(1);
+    expect(pty.writes).toEqual(["\x1b[B", "\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("triggers permission prompt directly from SQLite without requiring terminal panel screen scraping", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "no-panel-stream");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    // Terminal never emits permission panel markers to stdout
+    pty.emitPermissionPanelOnStart = false;
+    pty.emitArrowRedraw = false;
+    const session = interactiveSession(dir, pty);
+    let calls = 0;
+    const result = session.prompt("go", async () => {}, async () => {
+      calls++;
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "no-panel-stream.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 50);
+      return "agy-allow-once";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    expect(calls).toBe(1);
+    expect(pty.writes).toEqual(["\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("bridges manage_task status-9 interaction through full PTY turn loop", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const manageInput = JSON.stringify({ Action: "send_input", TaskId: "task-7", Input: "yes\n" });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1475,7 +1475,7 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("cancels cleanly while waiting for the permission panel to render", async () => {
+  it("cancels cleanly while waiting for the permission response", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {
       const db = createConversationDb(dir, "cancel-panel-wait");
@@ -1484,7 +1484,10 @@ describe("permission bridge", () => {
     });
     pty.emitPermissionPanelOnStart = false;
     const session = interactiveSession(dir, pty);
-    const pending = session.prompt("go", async () => {}, async () => "agy-allow-once");
+    const pending = session.prompt("go", async () => {}, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      return "agy-allow-once";
+    });
     setTimeout(() => void session.cancel(), 50);
 
     expect((await pending).stopReason).toBe("cancelled");


### PR DESCRIPTION
## Description

Resolves timeouts and unobserved errors during permission panel detection (`status 9` interactions):
1. **Direct SQLite Status-9 Triggering**: Eliminates terminal stdout screen-scraping requirement before displaying ACP permission prompts. ACP prompts trigger directly when `steps.status = 9` appears in SQLite.
2. **ANSI Escape Stripping**: Strips ANSI escape sequences (`\x1b[...]`) before matching permission menu markers.
3. **Increased Redraw Timeouts & Settle Loops**: Increases `PERMISSION_REDRAW_TIMEOUT_MS` from 500ms to 2,500ms and settles in-flight render timers before capturing keystroke counts.
4. **Phrasing Variants**: Supports dialog phrasing variants in `PERMISSION_MARKERS`.

## Related Issues

Fixes #122

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `pnpm run build` and it completed without errors
- [x] I have executed `pnpm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed