### PR TITLE
Premature turn completion on empty agentText placeholders after tool execution

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -984,6 +984,48 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("does not prematurely complete turn on empty agentText placeholder following tool run when PTY redraws (gh#114)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-placeholder-tool-"));
+    let dbHandle: any;
+    const pty = new FakePty(() => {
+      dbHandle = createConversationDb(dir, "placeholder-tool");
+      // Tool execution finishes
+      insertStep(dbHandle, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "git log -n 6 --oneline", output: "abc1234 Initial commit" }) })
+      });
+      // Empty agent text placeholder written while model prepares generation
+      insertStep(dbHandle, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "" })
+      });
+      // PTY emits prompt redraw / idle marker during the placeholder window
+      setTimeout(() => pty.emitData("\n? for shortcuts\n"), 40);
+
+      // Model takes 350ms to finish generating actual assistant text
+      setTimeout(() => {
+        updateStep(dbHandle, 2, {
+          status: 3,
+          stepPayload: encodeStepPayload({ agentText: "Found recent commit abc1234." })
+        });
+        dbHandle.close();
+        pty.emitData("\n? for shortcuts\n");
+      }, 350);
+    });
+
+    const session = interactiveSession(dir, pty, "5s");
+    const updates: any[] = [];
+    const result = await session.prompt("git log", async (u) => { updates.push(u); }, async () => "agy-allow-once");
+    expect(result.stopReason).toBe("end_turn");
+    expect(updates.some((u) => JSON.stringify(u).includes("Found recent commit abc1234"))).toBe(true);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("detects alternate permission markers split across PTY chunks via multi-marker prefix tails", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-chunked-marker-"));
     const pty = new FakePty(() => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2985,6 +2985,52 @@ describe("StreamPoller", () => {
     db.close();
   });
 
+  it("does not treat empty stepType 15 placeholders after tool execution as conclusive turn end (gh#114)", () => {
+    const db = createConversationDb(dir, "conv-tool-empty-placeholder");
+    insertStep(db, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Check git log" })
+    });
+    // Tool execution finishes with status 3
+    insertStep(db, {
+      idx: 2,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "git log -n 6 --oneline", output: "commit abc" }) })
+    });
+    // agy writes an empty stepType 15 placeholder while model prepares the summary
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({ agentText: "" })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-tool-empty-placeholder",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    // Although the tool step is terminal, the empty placeholder prevents conclusive turn ending
+    expect(poller.isConclusiveTurnEnd).toBe(false);
+
+    // When the model writes the actual summary, it becomes a conclusive turn end
+    updateStep(db, 3, {
+      status: 3,
+      stepPayload: encodeStepPayload({ agentText: "Here are the last 6 commits on this branch." })
+    });
+    poller.poll();
+    expect(poller.isConclusiveTurnEnd).toBe(true);
+
+    poller.close();
+    db.close();
+  });
+
   it("does not treat early lifecycle steps (stepType 90, 98, 101, status 3) as turn completion candidates", () => {
     const db = createConversationDb(dir, "conv-early-lifecycle");
     insertStep(db, {


### PR DESCRIPTION
## Description

- Filter and ignore empty `stepType 15` (`agentText`) placeholders (`len=0` and no thought) committed after tool executions from triggering conclusive turn completion.
- Keep interactive prompt turns active while model generation initializes until non-empty assistant text arrives or a conclusive quiescence settle window completes.
- Add unit and interactive regression tests verifying turn flow persists across empty placeholder windows and intermediate PTY prompt redraws.

## Related Issues

Fixes #114

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `pnpm run build` and it completed without errors
- [x] I have executed `pnpm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [ ] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed