### PR TITLE
Premature turn completion during active background tasks before completion notices

### DIFF
--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -300,7 +300,7 @@ export class StreamPoller {
     // has been produced beyond that wake, do not treat the prior assistant response as conclusive.
     const latestMeaningful = findLastMeaningfulStep(this._lastObservedRows ?? []);
     const latestWakeIdx = Math.max(this._latestSystemMessageStepIdx, this._latestTaskCompletionStepIdx);
-    if (latestWakeIdx > (latestMeaningful?.idx ?? -1)) {
+    if (latestWakeIdx >= (latestMeaningful?.idx ?? -1) && latestWakeIdx >= 0) {
       return false;
     }
     // Cancelled/failed terminal rows (notably denied commands) end the turn

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -141,6 +141,7 @@ export class StreamPoller {
   private readonly observedUserStepIdxs = new Set<number>();
   private _lastUserStepIdx = -1;
   private _latestSystemMessageStepIdx = -1;
+  private _latestTaskCompletionStepIdx = -1;
   private _hasBackgroundWaiting = false;
   /** Launched background task id -> idx of the first row that carried it. */
   private readonly _launchedTaskIdxs = new Map<string, number>();
@@ -298,7 +299,8 @@ export class StreamPoller {
     // If a background completion wake has arrived but no follow-up assistant response
     // has been produced beyond that wake, do not treat the prior assistant response as conclusive.
     const latestMeaningful = findLastMeaningfulStep(this._lastObservedRows ?? []);
-    if (this._latestSystemMessageStepIdx > (latestMeaningful?.idx ?? -1)) {
+    const latestWakeIdx = Math.max(this._latestSystemMessageStepIdx, this._latestTaskCompletionStepIdx);
+    if (latestWakeIdx > (latestMeaningful?.idx ?? -1)) {
       return false;
     }
     // Cancelled/failed terminal rows (notably denied commands) end the turn
@@ -346,6 +348,9 @@ export class StreamPoller {
       ) {
         if (isSystemMessage(text)) {
           this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
+        }
+        if (isTaskTerminalRow) {
+          this._latestTaskCompletionStepIdx = Math.max(this._latestTaskCompletionStepIdx, row.idx);
         }
         // Rows are re-read on every poll, so an id-less lifecycle row observed
         // before a later launch would otherwise close that newer task on the

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1138,6 +1138,65 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("keeps turn open when cancelled background task (status 6) is the latest meaningful step until assistant responds", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-cancelled-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "bg-cancelled");
+      // Task launches
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "agy models | cat", output: "" }) }),
+        task: encodeTaskDetails({ taskId: "task-82", logUri: "", description: "agy models | cat" })
+      });
+      insertStep(db, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "Running models query..." })
+      });
+      db.close();
+
+      setTimeout(() => {
+        pty.emitData("? for shortcuts");
+        // Task cancelled (status 6) after 200ms — this row IS the latest meaningful step
+        setTimeout(async () => {
+          const db2 = new (await import("better-sqlite3")).default(path.join(dir, "bg-cancelled.db"));
+          insertStep(db2, {
+            idx: 3,
+            stepType: 21,
+            status: 6,
+            stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "agy models | cat", output: "cancelled" }) }),
+            task: encodeTaskDetails({ taskId: "task-82", logUri: "", description: "agy models | cat" })
+          });
+          // Model responds 250ms later with summary
+          setTimeout(() => {
+            insertStep(db2, {
+              idx: 4,
+              stepType: 15,
+              status: 3,
+              stepPayload: encodeStepPayload({ agentText: "The background task was cancelled." })
+            });
+            db2.close();
+            pty.emitData("? for shortcuts");
+          }, 250);
+        }, 200);
+      }, 30);
+    });
+
+    const session = interactiveSession(dir, pty);
+    const updates: any[] = [];
+    const outcome = await session.prompt("list models", async (update) => {
+      updates.push(update);
+    }, async () => "agy-allow-once");
+
+    expect(outcome.stopReason).toBe("end_turn");
+    expect(updates.some(u => JSON.stringify(u).includes("background task was cancelled"))).toBe(true);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("writes only the verbatim user prompt back to a reused interactive PTY", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-reuse-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1080,6 +1080,64 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("keeps turn open when background task completes via task_details terminal row until assistant summary arrives", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-task-row-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "bg-task-row");
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "long_job &", output: "Started task-99" }) }),
+        task: encodeTaskDetails({ taskId: "task-99", logUri: "", description: "Long job" })
+      });
+      insertStep(db, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "Running task in background..." })
+      });
+      db.close();
+
+      setTimeout(() => {
+        pty.emitData("? for shortcuts");
+        // Task finishes after 200ms with a terminal task_details row (no system message)
+        setTimeout(async () => {
+          const db2 = new (await import("better-sqlite3")).default(path.join(dir, "bg-task-row.db"));
+          insertStep(db2, {
+            idx: 3,
+            stepType: 21,
+            status: 3,
+            stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "long_job", output: "Done with job" }) }),
+            task: encodeTaskDetails({ taskId: "task-99", logUri: "", description: "Long job" })
+          });
+          // Model takes another 250ms to generate the summary response
+          setTimeout(() => {
+            insertStep(db2, {
+              idx: 4,
+              stepType: 15,
+              status: 3,
+              stepPayload: encodeStepPayload({ agentText: "Long job finished successfully with output: Done with job" })
+            });
+            db2.close();
+            pty.emitData("? for shortcuts");
+          }, 250);
+        }, 200);
+      }, 30);
+    });
+
+    const session = interactiveSession(dir, pty);
+    const updates: any[] = [];
+    const outcome = await session.prompt("run job", async (update) => {
+      updates.push(update);
+    }, async () => "agy-allow-once");
+
+    expect(outcome.stopReason).toBe("end_turn");
+    expect(updates.some(u => JSON.stringify(u).includes("Long job finished successfully"))).toBe(true);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("writes only the verbatim user prompt back to a reused interactive PTY", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-reuse-"));
     const pty = new FakePty(() => {


### PR DESCRIPTION
## Description

- Track `_latestTaskCompletionStepIdx` in `StreamPoller` when terminal `task_details` rows arrive so that prior assistant messages emitted before background task completion are not mistakenly treated as conclusive.
- Ensure prompt turns remain open across background task executions and wake notices until the model produces its follow-up summary response.
- Add regression test verifying turn execution persists through background task completion until the final summary is delivered.

## Related Issues

Fixes #120

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `pnpm run build` and it completed without errors
- [x] I have executed `pnpm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed