### PR TITLE
Premature turn completion on failed tool or cancelled permission without assistant recovery

### DIFF
--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -292,14 +292,14 @@ export class StreamPoller {
    * same data_version as that intermediate tool and look like turn end.
    */
   get isConclusiveTurnEnd(): boolean {
-    if (!this._latestStepTerminal || this._latestStepStatus === null) {
+    if (!this._latestStepTerminal || this._latestStepStatus === null || this._latestStepType === null) {
       return false;
     }
-    // Cancelled/failed terminal rows (notably denied commands) end the turn
-    // with no trailing agent text and no further tool runs.
-    if (this._latestStepStatus === 6 || this._latestStepStatus === 7) return true;
-    // Completed agent text (stepType 15, status 3) is the normal conclusive turn ending.
-    return this._latestStepStatus === 3 && this._latestStepType === 15;
+    // Completed agent text (stepType 15) is the normal conclusive turn ending.
+    // Tool steps (status 3/6/7) are turn-complete candidates but must not bypass
+    // the idle marker / quiescence wait, allowing agy to emit trailing error
+    // commentary or recovery explanations after failed (7) or cancelled (6) tools.
+    return this._latestStepType === 15 && isTerminalStepStatus(this._latestStepStatus);
   }
 
   /**

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -295,11 +295,11 @@ export class StreamPoller {
     if (!this._latestStepTerminal || this._latestStepStatus === null || this._latestStepType === null) {
       return false;
     }
-    // Completed agent text (stepType 15) is the normal conclusive turn ending.
+    // Completed agent text (stepType 15) or model error wrapper (stepType 17) is the conclusive turn ending.
     // Tool steps (status 3/6/7) are turn-complete candidates but must not bypass
     // the idle marker / quiescence wait, allowing agy to emit trailing error
     // commentary or recovery explanations after failed (7) or cancelled (6) tools.
-    return this._latestStepType === 15 && isTerminalStepStatus(this._latestStepStatus);
+    return (this._latestStepType === 15 || this._latestStepType === 17) && isTerminalStepStatus(this._latestStepStatus);
   }
 
   /**

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -499,6 +499,98 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("captures assistant recovery commentary after a failed tool execution without premature turn cutoff", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "tool-fail-recovery");
+      // Prompt starts, tool executes and fails
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 7,
+        stepPayload: encodeStepPayload({
+          commandResult: encodeCommandResult({ command: "python script.py", output: "Traceback: error occurred" })
+        })
+      });
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const updates: any[] = [];
+    const result = session.prompt(
+      "run script",
+      async (update) => {
+        updates.push(update);
+      },
+      async () => "agy-allow-once"
+    );
+
+    // After tool fails, agy generates assistant recovery explanation before emitting idle marker
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    const db = new (await import("better-sqlite3")).default(path.join(dir, "tool-fail-recovery.db"));
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "The Python script failed with an error. I will analyze the traceback."
+      })
+    });
+    db.close();
+    setTimeout(() => pty.emitData("? for shortcuts"), 100);
+
+    expect((await result).stopReason).toBe("end_turn");
+    // Ensure the recovery explanation was delivered in updates
+    const textChunks = updates
+      .filter((u) => u.sessionUpdate === "agent_message_chunk")
+      .map((u) => u.content?.text ?? "");
+    expect(textChunks.join("")).toContain("The Python script failed with an error");
+
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("captures assistant explanation after a cancelled permission check without premature turn cutoff", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "permission-cancel-recovery");
+      insertStep(db, pendingToolRow("run_command", '{"CommandLine":"rm -rf /tmp/test"}'));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const updates: any[] = [];
+    const result = session.prompt(
+      "clean directory",
+      async (update) => {
+        updates.push(update);
+      },
+      async () => {
+        // User rejects the permission, agy writes status 7 for tool and then explains
+        const db = new (await import("better-sqlite3")).default(path.join(dir, "permission-cancel-recovery.db"));
+        updateStep(db, 1, { status: 7 });
+        insertStep(db, {
+          idx: 2,
+          stepType: 15,
+          status: 3,
+          stepPayload: encodeStepPayload({
+            agentText: "Permission was denied. I will proceed without deleting the directory."
+          })
+        });
+        db.close();
+        setTimeout(() => pty.emitData("? for shortcuts"), 100);
+        return "agy-reject-once";
+      }
+    );
+
+    expect((await result).stopReason).toBe("end_turn");
+    const textChunks = updates
+      .filter((u) => u.sessionUpdate === "agent_message_chunk")
+      .map((u) => u.content?.text ?? "");
+    expect(textChunks.join("")).toContain("Permission was denied");
+
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("preserves permission panel visibility when intervening non-marker PTY data arrives before applying permission response", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2908,10 +2908,43 @@ describe("StreamPoller", () => {
     expect(poller.turnCompleteCandidate).toBe(true);
     expect(poller.isConclusiveTurnEnd).toBe(true);
 
+    // 3. Model provider error wrapper (stepType 17, status 7) is also conclusive
+    const db3 = createConversationDb(dir, "conv-model-error-conclusive");
+    insertStep(db3, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Trigger model error" })
+    });
+    insertStep(db3, {
+      idx: 2,
+      stepType: 17,
+      status: 7,
+      stepPayload: encodeStepPayload({
+        modelProviderError: encodeModelProviderError({
+          summary: "Rate limit exceeded",
+          userMessage: "Rate limit exceeded",
+          responseJson: JSON.stringify({ error: { code: 429, status: "RESOURCE_EXHAUSTED", details: [{ reason: "QUOTA_EXHAUSTED" }] } })
+        })
+      })
+    });
+    const poller3 = new StreamPoller({
+      dir,
+      conversationId: "conv-model-error-conclusive",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+    expect(poller3.poll()).toHaveLength(1);
+    expect(poller3.turnCompleteCandidate).toBe(true);
+    expect(poller3.isConclusiveTurnEnd).toBe(true);
+
     poller.close();
     poller2.close();
+    poller3.close();
     db.close();
     db2.close();
+    db3.close();
   });
 
   it("does not treat empty stepType 15 (text: '' and no thought, status 3) as a turn completion candidate", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2833,9 +2833,85 @@ describe("StreamPoller", () => {
     });
     expect(poller.poll()).toHaveLength(1);
     expect(poller.turnCompleteCandidate).toBe(true);
+    expect(poller.isConclusiveTurnEnd).toBe(true);
 
     poller.close();
     db.close();
+  });
+
+  it("does not treat failed (status 7), cancelled (status 6), or successful (status 3) tool steps as conclusive turn ends", () => {
+    const db = createConversationDb(dir, "conv-tool-inconclusive");
+    insertStep(db, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Run a test command" })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-tool-inconclusive",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    // 1. Tool step runs and fails (status 7)
+    insertStep(db, {
+      idx: 2,
+      stepType: 21,
+      status: 7,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "false", output: "exit status 1" })
+      })
+    });
+    expect(poller.poll()).toHaveLength(1);
+    // turnCompleteCandidate is true (valid terminal step), but isConclusiveTurnEnd must be false
+    // so agy-acp does not bypass the settle/marker wait and cut off subsequent assistant recovery text.
+    expect(poller.turnCompleteCandidate).toBe(true);
+    expect(poller.isConclusiveTurnEnd).toBe(false);
+
+    // 2. Cancelled tool step (status 6)
+    const db2 = createConversationDb(dir, "conv-tool-cancelled");
+    insertStep(db2, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Run another command" })
+    });
+    insertStep(db2, {
+      idx: 2,
+      stepType: 21,
+      status: 6,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "cat", output: "cancelled by user" })
+      })
+    });
+    const poller2 = new StreamPoller({
+      dir,
+      conversationId: "conv-tool-cancelled",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+    expect(poller2.poll()).toHaveLength(1);
+    expect(poller2.turnCompleteCandidate).toBe(true);
+    expect(poller2.isConclusiveTurnEnd).toBe(false);
+
+    // When assistant adds recovery text, isConclusiveTurnEnd becomes true
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({ agentText: "The command failed with exit status 1. Let me try an alternative." })
+    });
+    expect(poller.poll()).toHaveLength(1);
+    expect(poller.turnCompleteCandidate).toBe(true);
+    expect(poller.isConclusiveTurnEnd).toBe(true);
+
+    poller.close();
+    poller2.close();
+    db.close();
+    db2.close();
   });
 
   it("does not treat empty stepType 15 (text: '' and no thought, status 3) as a turn completion candidate", () => {


### PR DESCRIPTION
## Description

Resolves premature turn termination when a tool call fails or a permission check is denied/cancelled:
1. **`StreamPoller.isConclusiveTurnEnd`**: Updated to evaluate `true` exclusively for terminal assistant message steps (`stepType === 15`) and model error wrappers (`stepType === 17` / `modelProviderError`), ensuring failed (`status 7`) or cancelled (`status 6`) tool rows do not bypass the idle marker or quiescence settle window before `agy` emits error explanations or recovery commentary.
2. **Unit & Integration Tests**: Added unit tests in `tests/db.test.ts` for tool vs assistant step classification and end-to-end PTY turn tests in `tests/cli.test.ts` validating assistant commentary delivery after failed commands and permission rejections.

## Related Issues

Fixes #115

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `pnpm run build` and it completed without errors
- [x] I have executed `pnpm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed