### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 - Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and ANSI-resilient permission panel detection. (#113)
 - Refine `_busy` calculation in `StreamPoller` to evaluate `latestMeaningful` step status rather than raw trailing rows (such as lifecycle `stepType 101` or `gen_metadata` records), ensuring trailing metadata does not prevent clean turn completion. (#113)
 - Decode protobuf payload field 114 (task completion notifications) on lifecycle `stepType 101` rows and expand `isSystemMessage()` to recognize un-tagged message envelopes (`[Message]`, `[Notice]`, `[System]`, `sender=`), ensuring background task completions properly retire active tasks in `StreamPoller` without hanging turns. (#131)
+- Keep interactive turns open after failed or cancelled tools and background-task completion wakes until a conclusive SQLite follow-up row arrives, instead of idling on PTY silence. (#113, #115, #120)
 
 ## [0.5.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 - Serialize `session/fork` against `session/resume` and `session/load` for the same parent session ID — including persisted-but-inactive parents — and bind the child's `lastStepIdx` to the copied conversation snapshot so inherited agy step rows cannot be emitted as the child's first-turn output. (#58)
 - Fail `session/fork` and delete the partial child database when rebinding `trajectory_meta.cascade_id` or reading the snapshot cursor fails, instead of returning a child that still carries the source conversation identity. (#58)
+- Delete the copied child conversation database and brain directory if `session/fork` is aborted or fails after the snapshot is taken and before the child is registered. (#58)
 - Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and ANSI-resilient permission panel detection. (#113)
 - Refine `_busy` calculation in `StreamPoller` to evaluate `latestMeaningful` step status rather than raw trailing rows (such as lifecycle `stepType 101` or `gen_metadata` records), ensuring trailing metadata does not prevent clean turn completion. (#113)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 - Decode protobuf payload field 114 (task completion notifications) on lifecycle `stepType 101` rows and expand `isSystemMessage()` to recognize un-tagged message envelopes (`[Message]`, `[Notice]`, `[System]`, `sender=`), ensuring background task completions properly retire active tasks in `StreamPoller` without hanging turns. (#131)
 - Keep interactive turns open after failed or cancelled tools and background-task completion wakes until a conclusive SQLite follow-up row arrives, instead of idling on PTY silence. (#113, #115, #120)
 - Send alternate permission-menu choices without waiting for a PTY panel redraw; confirm the decision from the status-9 row and `permissions` blob. (#122)
+- Surface `SessionStore.persist` write failures to callers so `session/fork` can roll back a registered child instead of returning an unpersisted session ID. (#58)
 
 ## [0.5.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ pre-1.0 caveat that minor versions may include breaking changes. Starting with
 `1.0.0-alpha.0`, package pre-releases track ACP v2 draft work; the wire protocol
 for draft v2 may still change before ACP v2 stabilizes.
 
+## [0.5.2] - Unreleased
+
+### Fixed
+
+- Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and ANSI-resilient permission panel detection. (#113)
+- Refine `_busy` calculation in `StreamPoller` to evaluate `latestMeaningful` step status rather than raw trailing rows (such as lifecycle `stepType 101` or `gen_metadata` records), ensuring trailing metadata does not prevent clean turn completion. (#113)
+
 ## [0.5.1] - 2026-08-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 - Refine `_busy` calculation in `StreamPoller` to evaluate `latestMeaningful` step status rather than raw trailing rows (such as lifecycle `stepType 101` or `gen_metadata` records), ensuring trailing metadata does not prevent clean turn completion. (#113)
 - Decode protobuf payload field 114 (task completion notifications) on lifecycle `stepType 101` rows and expand `isSystemMessage()` to recognize un-tagged message envelopes (`[Message]`, `[Notice]`, `[System]`, `sender=`), ensuring background task completions properly retire active tasks in `StreamPoller` without hanging turns. (#131)
 - Keep interactive turns open after failed or cancelled tools and background-task completion wakes until a conclusive SQLite follow-up row arrives, instead of idling on PTY silence. (#113, #115, #120)
+- Send alternate permission-menu choices without waiting for a PTY panel redraw; confirm the decision from the status-9 row and `permissions` blob. (#122)
 
 ## [0.5.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ pre-1.0 caveat that minor versions may include breaking changes. Starting with
 `1.0.0-alpha.0`, package pre-releases track ACP v2 draft work; the wire protocol
 for draft v2 may still change before ACP v2 stabilizes.
 
-## [0.5.2] - Unreleased
+## [0.5.2] - 2026-08-19
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ### Fixed
 
+- Serialize `session/fork` against `session/resume` and `session/load` for the same parent session ID — including persisted-but-inactive parents — and bind the child's `lastStepIdx` to the copied conversation snapshot so inherited agy step rows cannot be emitted as the child's first-turn output. (#58)
 - Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and ANSI-resilient permission panel detection. (#113)
 - Refine `_busy` calculation in `StreamPoller` to evaluate `latestMeaningful` step status rather than raw trailing rows (such as lifecycle `stepType 101` or `gen_metadata` records), ensuring trailing metadata does not prevent clean turn completion. (#113)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 - Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and ANSI-resilient permission panel detection. (#113)
 - Refine `_busy` calculation in `StreamPoller` to evaluate `latestMeaningful` step status rather than raw trailing rows (such as lifecycle `stepType 101` or `gen_metadata` records), ensuring trailing metadata does not prevent clean turn completion. (#113)
+- Decode protobuf payload field 114 (task completion notifications) on lifecycle `stepType 101` rows and expand `isSystemMessage()` to recognize un-tagged message envelopes (`[Message]`, `[Notice]`, `[System]`, `sender=`), ensuring background task completions properly retire active tasks in `StreamPoller` without hanging turns. (#131)
 
 ## [0.5.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [0.5.2] - Unreleased
 
+### Added
+
+- Support `session/fork` across ACP v1 and v2: duplicate conversation history using atomic SQLite backup, clone brain directory artifacts, rebind trajectory metadata, and inherit active configuration options and working directory. (#58)
+
 ### Fixed
 
 - Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and ANSI-resilient permission panel detection. (#113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 - Send alternate permission-menu choices without waiting for a PTY panel redraw; confirm the decision from the status-9 row and `permissions` blob. (#122)
 - Surface `SessionStore.persist` write failures to callers so `session/fork` can roll back a registered child instead of returning an unpersisted session ID. (#58)
 - Fail `session/fork` and discard the partial child when cloning brain-directory artifacts fails, instead of returning a child with an incomplete artifact tree. (#58)
+- Evict the forked parent when `maxActiveSessions` is already full so a fork claim cannot bypass the active-session cap. (#58)
 
 ## [0.5.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 ### Fixed
 
 - Serialize `session/fork` against `session/resume` and `session/load` for the same parent session ID — including persisted-but-inactive parents — and bind the child's `lastStepIdx` to the copied conversation snapshot so inherited agy step rows cannot be emitted as the child's first-turn output. (#58)
+- Fail `session/fork` and delete the partial child database when rebinding `trajectory_meta.cascade_id` or reading the snapshot cursor fails, instead of returning a child that still carries the source conversation identity. (#58)
 - Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and ANSI-resilient permission panel detection. (#113)
 - Refine `_busy` calculation in `StreamPoller` to evaluate `latestMeaningful` step status rather than raw trailing rows (such as lifecycle `stepType 101` or `gen_metadata` records), ensuring trailing metadata does not prevent clean turn completion. (#113)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 - Keep interactive turns open after failed or cancelled tools and background-task completion wakes until a conclusive SQLite follow-up row arrives, instead of idling on PTY silence. (#113, #115, #120)
 - Send alternate permission-menu choices without waiting for a PTY panel redraw; confirm the decision from the status-9 row and `permissions` blob. (#122)
 - Surface `SessionStore.persist` write failures to callers so `session/fork` can roll back a registered child instead of returning an unpersisted session ID. (#58)
+- Fail `session/fork` and discard the partial child when cloning brain-directory artifacts fails, instead of returning a child with an incomplete artifact tree. (#58)
 
 ## [0.5.1] - 2026-08-15
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,7 @@ Gaps relative to ACP v1 as exposed by `@agentclientprotocol/sdk`.
 - [x] [`session/new`](https://agentclientprotocol.com/protocol/v1/session-setup): create session with persisted bindings
 - [x] [`session/load`](https://agentclientprotocol.com/protocol/v1/session-setup): restore and replay conversation history
 - [x] [`session/resume`](https://agentclientprotocol.com/rfds/session-resume): reattach without replaying history
+- [x] [`session/fork`](https://agentclientprotocol.com/rfds/session-fork): fork conversation into a new independent session
 - [x] [`session/close`](https://agentclientprotocol.com/rfds/session-close): close active session
 - [x] [`session/delete`](https://agentclientprotocol.com/protocol/v1/session-delete): delete persisted session binding from session store
 - [x] [`session/list`](https://agentclientprotocol.com/protocol/v1/session-list): list sessions from the session store
@@ -74,7 +75,6 @@ Need interactive agy control plane or client terminal protocol beyond DB polling
 
 ### Medium priority
 
-- [ ] [`session/fork`](https://agentclientprotocol.com/rfds/session-fork): fork when useful for clients
 - [ ] [`usage_update`](https://agentclientprotocol.com/rfds/session-usage): when token/usage data is available from agy
 - [ ] [`usage`](https://agentclientprotocol.com/rfds/end-turn-token-usage): prompt-response field when available
 - [ ] [`stopReason`](https://agentclientprotocol.com/protocol/v1/prompt-turn#stop-reasons): richer values (`max_tokens`, `refusal`, `max_turn_requests`) when agy exposes them (today: `end_turn` or `cancelled`)
@@ -115,6 +115,7 @@ differs or is incomplete.
 - [x] [`session/new`](https://agentclientprotocol.com/protocol/v2/session-setup): create session
 - [x] [`session/list`](https://agentclientprotocol.com/protocol/v2/session-list): list sessions
 - [x] [`session/resume`](https://agentclientprotocol.com/protocol/v2/session-setup): optional `replayFrom: { "type": "start" }` ([replay RFD](https://agentclientprotocol.com/rfds/v2/session-resume-replay))
+- [x] [`session/fork`](https://agentclientprotocol.com/rfds/session-fork): fork conversation into a new independent session
 - [x] [`session/close`](https://agentclientprotocol.com/protocol/v2/session-setup): close session
 - [x] [`session/delete`](https://agentclientprotocol.com/protocol/v2/session-delete): delete persisted session binding from session store
 - [x] [`session/prompt`](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle): accept with `{}` immediately
@@ -145,7 +146,6 @@ differs or is incomplete.
 
 ### Medium priority
 
-- [ ] [`session/fork`](https://agentclientprotocol.com/rfds/session-fork): when useful
 - [ ] [`usage_update`](https://agentclientprotocol.com/rfds/session-usage): when token data is available from agy
 - [ ] [`stopReason`](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle): richer values on idle `state_update` when agy exposes them
 - [ ] [`agent_message`](https://agentclientprotocol.com/rfds/v2/message-updates): optional full-message updates (+ `agent_thought`) in addition to chunks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agy-acp",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Agent Client Protocol adapter that wraps the Google Antigravity CLI (ACP v1 + experimental draft ACP v2)",
   "type": "module",
   "author": {

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -102,6 +102,7 @@ import {
   reloadSession,
   replayConversation,
   persistSession,
+  KeyedAsyncLock,
   type SessionBuildDeps
 } from "./session/setup.js";
 import { deferAfterResponse, handleNewSessionV1, handleNewSessionV2, type NewSessionDeps } from "./session/new.js";
@@ -202,6 +203,7 @@ export class AcpAgent {
   readonly #argv: string[];
   readonly #backend: AgyCliBackend;
   readonly #sessions = new Map<string, SessionState>();
+  readonly #setupLocks = new KeyedAsyncLock();
   readonly #store: SessionStore;
   readonly #replayCache = new ReplayCache(REPLAY_CACHE_CAPACITY);
   readonly #modelCacheFile: string;
@@ -742,7 +744,8 @@ export class AcpAgent {
       ...this.sessionBuildDeps(),
       store: this.#store,
       sessions: this.#sessions,
-      maxActiveSessions: this.#maxActiveSessions
+      maxActiveSessions: this.#maxActiveSessions,
+      setupLocks: this.#setupLocks
     });
     this.reconcileSessionCatalog(result.session);
     return result;
@@ -758,7 +761,8 @@ export class AcpAgent {
       store: this.#store,
       sessions: this.#sessions,
       maxActiveSessions: this.#maxActiveSessions,
-      persistSession: (sessionId, session) => this.persistSession(sessionId, session)
+      persistSession: (sessionId, session) => this.persistSession(sessionId, session),
+      setupLocks: this.#setupLocks
     });
     this.reconcileSessionCatalog(result.childSession);
     return result;

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -97,6 +97,7 @@ import { handleSetConfigOptionV1, handleSetConfigOptionV2 } from "./session/set-
 import {
   buildSession,
   createSession,
+  forkSession,
   registerSession,
   reloadSession,
   replayConversation,
@@ -104,6 +105,15 @@ import {
   type SessionBuildDeps
 } from "./session/setup.js";
 import { deferAfterResponse, handleNewSessionV1, handleNewSessionV2, type NewSessionDeps } from "./session/new.js";
+import {
+  handleForkSessionV1,
+  handleForkSessionV2,
+  type ForkSessionDeps,
+  type V1ForkSessionRequest,
+  type V1ForkSessionResponse,
+  type V2ForkSessionRequest,
+  type V2ForkSessionResponse
+} from "./session/fork.js";
 import { handleLoadSession } from "./session/load.js";
 import { handleResumeSessionV1, handleResumeSessionV2 } from "./session/resume.js";
 import { handleSetSessionMode } from "./session/set-mode.js";
@@ -350,6 +360,27 @@ export class AcpAgent {
   newSessionV2(params: V2NewSessionRequest, client?: V2AgentContext): Promise<V2NewSessionResponse> {
     return handleNewSessionV2(params, client, {
       ...this.newSessionDeps(),
+      notifyAvailableCommandsV2
+    });
+  }
+
+  private forkSessionDeps(): ForkSessionDeps {
+    return {
+      requireAuthenticated: (cwd) => this.requireAuthenticated(cwd),
+      forkSession: (parentSessionId, cwd, dirs) => this.forkSession(parentSessionId, cwd, dirs)
+    };
+  }
+
+  forkSessionV1(params: V1ForkSessionRequest, client?: V1AgentContext): Promise<V1ForkSessionResponse> {
+    return handleForkSessionV1(params, client, {
+      ...this.forkSessionDeps(),
+      notifyAvailableCommandsV1
+    });
+  }
+
+  forkSessionV2(params: V2ForkSessionRequest, client?: V2AgentContext): Promise<V2ForkSessionResponse> {
+    return handleForkSessionV2(params, client, {
+      ...this.forkSessionDeps(),
       notifyAvailableCommandsV2
     });
   }
@@ -717,6 +748,22 @@ export class AcpAgent {
     return result;
   }
 
+  private async forkSession(
+    parentSessionId: string,
+    requestedCwd: string | undefined,
+    requestedDirs: string[] | undefined
+  ): Promise<{ childSession: SessionState; cwd: string; childSessionId: string }> {
+    const result = await forkSession(parentSessionId, requestedCwd, requestedDirs, {
+      ...this.sessionBuildDeps(),
+      store: this.#store,
+      sessions: this.#sessions,
+      maxActiveSessions: this.#maxActiveSessions,
+      persistSession: (sessionId, session) => this.persistSession(sessionId, session)
+    });
+    this.reconcileSessionCatalog(result.childSession);
+    return result;
+  }
+
   private reconcileSessionCatalog(session: SessionState): void {
     const key = session.agy.config.agyPath;
     const cached = this.#modelOptionsCache.get(key);
@@ -759,6 +806,7 @@ export function createAcpApp(options: AcpAgentOptions | AcpAgent = {}): V1AgentA
     .onRequest(v1.methods.agent.session.list, (ctx) => agent.listSessions(ctx.params))
     .onRequest(v1.methods.agent.session.load, (ctx) => agent.loadSession(ctx.params, ctx.client))
     .onRequest(v1.methods.agent.session.resume, (ctx) => agent.resumeSessionV1(ctx.params, ctx.client))
+    .onRequest(v1.methods.agent.session.fork, (ctx) => agent.forkSessionV1(ctx.params, ctx.client))
     .onRequest(v1.methods.agent.session.setMode, (ctx) => agent.setSessionMode(ctx.params, ctx.client))
     .onRequest(v1.methods.agent.session.setConfigOption, (ctx) =>
       agent.setConfigOptionV1(ctx.params, ctx.client)
@@ -783,6 +831,7 @@ export function createAcpV2App(options: AcpAgentOptions | AcpAgent = {}): V2Agen
     .onRequest(v2.methods.agent.session.new, (ctx) => agent.newSessionV2(ctx.params, ctx.client))
     .onRequest(v2.methods.agent.session.list, (ctx) => agent.listSessions(ctx.params))
     .onRequest(v2.methods.agent.session.resume, (ctx) => agent.resumeSessionV2(ctx.params, ctx.client))
+    .onRequest(v2.methods.agent.session.fork, (ctx) => agent.forkSessionV2(ctx.params, ctx.client))
     .onRequest(v2.methods.agent.session.setConfigOption, (ctx) => agent.setConfigOptionV2(ctx.params))
     .onRequest(v2.methods.agent.session.prompt, (ctx) => agent.promptV2(ctx.params, ctx.client))
     .onRequest(v2.methods.agent.session.close, (ctx) => agent.closeSession(ctx.params))

--- a/src/acp/initialize.ts
+++ b/src/acp/initialize.ts
@@ -105,7 +105,8 @@ export function handleInitializeV1(
           list: {},
           additionalDirectories: {},
           resume: {},
-          close: {}
+          close: {},
+          fork: {}
         },
         auth: {
           logout: {}
@@ -140,7 +141,8 @@ export function handleInitializeV2(
             image: {},
             embeddedContext: {}
           },
-          additionalDirectories: {}
+          additionalDirectories: {},
+          fork: {}
         },
         auth: {},
         toolCallName: {},

--- a/src/acp/session/fork.ts
+++ b/src/acp/session/fork.ts
@@ -1,0 +1,75 @@
+// ACP session/fork: create a new session branching off an existing session's history and configuration.
+// Docs: https://agentclientprotocol.com/rfds/session-fork
+
+import type {
+  AgentContext as V1AgentContext,
+  ForkSessionRequest as V1ForkSessionRequest,
+  ForkSessionResponse as V1ForkSessionResponse
+} from "@agentclientprotocol/sdk";
+import type {
+  AgentContext as V2AgentContext,
+  ForkSessionRequest as V2ForkSessionRequest,
+  ForkSessionResponse as V2ForkSessionResponse
+} from "@agentclientprotocol/sdk/experimental/v2";
+import { sessionConfigOptionsV1, sessionConfigOptionsV2 } from "./config-options.js";
+import { sessionModeState } from "./modes.js";
+import { deferAfterResponse } from "./new.js";
+import type { SessionState } from "./types.js";
+
+export type { V1ForkSessionRequest, V1ForkSessionResponse, V2ForkSessionRequest, V2ForkSessionResponse };
+
+export interface ForkSessionDeps {
+  requireAuthenticated(cwd?: string): Promise<void>;
+  forkSession(
+    parentSessionId: string,
+    cwd: string | undefined,
+    additionalDirectories: string[] | undefined
+  ): Promise<{ childSession: SessionState; cwd: string; childSessionId: string }>;
+}
+
+export async function handleForkSessionV1(
+  params: V1ForkSessionRequest,
+  client: V1AgentContext | undefined,
+  deps: ForkSessionDeps & {
+    notifyAvailableCommandsV1(client: V1AgentContext, sessionId: string): Promise<void>;
+  }
+): Promise<V1ForkSessionResponse> {
+  await deps.requireAuthenticated(params.cwd);
+  const { childSession, childSessionId } = await deps.forkSession(
+    params.sessionId,
+    params.cwd,
+    params.additionalDirectories
+  );
+  if (client) {
+    childSession.v1Client = client;
+    deferAfterResponse(() => deps.notifyAvailableCommandsV1(client, childSessionId));
+  }
+  return {
+    sessionId: childSessionId,
+    modes: sessionModeState(childSession.agy.config.mode),
+    configOptions: sessionConfigOptionsV1(childSession)
+  };
+}
+
+export async function handleForkSessionV2(
+  params: V2ForkSessionRequest,
+  client: V2AgentContext | undefined,
+  deps: ForkSessionDeps & {
+    notifyAvailableCommandsV2(client: V2AgentContext, sessionId: string): Promise<void>;
+  }
+): Promise<V2ForkSessionResponse> {
+  await deps.requireAuthenticated(params.cwd);
+  const { childSession, childSessionId } = await deps.forkSession(
+    params.sessionId,
+    params.cwd,
+    params.additionalDirectories
+  );
+  if (client) {
+    childSession.v2Client = client;
+    deferAfterResponse(() => deps.notifyAvailableCommandsV2(client, childSessionId));
+  }
+  return {
+    sessionId: childSessionId,
+    configOptions: sessionConfigOptionsV2(childSession)
+  };
+}

--- a/src/acp/session/setup-lock.ts
+++ b/src/acp/session/setup-lock.ts
@@ -1,0 +1,23 @@
+// Per-session-ID mutex for setup RPCs (fork / load / resume).
+//
+// Turn claims only exist on an in-memory SessionState. Fork of a persisted
+// but inactive parent has no SessionState, so resume/load can register that
+// parent and start writing its conversation DB while the fork is still
+// snapshotting. A keyed lock serializes those setup paths regardless of
+// whether the session is currently in the active map.
+
+export class KeyedAsyncLock {
+  readonly #tails = new Map<string, Promise<unknown>>();
+
+  run<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.#tails.get(key) ?? Promise.resolve();
+    const next: Promise<T> = prev.catch(() => undefined).then(() => fn());
+    this.#tails.set(key, next);
+    void next
+      .finally(() => {
+        if (this.#tails.get(key) === next) this.#tails.delete(key);
+      })
+      .catch(() => {});
+    return next;
+  }
+}

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -79,7 +79,8 @@ export async function registerSession(
   sessionId: string,
   session: SessionState,
   sessions: Map<string, SessionState>,
-  maxActiveSessions: number
+  maxActiveSessions: number,
+  options?: { evictable?: ReadonlySet<string> }
 ): Promise<void> {
   const replaced = sessions.get(sessionId);
   if (replaced && replaced !== session) {
@@ -94,7 +95,9 @@ export async function registerSession(
   }
 
   while (sessions.size >= maxActiveSessions) {
-    const candidate = [...sessions].find(([, current]) => !sessionTurnBusy(current));
+    const candidate = [...sessions].find(
+      ([id, current]) => !sessionTurnBusy(current) || options?.evictable?.has(id)
+    );
     if (!candidate) break;
     const [evictedId, evicted] = candidate;
     sessions.delete(evictedId);
@@ -225,7 +228,13 @@ export async function forkSession(
         childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
         claim?.throwIfAborted();
         childSession.sessionId = childSessionId;
-        await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
+        await registerSession(
+          childSessionId,
+          childSession,
+          deps.sessions,
+          deps.maxActiveSessions,
+          activeParent ? { evictable: new Set([parentSessionId]) } : undefined
+        );
         await deps.persistSession(childSessionId, childSession);
         setupComplete = true;
 

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -80,6 +80,9 @@ export async function registerSession(
 ): Promise<void> {
   const replaced = sessions.get(sessionId);
   if (replaced && replaced !== session) {
+    if (sessionTurnBusy(replaced)) {
+      throw new Error(`Cannot replace session while a turn is active: ${sessionId}`);
+    }
     sessions.delete(sessionId);
     replaced.closed = true;
     turnsOf(replaced).close();
@@ -188,6 +191,7 @@ export async function forkSession(
       childConversationId = randomUUID();
       const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
       await forkConversation(convDir, parentStored.conversationId, childConversationId);
+      claim?.throwIfAborted();
     }
 
     const childStored: StoredSession = {
@@ -203,6 +207,7 @@ export async function forkSession(
     };
 
     const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
+    claim?.throwIfAborted();
     childSession.sessionId = childSessionId;
     await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
     await deps.persistSession(childSessionId, childSession);

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -161,6 +161,9 @@ export async function forkSession(
   }
 ): Promise<{ childSession: SessionState; cwd: string; childSessionId: string }> {
   const activeParent = deps.sessions.get(parentSessionId);
+  if (activeParent && sessionTurnBusy(activeParent)) {
+    throw new Error(`Cannot fork session while a turn is active: ${parentSessionId}`);
+  }
   const parentStored = activeParent
     ? sessionRecord(activeParent)
     : await deps.store.restore(parentSessionId);

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -5,10 +5,12 @@ import { randomUUID } from "node:crypto";
 import type * as v1 from "@agentclientprotocol/sdk";
 import {
   configFromEnv,
+  DEFAULT_CONVERSATIONS_DIR,
   isSessionModeId,
   type AgyCliBackend,
   type AgyCliConfig
 } from "../../agy/cli.js";
+import { forkConversation } from "../../agy/db/fork.js";
 import type { ReplayCache } from "../../agy/db/replay.js";
 import { buildModelCatalog } from "../../agy/model/catalog.js";
 import { applyModelSelection, initialModelSelection, restoredModelSelection } from "../../agy/model/selection.js";
@@ -144,6 +146,59 @@ export async function reloadSession(
   session.sessionId = sessionId;
   await registerSession(sessionId, session, deps.sessions, deps.maxActiveSessions);
   return { session, cwd, stored };
+}
+
+/** Fork an existing session into a new independent session binding. */
+export async function forkSession(
+  parentSessionId: string,
+  requestedCwd: string | undefined,
+  requestedDirs: string[] | undefined,
+  deps: SessionBuildDeps & {
+    store: SessionStore;
+    sessions: Map<string, SessionState>;
+    maxActiveSessions: number;
+    persistSession(sessionId: string, session: SessionState): Promise<void>;
+  }
+): Promise<{ childSession: SessionState; cwd: string; childSessionId: string }> {
+  const activeParent = deps.sessions.get(parentSessionId);
+  const parentStored = activeParent
+    ? sessionRecord(activeParent)
+    : await deps.store.restore(parentSessionId);
+  if (!parentStored) {
+    throw new Error(`Unknown session: ${parentSessionId}`);
+  }
+
+  const cwd = requestedCwd || parentStored.cwd;
+  const additionalDirectories = dedupe(requestedDirs ?? parentStored.additionalDirectories);
+  const childSessionId = randomUUID();
+
+  let childConversationId: string | null = null;
+  const childLastStepIdx = parentStored.lastStepIdx;
+
+  if (parentStored.conversationId) {
+    childConversationId = randomUUID();
+    const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
+    await forkConversation(convDir, parentStored.conversationId, childConversationId);
+  }
+
+  const childStored: StoredSession = {
+    cwd,
+    additionalDirectories,
+    conversationId: childConversationId,
+    lastStepIdx: childLastStepIdx,
+    model: parentStored.model,
+    reasoningEffort: parentStored.reasoningEffort,
+    mode: parentStored.mode,
+    v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
+    updatedAt: new Date().toISOString()
+  };
+
+  const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
+  childSession.sessionId = childSessionId;
+  await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
+  await deps.persistSession(childSessionId, childSession);
+
+  return { childSession, cwd, childSessionId };
 }
 
 export function sessionRecord(session: SessionState): StoredSession {

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -18,7 +18,10 @@ import type { SessionStore, StoredSession } from "./store.js";
 import type { SessionState } from "./types.js";
 import { cancelQueuedPrompts } from "./cancel.js";
 import { notifyIdleAndDrainQueue, sessionTurnBusy } from "./prompt.js";
+import { KeyedAsyncLock } from "./setup-lock.js";
 import { type TurnClaim, turnsOf } from "./turn-scheduler.js";
+
+export { KeyedAsyncLock } from "./setup-lock.js";
 
 export interface SessionBuildDeps {
   env: NodeJS.ProcessEnv;
@@ -136,19 +139,22 @@ export async function reloadSession(
     store: SessionStore;
     sessions: Map<string, SessionState>;
     maxActiveSessions: number;
+    setupLocks: KeyedAsyncLock;
   }
 ): Promise<{ session: SessionState; cwd: string; stored: StoredSession }> {
-  const stored = await deps.store.restore(sessionId);
-  if (!stored) {
-    throw new Error(`Unknown session: ${sessionId}`);
-  }
-  const cwd = requestedCwd || stored.cwd;
-  const additionalDirectories = dedupe(requestedDirs ?? stored.additionalDirectories);
+  return deps.setupLocks.run(sessionId, async () => {
+    const stored = await deps.store.restore(sessionId);
+    if (!stored) {
+      throw new Error(`Unknown session: ${sessionId}`);
+    }
+    const cwd = requestedCwd || stored.cwd;
+    const additionalDirectories = dedupe(requestedDirs ?? stored.additionalDirectories);
 
-  const session = await buildSession(cwd, additionalDirectories, stored, deps);
-  session.sessionId = sessionId;
-  await registerSession(sessionId, session, deps.sessions, deps.maxActiveSessions);
-  return { session, cwd, stored };
+    const session = await buildSession(cwd, additionalDirectories, stored, deps);
+    session.sessionId = sessionId;
+    await registerSession(sessionId, session, deps.sessions, deps.maxActiveSessions);
+    return { session, cwd, stored };
+  });
 }
 
 /** Fork an existing session into a new independent session binding. */
@@ -161,64 +167,71 @@ export async function forkSession(
     sessions: Map<string, SessionState>;
     maxActiveSessions: number;
     persistSession(sessionId: string, session: SessionState): Promise<void>;
+    setupLocks: KeyedAsyncLock;
   }
 ): Promise<{ childSession: SessionState; cwd: string; childSessionId: string }> {
-  const activeParent = deps.sessions.get(parentSessionId);
-  let claim: TurnClaim | undefined;
-  if (activeParent) {
-    if (sessionTurnBusy(activeParent)) {
-      throw new Error(`Cannot fork session while a turn is active: ${parentSessionId}`);
-    }
-    claim = turnsOf(activeParent).claimIdle("foreground");
-  }
-
-  try {
-    const parentStored = activeParent
-      ? sessionRecord(activeParent)
-      : await deps.store.restore(parentSessionId);
-    if (!parentStored) {
-      throw new Error(`Unknown session: ${parentSessionId}`);
+  return deps.setupLocks.run(parentSessionId, async () => {
+    const activeParent = deps.sessions.get(parentSessionId);
+    let claim: TurnClaim | undefined;
+    if (activeParent) {
+      if (sessionTurnBusy(activeParent)) {
+        throw new Error(`Cannot fork session while a turn is active: ${parentSessionId}`);
+      }
+      claim = turnsOf(activeParent).claimIdle("foreground");
     }
 
-    const cwd = requestedCwd || parentStored.cwd;
-    const additionalDirectories = dedupe(requestedDirs ?? parentStored.additionalDirectories);
-    const childSessionId = randomUUID();
+    try {
+      const parentStored = activeParent
+        ? sessionRecord(activeParent)
+        : await deps.store.restore(parentSessionId);
+      if (!parentStored) {
+        throw new Error(`Unknown session: ${parentSessionId}`);
+      }
 
-    let childConversationId: string | null = null;
-    const childLastStepIdx = parentStored.lastStepIdx;
+      const cwd = requestedCwd || parentStored.cwd;
+      const additionalDirectories = dedupe(requestedDirs ?? parentStored.additionalDirectories);
+      const childSessionId = randomUUID();
 
-    if (parentStored.conversationId) {
-      childConversationId = randomUUID();
-      const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
-      await forkConversation(convDir, parentStored.conversationId, childConversationId);
+      let childConversationId: string | null = null;
+      let childLastStepIdx = parentStored.lastStepIdx;
+
+      if (parentStored.conversationId) {
+        childConversationId = randomUUID();
+        const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
+        const forked = await forkConversation(convDir, parentStored.conversationId, childConversationId);
+        // Bind the child cursor to the copied snapshot so inherited rows cannot
+        // be emitted as the child's first-turn output. agy resumes via
+        // `--conversation <id>` and StreamPoller emits idx > lastStepIdx.
+        childLastStepIdx = Math.max(parentStored.lastStepIdx, forked.maxStepIdx);
+        claim?.throwIfAborted();
+      }
+
+      const childStored: StoredSession = {
+        cwd,
+        additionalDirectories,
+        conversationId: childConversationId,
+        lastStepIdx: childLastStepIdx,
+        model: parentStored.model,
+        reasoningEffort: parentStored.reasoningEffort,
+        mode: parentStored.mode,
+        v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
+        updatedAt: new Date().toISOString()
+      };
+
+      const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
       claim?.throwIfAborted();
+      childSession.sessionId = childSessionId;
+      await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
+      await deps.persistSession(childSessionId, childSession);
+
+      return { childSession, cwd, childSessionId };
+    } finally {
+      if (activeParent && claim) {
+        turnsOf(activeParent).release(claim);
+        notifyIdleAndDrainQueue(activeParent);
+      }
     }
-
-    const childStored: StoredSession = {
-      cwd,
-      additionalDirectories,
-      conversationId: childConversationId,
-      lastStepIdx: childLastStepIdx,
-      model: parentStored.model,
-      reasoningEffort: parentStored.reasoningEffort,
-      mode: parentStored.mode,
-      v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
-      updatedAt: new Date().toISOString()
-    };
-
-    const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
-    claim?.throwIfAborted();
-    childSession.sessionId = childSessionId;
-    await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
-    await deps.persistSession(childSessionId, childSession);
-
-    return { childSession, cwd, childSessionId };
-  } finally {
-    if (activeParent && claim) {
-      turnsOf(activeParent).release(claim);
-      notifyIdleAndDrainQueue(activeParent);
-    }
-  }
+  });
 }
 
 export function sessionRecord(session: SessionState): StoredSession {

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -196,7 +196,7 @@ export async function forkSession(
       let convDir: string | undefined;
       let childLastStepIdx = parentStored.lastStepIdx;
       let childSession: SessionState | undefined;
-      let registered = false;
+      let setupComplete = false;
 
       try {
         if (parentStored.conversationId) {
@@ -226,12 +226,15 @@ export async function forkSession(
         claim?.throwIfAborted();
         childSession.sessionId = childSessionId;
         await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
-        registered = true;
         await deps.persistSession(childSessionId, childSession);
+        setupComplete = true;
 
         return { childSession, cwd, childSessionId };
       } finally {
-        if (!registered) {
+        if (!setupComplete) {
+          if (deps.sessions.get(childSessionId) === childSession) {
+            deps.sessions.delete(childSessionId);
+          }
           if (childSession) {
             childSession.closed = true;
             turnsOf(childSession).close();

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -10,7 +10,7 @@ import {
   type AgyCliBackend,
   type AgyCliConfig
 } from "../../agy/cli.js";
-import { forkConversation } from "../../agy/db/fork.js";
+import { discardForkedConversation, forkConversation } from "../../agy/db/fork.js";
 import type { ReplayCache } from "../../agy/db/replay.js";
 import { buildModelCatalog } from "../../agy/model/catalog.js";
 import { applyModelSelection, initialModelSelection, restoredModelSelection } from "../../agy/model/selection.js";
@@ -193,38 +193,55 @@ export async function forkSession(
       const childSessionId = randomUUID();
 
       let childConversationId: string | null = null;
+      let convDir: string | undefined;
       let childLastStepIdx = parentStored.lastStepIdx;
+      let childSession: SessionState | undefined;
+      let registered = false;
 
-      if (parentStored.conversationId) {
-        childConversationId = randomUUID();
-        const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
-        const forked = await forkConversation(convDir, parentStored.conversationId, childConversationId);
-        // Bind the child cursor to the copied snapshot so inherited rows cannot
-        // be emitted as the child's first-turn output. agy resumes via
-        // `--conversation <id>` and StreamPoller emits idx > lastStepIdx.
-        childLastStepIdx = Math.max(parentStored.lastStepIdx, forked.maxStepIdx);
+      try {
+        if (parentStored.conversationId) {
+          childConversationId = randomUUID();
+          convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
+          const forked = await forkConversation(convDir, parentStored.conversationId, childConversationId);
+          // Bind the child cursor to the copied snapshot so inherited rows cannot
+          // be emitted as the child's first-turn output. agy resumes via
+          // `--conversation <id>` and StreamPoller emits idx > lastStepIdx.
+          childLastStepIdx = Math.max(parentStored.lastStepIdx, forked.maxStepIdx);
+          claim?.throwIfAborted();
+        }
+
+        const childStored: StoredSession = {
+          cwd,
+          additionalDirectories,
+          conversationId: childConversationId,
+          lastStepIdx: childLastStepIdx,
+          model: parentStored.model,
+          reasoningEffort: parentStored.reasoningEffort,
+          mode: parentStored.mode,
+          v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
+          updatedAt: new Date().toISOString()
+        };
+
+        childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
         claim?.throwIfAborted();
+        childSession.sessionId = childSessionId;
+        await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
+        registered = true;
+        await deps.persistSession(childSessionId, childSession);
+
+        return { childSession, cwd, childSessionId };
+      } finally {
+        if (!registered) {
+          if (childSession) {
+            childSession.closed = true;
+            turnsOf(childSession).close();
+            await childSession.agy.close().catch(() => {});
+          }
+          if (childConversationId && convDir) {
+            discardForkedConversation(convDir, childConversationId);
+          }
+        }
       }
-
-      const childStored: StoredSession = {
-        cwd,
-        additionalDirectories,
-        conversationId: childConversationId,
-        lastStepIdx: childLastStepIdx,
-        model: parentStored.model,
-        reasoningEffort: parentStored.reasoningEffort,
-        mode: parentStored.mode,
-        v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
-        updatedAt: new Date().toISOString()
-      };
-
-      const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
-      claim?.throwIfAborted();
-      childSession.sessionId = childSessionId;
-      await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
-      await deps.persistSession(childSessionId, childSession);
-
-      return { childSession, cwd, childSessionId };
     } finally {
       if (activeParent && claim) {
         turnsOf(activeParent).release(claim);

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -17,8 +17,8 @@ import { applyModelSelection, initialModelSelection, restoredModelSelection } fr
 import type { SessionStore, StoredSession } from "./store.js";
 import type { SessionState } from "./types.js";
 import { cancelQueuedPrompts } from "./cancel.js";
-import { sessionTurnBusy } from "./prompt.js";
-import { turnsOf } from "./turn-scheduler.js";
+import { notifyIdleAndDrainQueue, sessionTurnBusy } from "./prompt.js";
+import { type TurnClaim, turnsOf } from "./turn-scheduler.js";
 
 export interface SessionBuildDeps {
   env: NodeJS.ProcessEnv;
@@ -161,47 +161,59 @@ export async function forkSession(
   }
 ): Promise<{ childSession: SessionState; cwd: string; childSessionId: string }> {
   const activeParent = deps.sessions.get(parentSessionId);
-  if (activeParent && sessionTurnBusy(activeParent)) {
-    throw new Error(`Cannot fork session while a turn is active: ${parentSessionId}`);
-  }
-  const parentStored = activeParent
-    ? sessionRecord(activeParent)
-    : await deps.store.restore(parentSessionId);
-  if (!parentStored) {
-    throw new Error(`Unknown session: ${parentSessionId}`);
+  let claim: TurnClaim | undefined;
+  if (activeParent) {
+    if (sessionTurnBusy(activeParent)) {
+      throw new Error(`Cannot fork session while a turn is active: ${parentSessionId}`);
+    }
+    claim = turnsOf(activeParent).claimIdle("foreground");
   }
 
-  const cwd = requestedCwd || parentStored.cwd;
-  const additionalDirectories = dedupe(requestedDirs ?? parentStored.additionalDirectories);
-  const childSessionId = randomUUID();
+  try {
+    const parentStored = activeParent
+      ? sessionRecord(activeParent)
+      : await deps.store.restore(parentSessionId);
+    if (!parentStored) {
+      throw new Error(`Unknown session: ${parentSessionId}`);
+    }
 
-  let childConversationId: string | null = null;
-  const childLastStepIdx = parentStored.lastStepIdx;
+    const cwd = requestedCwd || parentStored.cwd;
+    const additionalDirectories = dedupe(requestedDirs ?? parentStored.additionalDirectories);
+    const childSessionId = randomUUID();
 
-  if (parentStored.conversationId) {
-    childConversationId = randomUUID();
-    const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
-    await forkConversation(convDir, parentStored.conversationId, childConversationId);
+    let childConversationId: string | null = null;
+    const childLastStepIdx = parentStored.lastStepIdx;
+
+    if (parentStored.conversationId) {
+      childConversationId = randomUUID();
+      const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
+      await forkConversation(convDir, parentStored.conversationId, childConversationId);
+    }
+
+    const childStored: StoredSession = {
+      cwd,
+      additionalDirectories,
+      conversationId: childConversationId,
+      lastStepIdx: childLastStepIdx,
+      model: parentStored.model,
+      reasoningEffort: parentStored.reasoningEffort,
+      mode: parentStored.mode,
+      v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
+      updatedAt: new Date().toISOString()
+    };
+
+    const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
+    childSession.sessionId = childSessionId;
+    await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
+    await deps.persistSession(childSessionId, childSession);
+
+    return { childSession, cwd, childSessionId };
+  } finally {
+    if (activeParent && claim) {
+      turnsOf(activeParent).release(claim);
+      notifyIdleAndDrainQueue(activeParent);
+    }
   }
-
-  const childStored: StoredSession = {
-    cwd,
-    additionalDirectories,
-    conversationId: childConversationId,
-    lastStepIdx: childLastStepIdx,
-    model: parentStored.model,
-    reasoningEffort: parentStored.reasoningEffort,
-    mode: parentStored.mode,
-    v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
-    updatedAt: new Date().toISOString()
-  };
-
-  const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
-  childSession.sessionId = childSessionId;
-  await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
-  await deps.persistSession(childSessionId, childSession);
-
-  return { childSession, cwd, childSessionId };
 }
 
 export function sessionRecord(session: SessionState): StoredSession {

--- a/src/acp/session/store.ts
+++ b/src/acp/session/store.ts
@@ -71,10 +71,11 @@ export class SessionStore {
 
   /** Persist a session binding. Resolves once written (writes are serialized). */
   persist(sessionId: string, session: StoredSession): Promise<void> {
-    this.#writeChain = this.#writeChain.then(() => this.writeOne(sessionId, session)).catch((error) => {
+    const op = this.#writeChain.then(() => this.writeOne(sessionId, session));
+    this.#writeChain = op.catch((error) => {
       console.error(`[agy-acp] WARN: failed to persist session: ${(error as Error).message}`);
     });
-    return this.#writeChain;
+    return op;
   }
 
   /** Delete a persisted session binding. Resolves once written (writes are serialized). Returns true if deleted. */

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -722,7 +722,7 @@ export class AgyCliSession {
         const isIdleCandidate =
           poller.turnCompleteCandidate &&
           poller.lastStepIdx > this.#lastStepIdx &&
-          (hasMatchedMarker || (candidateRevision === poller.revision && hasQuiesced));
+          (hasMatchedMarker || (candidateRevision === poller.revision && poller.isConclusiveTurnEnd && hasQuiesced));
         if (isIdleCandidate) {
           // Background work can finish after the TUI looks idle. Stay on this
           // user turn and keep polling — do not inject a synthetic "continue".

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -44,7 +44,8 @@ const POLL_INTERVAL_MS = 200;
 const TRAILING_POLL_ATTEMPTS = 3;
 const TRAILING_POLL_DELAY_MS = 100;
 const PERMISSION_RENDER_SETTLE_MS = 20;
-const PERMISSION_REDRAW_TIMEOUT_MS = 500;
+const PERMISSION_REDRAW_TIMEOUT_MS = 2_000;
+const QUIESCENT_SETTLE_MS = 300;
 
 /** Signature of the permission decision agy has recorded for a gated step.
  *  A re-armed status-9 prompt (e.g. the next segment of `a && b`) changes this
@@ -240,6 +241,7 @@ export class AgyCliSession {
   #activeStreamPoller: StreamPoller | undefined;
   #lastPtyIdleMarkerRevision: { count: number; databaseRevision: string } | null = null;
   #ptyConfig = "";
+  #lastPtyActivityTime = 0;
   #cancelled = false;
   #cancelTurn: (() => void) | undefined;
   #cancelWait: Promise<void> = Promise.resolve();
@@ -489,9 +491,11 @@ export class AgyCliSession {
           PERMISSION_RENDER_SETTLE_MS
         );
         this.#ptyOutput = (this.#ptyOutput + data).slice(-16_384);
+        this.#lastPtyActivityTime = Date.now();
       });
       this.#ptyExit = new Promise((resolve) => this.#pty!.onExit(resolve));
     } else {
+      this.#lastPtyActivityTime = Date.now();
       this.#pty.write(`\x1b[200~${prompt.replaceAll("\x1b", "")}\x1b[201~\r`);
     }
     // Tracked separately: a toolCallId can legitimately go through the live
@@ -515,9 +519,10 @@ export class AgyCliSession {
     // A newly spawned TUI first draws its initial idle prompt, then draws
     // another when the submitted turn finishes. A reused TUI only owes the
     // latter marker.
-    const startStepIdx = this.#lastStepIdx;
-    const initialIdleMarkerCount = this.#ptyIdleMarkerCount;
-    let requiredIdleMarkerCount = this.#ptyIdleMarkerCount + (freshPty ? 2 : 1);
+    let requiredIdleMarkerCount = freshPty
+      ? 2
+      : this.#ptyIdleMarkerCount + 1;
+    let lastActivityTime = Date.now();
     let failed = false;
     try {
       while (true) {
@@ -527,14 +532,14 @@ export class AgyCliSession {
           seenRevision = poller.revision;
           candidateRevision = poller.turnCompleteCandidate ? poller.revision : -1;
           deadline = Date.now() + timeoutMs;
+          lastActivityTime = Date.now();
         } else if (!poller.turnCompleteCandidate) candidateRevision = -1;
+        if (updates.length > 0) {
+          lastActivityTime = Date.now();
+        }
         if (Date.now() >= deadline) {
-          // Enough idle markers: the TUI is idle; keep the PTY for reuse.
-          if (this.#ptyIdleMarkerCount >= requiredIdleMarkerCount) break;
-          // Soft timeout: DB looks terminal but the required completion marker
-          // never arrived (e.g. intermediate terminal tool + long silence).
-          // Stop the PTY so the next client prompt cannot join a live turn.
-          if (poller.turnCompleteCandidate) {
+          if (this.#ptyIdleMarkerCount >= requiredIdleMarkerCount && poller.turnCompleteCandidate && poller.lastStepIdx > this.#lastStepIdx) break;
+          if (poller.turnCompleteCandidate && poller.lastStepIdx > this.#lastStepIdx) {
             await this.stopPty();
             break;
           }
@@ -712,30 +717,12 @@ export class AgyCliSession {
             }
           }
         }
-        const idleMarkerRevision = this.currentIdleMarkerRevision();
-        const markersSinceTurnStart = idleMarkerRevision === null
-          ? 0
-          : idleMarkerRevision.count - initialIdleMarkerCount;
-        // A single post-start marker on a fresh PTY may be a delayed startup
-        // redraw that captured an intermediate terminal tool revision. Only
-        // accept that shortcut when the latest step is a conclusive ending
-        // (agent text or cancelled/failed), or when a later marker proves the
-        // post-turn idle redraw (markersSinceTurnStart >= 2).
-        const revisionShortcutSafe =
-          !freshPty ||
-          markersSinceTurnStart >= 2 ||
-          poller.isConclusiveTurnEnd;
-        const hasRevisionMatchedIdleMarker =
-          idleMarkerRevision !== null &&
-          markersSinceTurnStart >= 1 &&
-          revisionShortcutSafe &&
-          idleMarkerRevision.databaseRevision === poller.observedDatabaseRevision;
+        const hasMatchedMarker = this.#ptyIdleMarkerCount >= requiredIdleMarkerCount;
+        const hasQuiesced = (Date.now() - Math.max(lastActivityTime, this.#lastPtyActivityTime)) >= QUIESCENT_SETTLE_MS;
         const isIdleCandidate =
-          (poller.turnCompleteCandidate &&
-           poller.lastUserStepIdx > startStepIdx &&
-           poller.lastStepIdx > poller.lastUserStepIdx &&
-           hasRevisionMatchedIdleMarker) ||
-          (candidateRevision === poller.revision && this.#ptyIdleMarkerCount >= requiredIdleMarkerCount);
+          poller.turnCompleteCandidate &&
+          poller.lastStepIdx > this.#lastStepIdx &&
+          (hasMatchedMarker || (candidateRevision === poller.revision && hasQuiesced));
         if (isIdleCandidate) {
           // Background work can finish after the TUI looks idle. Stay on this
           // user turn and keep polling — do not inject a synthetic "continue".
@@ -1184,10 +1171,17 @@ export class AgyCliSession {
   }
 
   private flushPermissionRender(): void {
+    const raw = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
+    const clean = raw.replace(/\x1b\[[0-9;?]*[a-zA-Z]|\x1b\].*?\x07|\x1b[()][AB012]/g, "");
     const marker = "Yes, and always allow";
-    const output = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
-    const visible = output.includes(marker);
-    this.#ptyPermissionMarkerTail = markerPrefixTail(output, marker);
+    const visible =
+      raw.includes(marker) ||
+      clean.includes(marker) ||
+      clean.includes("Always allow") ||
+      clean.includes("Allow once") ||
+      clean.includes("Allow this time") ||
+      clean.includes("Allow this command");
+    this.#ptyPermissionMarkerTail = markerPrefixTail(raw, marker);
     if (visible) {
       this.#ptyPermissionMarkerCount++;
       this.#ptyPermissionPanelVisible = true;
@@ -1236,7 +1230,11 @@ export class AgyCliSession {
     ) {
       await sleep(5);
     }
-    return this.#ptyPermissionPanelVisible && this.#ptyPermissionRenderTimer === undefined;
+    if (this.#ptyPermissionRenderTimer !== undefined) {
+      clearTimeout(this.#ptyPermissionRenderTimer);
+      this.flushPermissionRender();
+    }
+    return this.#ptyPermissionPanelVisible;
   }
 
   private async waitForPermissionRenderAfter(renderCount: number, deadline: number): Promise<boolean> {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -1173,15 +1173,8 @@ export class AgyCliSession {
   private flushPermissionRender(): void {
     const raw = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
     const clean = raw.replace(/\x1b\[[0-9;?]*[a-zA-Z]|\x1b\].*?\x07|\x1b[()][AB012]/g, "");
-    const marker = "Yes, and always allow";
-    const visible =
-      raw.includes(marker) ||
-      clean.includes(marker) ||
-      clean.includes("Always allow") ||
-      clean.includes("Allow once") ||
-      clean.includes("Allow this time") ||
-      clean.includes("Allow this command");
-    this.#ptyPermissionMarkerTail = markerPrefixTail(raw, marker);
+    const visible = PERMISSION_MARKERS.some((marker) => raw.includes(marker) || clean.includes(marker));
+    this.#ptyPermissionMarkerTail = multiMarkerPrefixTail(clean, PERMISSION_MARKERS);
     if (visible) {
       this.#ptyPermissionMarkerCount++;
       this.#ptyPermissionPanelVisible = true;
@@ -1250,6 +1243,14 @@ export class AgyCliSession {
   }
 }
 
+const PERMISSION_MARKERS = [
+  "Yes, and always allow",
+  "Always allow",
+  "Allow once",
+  "Allow this time",
+  "Allow this command"
+] as const;
+
 function markerPrefixTail(output: string, marker: string): string {
   const max = Math.min(output.length, marker.length - 1);
   for (let length = max; length > 0; length--) {
@@ -1257,6 +1258,17 @@ function markerPrefixTail(output: string, marker: string): string {
     if (marker.startsWith(suffix)) return suffix;
   }
   return "";
+}
+
+function multiMarkerPrefixTail(output: string, markers: readonly string[]): string {
+  let longest = "";
+  for (const marker of markers) {
+    const tail = markerPrefixTail(output, marker);
+    if (tail.length > longest.length) {
+      longest = tail;
+    }
+  }
+  return longest;
 }
 
 export class AgyCliBackend {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -44,7 +44,20 @@ const POLL_INTERVAL_MS = 200;
 const TRAILING_POLL_ATTEMPTS = 3;
 const TRAILING_POLL_DELAY_MS = 100;
 const PERMISSION_RENDER_SETTLE_MS = 20;
-const PERMISSION_REDRAW_TIMEOUT_MS = 500;
+const PERMISSION_REDRAW_TIMEOUT_MS = 2_500;
+
+const ANSI_REGEX = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\].*?(?:\x07|\x1B\\))/g;
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_REGEX, "");
+}
+
+const PERMISSION_MARKERS = [
+  "Yes, and always allow",
+  "Always allow",
+  "Allow this tool",
+  "Allow this command",
+  "Yes, allow"
+];
 
 /** Signature of the permission decision agy has recorded for a gated step.
  *  A re-armed status-9 prompt (e.g. the next segment of `a && b`) changes this
@@ -1174,10 +1187,10 @@ export class AgyCliSession {
   }
 
   private flushPermissionRender(): void {
-    const marker = "Yes, and always allow";
-    const output = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
-    const visible = output.includes(marker);
-    this.#ptyPermissionMarkerTail = markerPrefixTail(output, marker);
+    const rawOutput = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
+    const cleanOutput = stripAnsi(rawOutput);
+    const visible = PERMISSION_MARKERS.some((marker) => cleanOutput.includes(marker));
+    this.#ptyPermissionMarkerTail = permissionMarkerPrefixTail(cleanOutput);
     if (visible) {
       this.#ptyPermissionMarkerCount++;
       this.#ptyPermissionPanelVisible = true;
@@ -1218,19 +1231,46 @@ export class AgyCliSession {
   private async waitForPermissionPanel(deadline: number): Promise<boolean> {
     const expires = Math.min(deadline, Date.now() + PERMISSION_REDRAW_TIMEOUT_MS);
     while (
-      (!this.#ptyPermissionPanelVisible || this.#ptyPermissionRenderTimer !== undefined) &&
+      !this.#ptyPermissionPanelVisible &&
       !this.#cancelled &&
       Date.now() < expires
     ) {
+      if (this.#ptyPermissionRenderTimer !== undefined && this.#ptyPermissionRender.length > 0) {
+        const rawOutput = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
+        const cleanOutput = stripAnsi(rawOutput);
+        if (PERMISSION_MARKERS.some((marker) => cleanOutput.includes(marker))) {
+          if (this.#ptyPermissionRenderTimer) clearTimeout(this.#ptyPermissionRenderTimer);
+          this.flushPermissionRender();
+          break;
+        }
+      }
       await sleep(5);
     }
-    return this.#ptyPermissionPanelVisible && this.#ptyPermissionRenderTimer === undefined;
+    if (this.#ptyPermissionRenderTimer !== undefined) {
+      clearTimeout(this.#ptyPermissionRenderTimer);
+      this.flushPermissionRender();
+    }
+    return this.#ptyPermissionPanelVisible;
   }
 
   private async waitForPermissionRenderAfter(renderCount: number, deadline: number): Promise<boolean> {
     const expires = Math.min(deadline, Date.now() + PERMISSION_REDRAW_TIMEOUT_MS);
     while (this.#ptyPermissionMarkerCount <= renderCount && !this.#cancelled && Date.now() < expires) {
+      if (this.#ptyPermissionRenderTimer !== undefined && this.#ptyPermissionRender.length > 0) {
+        const rawOutput = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
+        const cleanOutput = stripAnsi(rawOutput);
+        if (PERMISSION_MARKERS.some((marker) => cleanOutput.includes(marker))) {
+          if (this.#ptyPermissionRenderTimer) clearTimeout(this.#ptyPermissionRenderTimer);
+          this.flushPermissionRender();
+          if (this.#ptyPermissionMarkerCount > renderCount) break;
+        }
+      }
       await sleep(5);
+    }
+    if (this.#cancelled) return false;
+    if (this.#ptyPermissionRenderTimer !== undefined) {
+      clearTimeout(this.#ptyPermissionRenderTimer);
+      this.flushPermissionRender();
     }
     return this.#ptyPermissionMarkerCount > renderCount;
   }
@@ -1238,6 +1278,21 @@ export class AgyCliSession {
   async close(): Promise<void> {
     await this.cancel();
   }
+}
+
+function permissionMarkerPrefixTail(output: string): string {
+  let longest = "";
+  for (const marker of PERMISSION_MARKERS) {
+    const max = Math.min(output.length, marker.length - 1);
+    for (let length = max; length > longest.length; length--) {
+      const suffix = output.slice(-length);
+      if (marker.startsWith(suffix)) {
+        longest = suffix;
+        break;
+      }
+    }
+  }
+  return longest;
 }
 
 function markerPrefixTail(output: string, marker: string): string {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -242,7 +242,6 @@ export class AgyCliSession {
   #ptyPermissionRenderTimer: ReturnType<typeof setTimeout> | undefined;
   #activeStreamPoller: StreamPoller | undefined;
   #ptyConfig = "";
-  #lastPtyActivityTime = 0;
   #cancelled = false;
   #cancelTurn: (() => void) | undefined;
   #cancelWait: Promise<void> = Promise.resolve();
@@ -468,11 +467,9 @@ export class AgyCliSession {
           PERMISSION_RENDER_SETTLE_MS
         );
         this.#ptyOutput = (this.#ptyOutput + data).slice(-16_384);
-        this.#lastPtyActivityTime = Date.now();
       });
       this.#ptyExit = new Promise((resolve) => this.#pty!.onExit(resolve));
     } else {
-      this.#lastPtyActivityTime = Date.now();
       this.#pty.write(`\x1b[200~${prompt.replaceAll("\x1b", "")}\x1b[201~\r`);
     }
     // Tracked separately: a toolCallId can legitimately go through the live
@@ -682,12 +679,13 @@ export class AgyCliSession {
         if (hadInteraction) {
           lastActivityTime = Date.now();
         }
-        const hasQuiesced = (Date.now() - Math.max(lastActivityTime, this.#lastPtyActivityTime)) >= QUIESCENT_SETTLE_MS;
+        const hasQuiesced = (Date.now() - lastActivityTime) >= QUIESCENT_SETTLE_MS;
         const isIdleCandidate =
           poller.turnCompleteCandidate &&
           poller.lastStepIdx > this.#lastStepIdx &&
           candidateRevision === poller.revision &&
-          hasQuiesced;
+          hasQuiesced &&
+          (poller.isConclusiveTurnEnd || poller.isSuccessfulToolOnlyEnd);
         if (isIdleCandidate) {
           // Background work can finish after the TUI looks idle. Stay on this
           // user turn and keep polling — do not inject a synthetic "continue".

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -518,6 +518,9 @@ export class AgyCliSession {
           throw new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final turn completion was observed`, [this.config.agyPath], null, this.#ptyOutput);
         }
         for (const update of updates) await this.raceTurnCallback(onUpdate(update), deadline);
+        if (updates.length > 0) {
+          lastActivityTime = Date.now();
+        }
         if (this.#cancelled) break;
         for (const [id, markerCount] of gateMarkerCounts) {
           if (this.#ptyPermissionMarkerCount <= markerCount) continue;
@@ -527,7 +530,9 @@ export class AgyCliSession {
           if (poller.requeuePending(id)) rearmedGateIds.add(id);
           gateMarkerCounts.delete(id);
         }
+        let hadInteraction = false;
         for (const interaction of poller.takePending()) {
+          hadInteraction = true;
           const toolCall = interaction.update;
           const id = String((toolCall as unknown as { toolCallId?: string }).toolCallId);
           if (interaction.blocked) {
@@ -675,6 +680,9 @@ export class AgyCliSession {
               await observeReported(revertedContents(this.config.cwd, toolCall, restored));
             }
           }
+        }
+        if (hadInteraction) {
+          lastActivityTime = Date.now();
         }
         const hasQuiesced = (Date.now() - Math.max(lastActivityTime, this.#lastPtyActivityTime)) >= QUIESCENT_SETTLE_MS;
         const isIdleCandidate =

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -239,7 +239,6 @@ export class AgyCliSession {
   #ptyPermissionMarkerCount = 0;
   #ptyPermissionRender = "";
   #ptyPermissionMarkerTail = "";
-  #ptyPermissionPanelVisible = false;
   #ptyPermissionRenderTimer: ReturnType<typeof setTimeout> | undefined;
   #activeStreamPoller: StreamPoller | undefined;
   #ptyConfig = "";
@@ -459,7 +458,6 @@ export class AgyCliSession {
       this.#ptyPermissionMarkerCount = 0;
       this.#ptyPermissionRender = "";
       this.#ptyPermissionMarkerTail = "";
-      this.#ptyPermissionPanelVisible = false;
       const activePty = this.#pty;
       activePty.onData((data) => {
         if (this.#pty !== activePty) return;
@@ -1119,7 +1117,6 @@ export class AgyCliSession {
     this.#ptyPermissionRenderTimer = undefined;
     this.#ptyPermissionRender = "";
     this.#ptyPermissionMarkerTail = "";
-    this.#ptyPermissionPanelVisible = false;
     this.#pty = undefined;
     this.#ptyExit = undefined;
     if (pty) {
@@ -1142,15 +1139,12 @@ export class AgyCliSession {
       clean.includes("Yes, and always allow") ||
       clean.includes("Select option:") ||
       clean.includes("Allow this command?") ||
-      clean.includes("Allow this tool") ||
-      clean.includes("Allow once") ||
-      clean.includes("Allow this time");
+      clean.includes("Allow this tool");
     const visible = isPermissionContext && PERMISSION_MARKERS.some((marker) => clean.includes(marker));
     const cleanTail = multiMarkerPrefixTail(clean, PERMISSION_MARKERS);
     this.#ptyPermissionMarkerTail = cleanTail + incomplete;
     if (visible) {
       this.#ptyPermissionMarkerCount++;
-      this.#ptyPermissionPanelVisible = true;
     }
     this.#ptyPermissionRender = "";
     this.#ptyPermissionRenderTimer = undefined;

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -44,13 +44,8 @@ const POLL_INTERVAL_MS = 200;
 const TRAILING_POLL_ATTEMPTS = 3;
 const TRAILING_POLL_DELAY_MS = 100;
 const PERMISSION_RENDER_SETTLE_MS = 20;
-const PERMISSION_REDRAW_TIMEOUT_MS = 2_500;
+const PERMISSION_KEY_DELAY_MS = 50;
 const QUIESCENT_SETTLE_MS = 300;
-
-const ANSI_REGEX = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\].*?(?:\x07|\x1B\\))/g;
-export function stripAnsi(text: string): string {
-  return text.replace(ANSI_REGEX, "");
-}
 
 /** Signature of the permission decision agy has recorded for a gated step.
  *  A re-armed status-9 prompt (e.g. the next segment of `a && b`) changes this
@@ -614,7 +609,7 @@ export class AgyCliSession {
                   this.#ptyOutput
                 );
               }
-              if (!await this.writePermissionKeys(keys, deadline)) break;
+              if (!await this.writePermissionKeys(keys)) break;
             }
             gateMarkerCounts.set(id, this.#ptyPermissionMarkerCount);
             continue;
@@ -1147,55 +1142,21 @@ export class AgyCliSession {
     this.#ptyPermissionRenderTimer = undefined;
   }
 
-  private async writePermissionKeys(keys: string, deadline: number): Promise<boolean> {
-    if (this.#cancelled) return false;
-
-    // Allow in-flight panel renders to settle before capturing marker count
-    while (this.#ptyPermissionRenderTimer !== undefined && !this.#cancelled) {
-      await sleep(10);
-    }
+  private async writePermissionKeys(keys: string): Promise<boolean> {
     if (this.#cancelled) return false;
 
     const down = "\x1b[B";
     let offset = 0;
     while (keys.startsWith(down, offset)) {
-      const renderCount = this.#ptyPermissionMarkerCount;
       this.#pty?.write(down);
-      if (!await this.waitForPermissionRenderAfter(renderCount, deadline)) {
-        if (this.#cancelled) return false;
-        throw new AgyCliError(
-          "agy permission panel did not redraw after menu navigation",
-          [this.config.agyPath],
-          null,
-          this.#ptyOutput
-        );
-      }
       offset += down.length;
+      if (offset < keys.length) {
+        await sleep(PERMISSION_KEY_DELAY_MS);
+        if (this.#cancelled) return false;
+      }
     }
     this.#pty?.write(keys.slice(offset));
     return true;
-  }
-
-  private async waitForPermissionRenderAfter(renderCount: number, deadline: number): Promise<boolean> {
-    const expires = Math.min(deadline, Date.now() + PERMISSION_REDRAW_TIMEOUT_MS);
-    while (this.#ptyPermissionMarkerCount <= renderCount && !this.#cancelled && Date.now() < expires) {
-      if (this.#ptyPermissionRenderTimer !== undefined && this.#ptyPermissionRender.length > 0) {
-        const rawOutput = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
-        const cleanOutput = stripAnsi(rawOutput);
-        if (PERMISSION_MARKERS.some((marker) => cleanOutput.includes(marker))) {
-          if (this.#ptyPermissionRenderTimer) clearTimeout(this.#ptyPermissionRenderTimer);
-          this.flushPermissionRender();
-          if (this.#ptyPermissionMarkerCount > renderCount) break;
-        }
-      }
-      await sleep(5);
-    }
-    if (this.#cancelled) return false;
-    if (this.#ptyPermissionRenderTimer !== undefined) {
-      clearTimeout(this.#ptyPermissionRenderTimer);
-      this.flushPermissionRender();
-    }
-    return this.#ptyPermissionMarkerCount > renderCount;
   }
 
   async close(): Promise<void> {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -687,7 +687,6 @@ export class AgyCliSession {
           poller.turnCompleteCandidate &&
           poller.lastStepIdx > this.#lastStepIdx &&
           candidateRevision === poller.revision &&
-          poller.isConclusiveTurnEnd &&
           hasQuiesced;
         if (isIdleCandidate) {
           // Background work can finish after the TUI looks idle. Stay on this

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -231,15 +231,12 @@ export class AgyCliSession {
   #pty: PtyProcess | undefined;
   #ptyExit: Promise<{ exitCode: number }> | undefined;
   #ptyOutput = "";
-  #ptyIdleMarkerCount = 0;
-  #ptyIdleMatchTail = "";
   #ptyPermissionMarkerCount = 0;
   #ptyPermissionRender = "";
   #ptyPermissionMarkerTail = "";
   #ptyPermissionPanelVisible = false;
   #ptyPermissionRenderTimer: ReturnType<typeof setTimeout> | undefined;
   #activeStreamPoller: StreamPoller | undefined;
-  #lastPtyIdleMarkerRevision: { count: number; databaseRevision: string } | null = null;
   #ptyConfig = "";
   #lastPtyActivityTime = 0;
   #cancelled = false;
@@ -449,16 +446,11 @@ export class AgyCliSession {
     const poller = new StreamPoller({ dir: this.config.conversationsDir, conversationId: this.#conversationId,
       baseStepIdx: this.#lastStepIdx, baseGenMetadataIdx: this.#lastGenMetadataIdx, skipNarration: false, cwd: this.config.cwd, snapshot });
     this.#activeStreamPoller = poller;
-    this.#lastPtyIdleMarkerRevision = null;
-    let freshPty = false;
     if (!this.#pty) {
       const [program, ...args] = this.interactiveCommandForPrompt(prompt);
       this.#pty = factory!.spawn(program, args, { ...this.spawnOptions(), cols: 120, rows: 40 });
-      freshPty = true;
       this.#ptyConfig = signature;
       this.#ptyOutput = "";
-      this.#ptyIdleMarkerCount = 0;
-      this.#ptyIdleMatchTail = "";
       this.#ptyPermissionMarkerCount = 0;
       this.#ptyPermissionRender = "";
       this.#ptyPermissionMarkerTail = "";
@@ -466,24 +458,6 @@ export class AgyCliSession {
       const activePty = this.#pty;
       activePty.onData((data) => {
         if (this.#pty !== activePty) return;
-        const idleMarker = "for shortcuts";
-        const searchable = this.#ptyIdleMatchTail + data;
-        let offset = 0;
-        while ((offset = searchable.indexOf(idleMarker, offset)) >= 0) {
-          this.#ptyIdleMarkerCount++;
-          const databaseRevision = this.#activeStreamPoller?.captureDatabaseRevision() ?? null;
-          this.#lastPtyIdleMarkerRevision = databaseRevision === null
-            ? null
-            : { count: this.#ptyIdleMarkerCount, databaseRevision };
-          this.#ptyPermissionPanelVisible = false;
-          offset += idleMarker.length;
-        }
-        this.#ptyIdleMatchTail = searchable.slice(-(idleMarker.length - 1));
-
-        // Treat a transition into agy's permission panel as one occurrence.
-        // Arrow-key navigation redraws the same panel and must not re-arm the
-        // gate; consecutive identical gates transition through a non-panel
-        // render while the approved command segment runs.
         this.#ptyPermissionRender = (this.#ptyPermissionRender + data).slice(-16_384);
         if (this.#ptyPermissionRenderTimer) clearTimeout(this.#ptyPermissionRenderTimer);
         this.#ptyPermissionRenderTimer = setTimeout(
@@ -516,12 +490,6 @@ export class AgyCliSession {
     let deadline = Date.now() + timeoutMs;
     let candidateRevision = -1;
     let seenRevision = -1;
-    // A newly spawned TUI first draws its initial idle prompt, then draws
-    // another when the submitted turn finishes. A reused TUI only owes the
-    // latter marker.
-    let requiredIdleMarkerCount = freshPty
-      ? 2
-      : this.#ptyIdleMarkerCount + 1;
     let lastActivityTime = Date.now();
     let failed = false;
     try {
@@ -538,12 +506,11 @@ export class AgyCliSession {
           lastActivityTime = Date.now();
         }
         if (Date.now() >= deadline) {
-          if (this.#ptyIdleMarkerCount >= requiredIdleMarkerCount && poller.turnCompleteCandidate && poller.lastStepIdx > this.#lastStepIdx) break;
           if (poller.turnCompleteCandidate && poller.lastStepIdx > this.#lastStepIdx) {
             await this.stopPty();
             break;
           }
-          throw new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final idle marker was observed`, [this.config.agyPath], null, this.#ptyOutput);
+          throw new AgyCliError(`agy interactive turn timed out after ${this.config.printTimeout}; no final turn completion was observed`, [this.config.agyPath], null, this.#ptyOutput);
         }
         for (const update of updates) await this.raceTurnCallback(onUpdate(update), deadline);
         if (this.#cancelled) break;
@@ -655,9 +622,6 @@ export class AgyCliSession {
               if (!await this.writePermissionKeys(keys, deadline)) break;
             }
             gateMarkerCounts.set(id, this.#ptyPermissionMarkerCount);
-            // An idle marker printed before the decision cannot mean that the
-            // approved/rejected command has finished.
-            requiredIdleMarkerCount = this.#ptyIdleMarkerCount + 1;
             continue;
           }
 
@@ -717,12 +681,13 @@ export class AgyCliSession {
             }
           }
         }
-        const hasMatchedMarker = this.#ptyIdleMarkerCount >= requiredIdleMarkerCount;
         const hasQuiesced = (Date.now() - Math.max(lastActivityTime, this.#lastPtyActivityTime)) >= QUIESCENT_SETTLE_MS;
         const isIdleCandidate =
           poller.turnCompleteCandidate &&
           poller.lastStepIdx > this.#lastStepIdx &&
-          (hasMatchedMarker || (candidateRevision === poller.revision && poller.isConclusiveTurnEnd && hasQuiesced));
+          candidateRevision === poller.revision &&
+          poller.isConclusiveTurnEnd &&
+          hasQuiesced;
         if (isIdleCandidate) {
           // Background work can finish after the TUI looks idle. Stay on this
           // user turn and keep polling — do not inject a synthetic "continue".
@@ -760,10 +725,6 @@ export class AgyCliSession {
       if (this.#activeStreamPoller === poller) this.#activeStreamPoller = undefined;
       if (this.#cancelled && !failed) await this.stopPty();
     }
-  }
-
-  private currentIdleMarkerRevision(): { count: number; databaseRevision: string } | null {
-    return this.#lastPtyIdleMarkerRevision;
   }
 
   private async raceTurnCallback<T>(callback: Promise<T>, deadline?: number): Promise<T | "cancelled"> {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -1177,31 +1177,6 @@ export class AgyCliSession {
     return true;
   }
 
-  private async waitForPermissionPanel(deadline: number): Promise<boolean> {
-    const expires = Math.min(deadline, Date.now() + PERMISSION_REDRAW_TIMEOUT_MS);
-    while (
-      !this.#ptyPermissionPanelVisible &&
-      !this.#cancelled &&
-      Date.now() < expires
-    ) {
-      if (this.#ptyPermissionRenderTimer !== undefined && this.#ptyPermissionRender.length > 0) {
-        const rawOutput = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
-        const cleanOutput = stripAnsi(rawOutput);
-        if (PERMISSION_MARKERS.some((marker) => cleanOutput.includes(marker))) {
-          if (this.#ptyPermissionRenderTimer) clearTimeout(this.#ptyPermissionRenderTimer);
-          this.flushPermissionRender();
-          break;
-        }
-      }
-      await sleep(5);
-    }
-    if (this.#ptyPermissionRenderTimer !== undefined) {
-      clearTimeout(this.#ptyPermissionRenderTimer);
-      this.flushPermissionRender();
-    }
-    return this.#ptyPermissionPanelVisible;
-  }
-
   private async waitForPermissionRenderAfter(renderCount: number, deadline: number): Promise<boolean> {
     const expires = Math.min(deadline, Date.now() + PERMISSION_REDRAW_TIMEOUT_MS);
     while (this.#ptyPermissionMarkerCount <= renderCount && !this.#cancelled && Date.now() < expires) {

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -1133,9 +1133,17 @@ export class AgyCliSession {
 
   private flushPermissionRender(): void {
     const raw = this.#ptyPermissionMarkerTail + this.#ptyPermissionRender;
-    const clean = raw.replace(/\x1b\[[0-9;?]*[a-zA-Z]|\x1b\].*?\x07|\x1b[()][AB012]/g, "");
-    const visible = PERMISSION_MARKERS.some((marker) => raw.includes(marker) || clean.includes(marker));
-    this.#ptyPermissionMarkerTail = multiMarkerPrefixTail(clean, PERMISSION_MARKERS);
+    const { completed, incomplete } = splitIncompleteAnsi(raw);
+    const clean = completed.replace(/\x1b\[[0-9;?]*[a-zA-Z]|\x1b\].*?\x07|\x1b[()][AB012]/g, "");
+    const isPermissionContext =
+      clean.includes("Yes, and always allow") ||
+      clean.includes("Select option:") ||
+      clean.includes("Allow this command?") ||
+      clean.includes("Allow once") ||
+      clean.includes("Allow this time");
+    const visible = isPermissionContext && PERMISSION_MARKERS.some((marker) => clean.includes(marker));
+    const cleanTail = multiMarkerPrefixTail(clean, PERMISSION_MARKERS);
+    this.#ptyPermissionMarkerTail = cleanTail + incomplete;
     if (visible) {
       this.#ptyPermissionMarkerCount++;
       this.#ptyPermissionPanelVisible = true;
@@ -1202,6 +1210,17 @@ export class AgyCliSession {
   async close(): Promise<void> {
     await this.cancel();
   }
+}
+
+function splitIncompleteAnsi(input: string): { completed: string; incomplete: string } {
+  const match = input.match(/\x1b(?:\[[0-9;?]*|\][^\x07]*|[()][AB012]?)?$/);
+  if (match && match.index !== undefined && match[0].length > 0) {
+    return {
+      completed: input.slice(0, match.index),
+      incomplete: match[0]
+    };
+  }
+  return { completed: input, incomplete: "" };
 }
 
 const PERMISSION_MARKERS = [

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -596,16 +596,6 @@ export class AgyCliSession {
               }
             }
 
-            if (interaction.toolName !== "ask_question" && !await this.waitForPermissionPanel(deadline)) {
-              if (this.#cancelled) break;
-              throw new AgyCliError(
-                "agy permission panel was not observed before requesting permission",
-                [this.config.agyPath],
-                null,
-                this.#ptyOutput
-              );
-            }
-
             if (interaction.toolName === "ask_question") {
               const ask = parseAskQuestion(toolCall);
               const count = ask?.questions.length ?? 1;
@@ -1197,15 +1187,13 @@ export class AgyCliSession {
   }
 
   private async writePermissionKeys(keys: string, deadline: number): Promise<boolean> {
-    if (!await this.waitForPermissionPanel(deadline)) {
-      if (this.#cancelled) return false;
-      throw new AgyCliError(
-        "agy permission panel did not settle before applying the permission response",
-        [this.config.agyPath],
-        null,
-        this.#ptyOutput
-      );
+    if (this.#cancelled) return false;
+
+    // Allow in-flight panel renders to settle before capturing marker count
+    while (this.#ptyPermissionRenderTimer !== undefined && !this.#cancelled) {
+      await sleep(10);
     }
+    if (this.#cancelled) return false;
 
     const down = "\x1b[B";
     let offset = 0;

--- a/src/agy/cli.ts
+++ b/src/agy/cli.ts
@@ -1423,6 +1423,7 @@ export async function defaultPtyFactory(): Promise<PtyFactory> {
       }
     }
   }
+  // @ts-ignore optional runtime dependency
   const pty = await import("node-pty");
   return { spawn: (command, args, options) => pty.spawn(command, args, { ...options, name: "xterm-256color" }) };
 }

--- a/src/agy/db/fork.ts
+++ b/src/agy/db/fork.ts
@@ -87,8 +87,9 @@ export async function forkConversation(
       await fs.promises.cp(srcBrainDir, destBrainDir, { recursive: true });
     }
   } catch (error) {
-    console.error(
-      `[agy-acp] WARN: failed to copy brain artifacts for forked conversation ${targetConversationId}: ${(error as Error).message}`
+    discardForkedConversation(conversationsDir, targetConversationId, resolvedBrainBase);
+    throw new Error(
+      `Failed to copy brain artifacts for forked conversation ${targetConversationId}: ${(error as Error).message}`
     );
   }
 

--- a/src/agy/db/fork.ts
+++ b/src/agy/db/fork.ts
@@ -44,7 +44,8 @@ export async function forkConversation(
   }
 
   // 2. Rebind trajectory_meta.cascade_id (agy identity for this file) and
-  //    read the snapshot cursor from the copied steps table.
+  //    read the snapshot cursor from the copied steps table. A child that
+  //    still carries the source cascade_id is not an independent conversation.
   let maxStepIdx = -1;
   try {
     const destDb = new Database(destDbPath);
@@ -58,18 +59,20 @@ export async function forkConversation(
       if (names.has("trajectory_meta")) {
         destDb.prepare("UPDATE trajectory_meta SET cascade_id = ?").run(targetConversationId);
       }
-      if (names.has("steps")) {
-        const row = destDb.prepare("SELECT MAX(idx) AS maxIdx FROM steps").get() as
-          | { maxIdx: number | null }
-          | undefined;
-        if (typeof row?.maxIdx === "number") maxStepIdx = row.maxIdx;
+      if (!names.has("steps")) {
+        throw new Error(`forked conversation database is missing steps table: ${targetConversationId}`);
       }
+      const row = destDb.prepare("SELECT MAX(idx) AS maxIdx FROM steps").get() as
+        | { maxIdx: number | null }
+        | undefined;
+      if (typeof row?.maxIdx === "number") maxStepIdx = row.maxIdx;
     } finally {
       destDb.close();
     }
   } catch (error) {
-    console.error(
-      `[agy-acp] WARN: failed to update trajectory_meta in forked db ${targetConversationId}: ${(error as Error).message}`
+    removeConversationFiles(destDbPath);
+    throw new Error(
+      `Failed to rebind forked conversation database ${targetConversationId}: ${(error as Error).message}`
     );
   }
 
@@ -90,4 +93,14 @@ export async function forkConversation(
   }
 
   return { maxStepIdx };
+}
+
+function removeConversationFiles(dbPath: string): void {
+  for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+    try {
+      fs.unlinkSync(`${dbPath}${suffix}`);
+    } catch {
+      // Sidecars are absent unless the copy used WAL/journal mode.
+    }
+  }
 }

--- a/src/agy/db/fork.ts
+++ b/src/agy/db/fork.ts
@@ -20,7 +20,7 @@ export async function forkConversation(
   const destDbPath = conversationDbPath(conversationsDir, targetConversationId);
 
   if (!fs.existsSync(srcDbPath)) {
-    return;
+    throw new Error(`Source conversation database not found: ${sourceConversationId}`);
   }
 
   await fs.promises.mkdir(conversationsDir, { recursive: true });

--- a/src/agy/db/fork.ts
+++ b/src/agy/db/fork.ts
@@ -95,6 +95,24 @@ export async function forkConversation(
   return { maxStepIdx };
 }
 
+/** Remove a forked conversation DB (and brain dir) that never became a live session. */
+export function discardForkedConversation(
+  conversationsDir: string,
+  conversationId: string,
+  brainBaseDir?: string
+): void {
+  removeConversationFiles(conversationDbPath(conversationsDir, conversationId));
+  const destBrainDir = path.join(
+    brainBaseDir ?? path.join(path.dirname(conversationsDir), "brain"),
+    conversationId
+  );
+  try {
+    fs.rmSync(destBrainDir, { recursive: true, force: true });
+  } catch {
+    // Destination brain may not have been copied.
+  }
+}
+
 function removeConversationFiles(dbPath: string): void {
   for (const suffix of ["", "-wal", "-shm", "-journal"]) {
     try {

--- a/src/agy/db/fork.ts
+++ b/src/agy/db/fork.ts
@@ -1,0 +1,74 @@
+// Fork an agy conversation database and associated brain artifacts.
+// Used by ACP session/fork to create an independent branch of an existing session.
+
+import Database from "better-sqlite3";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { conversationDbPath } from "./database.js";
+
+/**
+ * Fork an existing agy conversation database and brain artifacts directory into a new conversation ID.
+ * Uses SQLite's online backup API for an atomic, consistent snapshot without torn reads.
+ */
+export async function forkConversation(
+  conversationsDir: string,
+  sourceConversationId: string,
+  targetConversationId: string,
+  brainBaseDir?: string
+): Promise<void> {
+  const srcDbPath = conversationDbPath(conversationsDir, sourceConversationId);
+  const destDbPath = conversationDbPath(conversationsDir, targetConversationId);
+
+  if (!fs.existsSync(srcDbPath)) {
+    return;
+  }
+
+  await fs.promises.mkdir(conversationsDir, { recursive: true });
+
+  // 1. Safe atomic snapshot of SQLite DB
+  const srcDb = new Database(srcDbPath, { readonly: true, fileMustExist: true });
+  try {
+    await srcDb.backup(destDbPath);
+  } finally {
+    srcDb.close();
+  }
+
+  // 2. Update trajectory_meta in destination DB
+  try {
+    const destDb = new Database(destDbPath);
+    try {
+      const hasMeta = destDb
+        .prepare(
+          "SELECT COUNT(*) > 0 AS present FROM sqlite_master WHERE type='table' AND name='trajectory_meta'"
+        )
+        .get() as { present: number } | undefined;
+      if (hasMeta?.present) {
+        destDb
+          .prepare("UPDATE trajectory_meta SET cascade_id = ?")
+          .run(targetConversationId);
+      }
+    } finally {
+      destDb.close();
+    }
+  } catch (error) {
+    console.error(
+      `[agy-acp] WARN: failed to update trajectory_meta in forked db ${targetConversationId}: ${(error as Error).message}`
+    );
+  }
+
+  // 3. Copy brain artifacts directory if present
+  const resolvedBrainBase =
+    brainBaseDir ?? path.join(path.dirname(conversationsDir), "brain");
+  const srcBrainDir = path.join(resolvedBrainBase, sourceConversationId);
+  const destBrainDir = path.join(resolvedBrainBase, targetConversationId);
+
+  try {
+    if (fs.existsSync(srcBrainDir)) {
+      await fs.promises.cp(srcBrainDir, destBrainDir, { recursive: true });
+    }
+  } catch (error) {
+    console.error(
+      `[agy-acp] WARN: failed to copy brain artifacts for forked conversation ${targetConversationId}: ${(error as Error).message}`
+    );
+  }
+}

--- a/src/agy/db/fork.ts
+++ b/src/agy/db/fork.ts
@@ -6,16 +6,26 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { conversationDbPath } from "./database.js";
 
+export interface ForkedConversation {
+  /** Highest `steps.idx` present in the copied database, or -1 if none. */
+  maxStepIdx: number;
+}
+
 /**
  * Fork an existing agy conversation database and brain artifacts directory into a new conversation ID.
  * Uses SQLite's online backup API for an atomic, consistent snapshot without torn reads.
+ *
+ * `agy` has no fork flag — it resumes a conversation by `--conversation <id>`
+ * against `~/.gemini/antigravity-cli/conversations/<id>.db`. The child must
+ * therefore be a new conversation id whose DB is a consistent snapshot, and
+ * whose ACP cursor is not behind that snapshot.
  */
 export async function forkConversation(
   conversationsDir: string,
   sourceConversationId: string,
   targetConversationId: string,
   brainBaseDir?: string
-): Promise<void> {
+): Promise<ForkedConversation> {
   const srcDbPath = conversationDbPath(conversationsDir, sourceConversationId);
   const destDbPath = conversationDbPath(conversationsDir, targetConversationId);
 
@@ -33,19 +43,26 @@ export async function forkConversation(
     srcDb.close();
   }
 
-  // 2. Update trajectory_meta in destination DB
+  // 2. Rebind trajectory_meta.cascade_id (agy identity for this file) and
+  //    read the snapshot cursor from the copied steps table.
+  let maxStepIdx = -1;
   try {
     const destDb = new Database(destDbPath);
     try {
-      const hasMeta = destDb
+      const tables = destDb
         .prepare(
-          "SELECT COUNT(*) > 0 AS present FROM sqlite_master WHERE type='table' AND name='trajectory_meta'"
+          "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('trajectory_meta', 'steps')"
         )
-        .get() as { present: number } | undefined;
-      if (hasMeta?.present) {
-        destDb
-          .prepare("UPDATE trajectory_meta SET cascade_id = ?")
-          .run(targetConversationId);
+        .all() as Array<{ name: string }>;
+      const names = new Set(tables.map((table) => table.name));
+      if (names.has("trajectory_meta")) {
+        destDb.prepare("UPDATE trajectory_meta SET cascade_id = ?").run(targetConversationId);
+      }
+      if (names.has("steps")) {
+        const row = destDb.prepare("SELECT MAX(idx) AS maxIdx FROM steps").get() as
+          | { maxIdx: number | null }
+          | undefined;
+        if (typeof row?.maxIdx === "number") maxStepIdx = row.maxIdx;
       }
     } finally {
       destDb.close();
@@ -71,4 +88,6 @@ export async function forkConversation(
       `[agy-acp] WARN: failed to copy brain artifacts for forked conversation ${targetConversationId}: ${(error as Error).message}`
     );
   }
+
+  return { maxStepIdx };
 }

--- a/src/agy/db/step-payload.ts
+++ b/src/agy/db/step-payload.ts
@@ -153,6 +153,19 @@ export interface SubagentInfo {
   type?: string;
 }
 
+/**
+ * Step-payload field 114 — task_notification / system message wrapper.
+ * Field numbers from observed conversation DBs:
+ *   1 = message string ([Message] timestamp=... sender=... content=...)
+ *   2 = details / status
+ *   3 = notification type ("task_notification" / etc.)
+ */
+export interface TaskNotification {
+  message: string;
+  details?: string;
+  type?: string;
+}
+
 /** The blob in the `task_details` column. */
 export interface TaskDetails {
   taskId: string;
@@ -177,6 +190,7 @@ export interface StepPayload {
   urlContent: UrlContentResult | undefined;
   modelProviderError: ModelProviderError | undefined;
   subagentInfo: SubagentInfo | undefined;
+  taskNotification: TaskNotification | undefined;
 }
 
 function decodeToolCall(bytes: Uint8Array): ToolCall {
@@ -468,6 +482,18 @@ export function decodeSubagentInfo(bytes: Uint8Array): SubagentInfo {
   );
 }
 
+export function decodeTaskNotification(bytes: Uint8Array): TaskNotification {
+  return readMessage<TaskNotification>(
+    bytes,
+    { message: "", details: "", type: "" },
+    {
+      1: (m, r) => (m.message = r.string()),
+      2: (m, r) => (m.details = r.string()),
+      3: (m, r) => (m.type = r.string())
+    }
+  );
+}
+
 export function decodeStepPayload(bytes: Uint8Array): StepPayload {
   return readMessage<StepPayload>(
     bytes,
@@ -485,7 +511,8 @@ export function decodeStepPayload(bytes: Uint8Array): StepPayload {
       webSearch: undefined,
       urlContent: undefined,
       modelProviderError: undefined,
-      subagentInfo: undefined
+      subagentInfo: undefined,
+      taskNotification: undefined
     },
     {
       1: (m, r) => (m.validityCheck = readInt(r)),
@@ -501,6 +528,7 @@ export function decodeStepPayload(bytes: Uint8Array): StepPayload {
       30: (m, r) => (m.titleUpdate = readSubmessage(r, decodeTitleUpdate)),
       40: (m, r) => (m.urlContent = readSubmessage(r, decodeUrlContentResult)),
       42: (m, r) => (m.webSearch = readSubmessage(r, decodeWebSearchResult)),
+      114: (m, r) => (m.taskNotification = readSubmessage(r, decodeTaskNotification)),
       127: (m, r) => (m.subagentInfo = readSubmessage(r, decodeSubagentInfo))
     }
   );

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -417,7 +417,13 @@ export class StreamPoller {
     this._hasRows = rows.length > 0;
     const latestMeaningful = findLastMeaningfulStep(rows);
     const isEmptyAgentText = latestMeaningful !== undefined && isEmptyAgentTextStep(latestMeaningful);
-    this._busy = latestMeaningful === undefined || !isTerminalStepStatus(latestMeaningful.status) || isEmptyAgentText;
+    const lastRow = rows.at(-1);
+    const isTrailingEmptyPlaceholder = lastRow !== undefined && isEmptyAgentTextStep(lastRow);
+    this._busy =
+      latestMeaningful === undefined ||
+      !isTerminalStepStatus(latestMeaningful.status) ||
+      isEmptyAgentText ||
+      isTrailingEmptyPlaceholder;
     // A turn can end on a completed agent message, but also on a terminal tool
     // step with no trailing message — most notably a denied/failed command
     // (status 7), after which agy returns to idle without emitting more text.

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -300,7 +300,7 @@ export class StreamPoller {
     // has been produced beyond that wake, do not treat the prior assistant response as conclusive.
     const latestMeaningful = findLastMeaningfulStep(this._lastObservedRows ?? []);
     const latestWakeIdx = Math.max(this._latestSystemMessageStepIdx, this._latestTaskCompletionStepIdx);
-    if (latestWakeIdx > (latestMeaningful?.idx ?? -1)) {
+    if (latestWakeIdx >= (latestMeaningful?.idx ?? -1) && latestWakeIdx >= 0) {
       return false;
     }
     // Cancelled/failed terminal rows (notably denied commands) end the turn

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -304,7 +304,9 @@ export class StreamPoller {
       return false;
     }
     // Model provider errors end the turn conclusively.
-    if (this._latestStepType === 17 || (this._latestStepStatus === 3 && this._lastObservedRows?.some((r) => r.stepPayload?.modelProviderError))) return true;
+    if (latestMeaningful?.stepPayload?.modelProviderError && isTerminalStepStatus(this._latestStepStatus)) {
+      return true;
+    }
     // Completed agent text (stepType 15) is the normal conclusive turn ending.
     // Tool steps (status 3/6/7) are turn-complete candidates but must not bypass
     // the idle marker / quiescence wait, allowing agy to emit trailing error

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -334,7 +334,10 @@ export class StreamPoller {
       if (row.task?.taskId && !this._launchedTaskIdxs.has(row.task.taskId)) {
         this._launchedTaskIdxs.set(row.task.taskId, row.idx);
       }
-      const text = row.stepPayload.agentText?.text ?? "";
+      const notification = row.stepPayload.taskNotification;
+      const text =
+        row.stepPayload.agentText?.text ??
+        (notification ? `${notification.message} ${notification.details ?? ""}`.trim() : "");
       // Defer completion tracking until a system message is terminal so a
       // still-streaming system-message envelope cannot close the wait early.
       // Generic stepType 101 turn-end markers without a system message payload

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -292,14 +292,14 @@ export class StreamPoller {
    * same data_version as that intermediate tool and look like turn end.
    */
   get isConclusiveTurnEnd(): boolean {
-    if (!this._latestStepTerminal || this._latestStepStatus === null) {
+    if (!this._latestStepTerminal || this._latestStepStatus === null || this._latestStepType === null) {
       return false;
     }
-    // Cancelled/failed terminal rows (notably denied commands) end the turn
-    // with no trailing agent text and no further tool runs.
-    if (this._latestStepStatus === 6 || this._latestStepStatus === 7) return true;
-    // Completed agent text (stepType 15, status 3) is the normal conclusive turn ending.
-    return this._latestStepStatus === 3 && this._latestStepType === 15;
+    // Completed agent text (stepType 15) is the normal conclusive turn ending.
+    // Tool steps (status 3/6/7) are turn-complete candidates but must not bypass
+    // the idle marker / quiescence wait, allowing agy to emit trailing error
+    // commentary or recovery explanations after failed (7) or cancelled (6) tools.
+    return this._latestStepType === 15 && isTerminalStepStatus(this._latestStepStatus);
   }
 
   /**

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -298,11 +298,8 @@ export class StreamPoller {
     }
     // If a background completion wake has arrived but no follow-up assistant response
     // has been produced beyond that wake, do not treat the prior assistant response as conclusive.
+    if (this.hasNewerWake()) return false;
     const latestMeaningful = findLastMeaningfulStep(this._lastObservedRows ?? []);
-    const latestWakeIdx = Math.max(this._latestSystemMessageStepIdx, this._latestTaskCompletionStepIdx);
-    if (latestWakeIdx >= (latestMeaningful?.idx ?? -1) && latestWakeIdx >= 0) {
-      return false;
-    }
     // Model provider errors end the turn conclusively.
     if (latestMeaningful?.stepPayload?.modelProviderError && isTerminalStepStatus(this._latestStepStatus)) {
       return true;
@@ -312,6 +309,27 @@ export class StreamPoller {
     // the idle marker / quiescence wait, allowing agy to emit trailing error
     // commentary or recovery explanations after failed (7) or cancelled (6) tools.
     return this._latestStepType === 15 && isTerminalStepStatus(this._latestStepStatus);
+  }
+
+  /**
+   * Successful terminal tool with no trailing message and no pending follow-up.
+   * Failed/cancelled tools and task-completion wakes stay open for recovery text.
+   */
+  get isSuccessfulToolOnlyEnd(): boolean {
+    if (!this.turnCompleteCandidate) return false;
+    if (this.hasActiveBackgroundTasks) return false;
+    if (this._latestStepStatus !== 3 || this._latestStepType === null || this._latestStepType === 15) {
+      return false;
+    }
+    if (this.hasNewerWake()) return false;
+    const latestMeaningful = findLastMeaningfulStep(this._lastObservedRows ?? []);
+    return !latestMeaningful?.stepPayload?.modelProviderError;
+  }
+
+  private hasNewerWake(): boolean {
+    const latestMeaningful = findLastMeaningfulStep(this._lastObservedRows ?? []);
+    const latestWakeIdx = Math.max(this._latestSystemMessageStepIdx, this._latestTaskCompletionStepIdx);
+    return latestWakeIdx >= (latestMeaningful?.idx ?? -1) && latestWakeIdx >= 0;
   }
 
   /** Increments whenever the observed rows (including growing in-place rows) change. */

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -302,25 +302,6 @@ export class StreamPoller {
     return this._latestStepStatus === 3 && this._latestStepType === 15;
   }
 
-  /**
-   * Snapshot the conversation revision currently visible to SQLite.
-   *
-   * Idle-marker handling uses this before the normal polling loop runs, so a
-   * marker emitted after a DB commit but before the next poll can still prove
-   * ordering without consuming or dropping that poll's session updates.
-   */
-  captureDatabaseRevision(): string | null {
-    const db = this.ensureDb();
-    if (db === null || this.boundId === null) return null;
-    return databaseRevisionToken(this.boundId, db.dataVersion());
-  }
-
-  /** Last conversation revision successfully processed by poll(). */
-  get observedDatabaseRevision(): string | null {
-    if (this.boundId === null || this.dataVersion === null) return null;
-    return databaseRevisionToken(this.boundId, this.dataVersion);
-  }
-
   /** Increments whenever the observed rows (including growing in-place rows) change. */
   get revision(): number { return this._revision; }
 
@@ -487,10 +468,6 @@ export class StreamPoller {
     this.db?.close();
     this.db = null;
   }
-}
-
-function databaseRevisionToken(conversationId: string, dataVersion: number): string {
-  return `${conversationId}\0${dataVersion}`;
 }
 
 /** status 3/6/7 — completed, cancelled/aborted, or failed. */

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -141,6 +141,7 @@ export class StreamPoller {
   private readonly observedUserStepIdxs = new Set<number>();
   private _lastUserStepIdx = -1;
   private _latestSystemMessageStepIdx = -1;
+  private _latestTaskCompletionStepIdx = -1;
   private _hasBackgroundWaiting = false;
   /** Launched background task id -> idx of the first row that carried it. */
   private readonly _launchedTaskIdxs = new Map<string, number>();
@@ -298,7 +299,8 @@ export class StreamPoller {
     // If a background completion wake has arrived but no follow-up assistant response
     // has been produced beyond that wake, do not treat the prior assistant response as conclusive.
     const latestMeaningful = findLastMeaningfulStep(this._lastObservedRows ?? []);
-    if (this._latestSystemMessageStepIdx > (latestMeaningful?.idx ?? -1)) {
+    const latestWakeIdx = Math.max(this._latestSystemMessageStepIdx, this._latestTaskCompletionStepIdx);
+    if (latestWakeIdx > (latestMeaningful?.idx ?? -1)) {
       return false;
     }
     // Cancelled/failed terminal rows (notably denied commands) end the turn
@@ -346,6 +348,9 @@ export class StreamPoller {
       ) {
         if (isSystemMessage(text)) {
           this._latestSystemMessageStepIdx = Math.max(this._latestSystemMessageStepIdx, row.idx);
+        }
+        if (isTaskTerminalRow) {
+          this._latestTaskCompletionStepIdx = Math.max(this._latestTaskCompletionStepIdx, row.idx);
         }
         // Rows are re-read on every poll, so an id-less lifecycle row observed
         // before a later launch would otherwise close that newer task on the

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -298,6 +298,8 @@ export class StreamPoller {
     // Cancelled/failed terminal rows (notably denied commands) end the turn
     // with no trailing agent text and no further tool runs.
     if (this._latestStepStatus === 6 || this._latestStepStatus === 7) return true;
+    // Model provider errors end the turn conclusively.
+    if (this._latestStepType === 17 || (this._latestStepStatus === 3 && this._lastObservedRows?.some((r) => r.stepPayload?.modelProviderError))) return true;
     // Completed agent text (stepType 15, status 3) is the normal conclusive turn ending.
     return this._latestStepStatus === 3 && this._latestStepType === 15;
   }

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -295,11 +295,11 @@ export class StreamPoller {
     if (!this._latestStepTerminal || this._latestStepStatus === null || this._latestStepType === null) {
       return false;
     }
-    // Completed agent text (stepType 15) is the normal conclusive turn ending.
+    // Completed agent text (stepType 15) or model error wrapper (stepType 17) is the conclusive turn ending.
     // Tool steps (status 3/6/7) are turn-complete candidates but must not bypass
     // the idle marker / quiescence wait, allowing agy to emit trailing error
     // commentary or recovery explanations after failed (7) or cancelled (6) tools.
-    return this._latestStepType === 15 && isTerminalStepStatus(this._latestStepStatus);
+    return (this._latestStepType === 15 || this._latestStepType === 17) && isTerminalStepStatus(this._latestStepStatus);
   }
 
   /**

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -520,8 +520,8 @@ function isEmptyAgentTextStep(row: StepRow): boolean {
   // empty placeholders agy inserts while initializing response generation.
   if (isSystemMessage(text)) return false;
   const thought = row.stepPayload.agentText?.thought;
-  const hasText = text.length > 0;
-  const hasThought = Boolean(thought && thought.length > 0);
+  const hasText = text.trim().length > 0;
+  const hasThought = Boolean(thought && thought.trim().length > 0);
   return !hasText && !hasThought;
 }
 

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -411,15 +411,14 @@ export class StreamPoller {
     ]));
     if (snapshot !== this.rowSnapshot) { this.rowSnapshot = snapshot; this._revision++; }
     this._hasRows = rows.length > 0;
-    const latest = rows.at(-1);
     const latestMeaningful = findLastMeaningfulStep(rows);
-    const isEmptyAgentText = latest !== undefined && isEmptyAgentTextStep(latest);
-    this._busy = latest !== undefined && (!isTerminalStepStatus(latest.status) || isEmptyAgentText);
+    const isEmptyAgentText = latestMeaningful !== undefined && isEmptyAgentTextStep(latestMeaningful);
+    this._busy = latestMeaningful === undefined || !isTerminalStepStatus(latestMeaningful.status) || isEmptyAgentText;
     // A turn can end on a completed agent message, but also on a terminal tool
     // step with no trailing message — most notably a denied/failed command
     // (status 7), after which agy returns to idle without emitting more text.
     // Gate completion on "latest meaningful step is terminal" (3/6/7) while no
-    // subsequent step is currently busy, rather than naively checking rows.at(-1).
+    // step is currently busy, rather than naively checking rows.at(-1).
     // This excludes early lifecycle rows (90, 98, 101), system message notices,
     // and empty stepType 15 placeholders that agy inserts while preparing generation.
     this._latestStepTerminal =

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -295,6 +295,12 @@ export class StreamPoller {
     if (!this._latestStepTerminal || this._latestStepStatus === null) {
       return false;
     }
+    // If a background completion wake has arrived but no follow-up assistant response
+    // has been produced beyond that wake, do not treat the prior assistant response as conclusive.
+    const latestMeaningful = findLastMeaningfulStep(this._lastObservedRows ?? []);
+    if (this._latestSystemMessageStepIdx > (latestMeaningful?.idx ?? -1)) {
+      return false;
+    }
     // Cancelled/failed terminal rows (notably denied commands) end the turn
     // with no trailing agent text and no further tool runs.
     if (this._latestStepStatus === 6 || this._latestStepStatus === 7) return true;

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -374,10 +374,15 @@ export class StreamPoller {
             matchedTask = true;
           }
         }
+        // If the notification/message explicitly referenced an external or older task not
+        // in launchedBefore, do not let the close-all fallback retire currently running tasks.
+        const referencedTaskOrSender = extractTaskOrSenderId(text);
+        const hasUnmatchedExplicitTask = referencedTaskOrSender !== null && !matchedTask;
+
         // Lifecycle/system wake without an embedded task id (common for system message
         // wakes): close every still-pending launch so the turn cannot hang
         // forever waiting for a match that never arrives.
-        if (!matchedTask) {
+        if (!matchedTask && !hasUnmatchedExplicitTask) {
           for (const taskId of launchedBefore) {
             this._completedTaskIds.add(taskId);
           }
@@ -552,4 +557,25 @@ function textMentionsTaskId(text: string, taskId: string): boolean {
     from = index + 1;
   }
   return false;
+}
+
+/**
+ * Extracts explicit task or sender ID token from a notification or system message text.
+ * Returns null if the text is genuinely ID-less (e.g. sender=system or generic wake).
+ */
+function extractTaskOrSenderId(text: string): string | null {
+  if (!text) return null;
+  const taskIdMatch = text.match(/Task id ["'](?:[^"'/]+\/)?([^"']+)["']/i);
+  if (taskIdMatch && taskIdMatch[1]) {
+    return taskIdMatch[1];
+  }
+  const senderMatch = text.match(/sender=(?:[^\s/]+\/)?([^\s]+)/i);
+  if (senderMatch && senderMatch[1] && senderMatch[1].toLowerCase() !== "system") {
+    return senderMatch[1];
+  }
+  const taskTokenMatch = text.match(/\b(task-\d+)\b/i);
+  if (taskTokenMatch && taskTokenMatch[1]) {
+    return taskTokenMatch[1];
+  }
+  return null;
 }

--- a/src/agy/db/system-message.ts
+++ b/src/agy/db/system-message.ts
@@ -5,10 +5,10 @@
 
 /**
  * True if the text matches an internal agy system message envelope
- * (starts with `<SYSTEM_MESSAGE>\n[Message]`).
+ * (e.g. `<SYSTEM_MESSAGE>\n[Message]...` or `[Message] timestamp=... sender=...`).
  */
 export function isSystemMessage(text: string): boolean {
-  return /^\s*<SYSTEM_MESSAGE>(?:\s*\n|\s*\r\n|\s)*(?:\[Message\]|\[Notice\]|\[System\]|sender=|content=|timestamp=|priority=|task|Task|\s*$)/i.test(text);
+  return /^\s*(?:<SYSTEM_MESSAGE>(?:\s*\n|\s*\r\n|\s)*(?:\[Message\]|\[Notice\]|\[System\]|sender=|content=|timestamp=|priority=|task|Task|\s*$)|\[Message\]\s*(?:timestamp=|sender=|priority=|content=)|\[Notice\]|\[System\]|sender=)/i.test(text);
 }
 
 /**

--- a/src/agy/db/system-message.ts
+++ b/src/agy/db/system-message.ts
@@ -8,7 +8,7 @@
  * (e.g. `<SYSTEM_MESSAGE>\n[Message]...` or `[Message] timestamp=... sender=...`).
  */
 export function isSystemMessage(text: string): boolean {
-  return /^\s*(?:<SYSTEM_MESSAGE>(?:\s*\n|\s*\r\n|\s)*(?:\[Message\]|\[Notice\]|\[System\]|sender=|content=|timestamp=|priority=|task|Task|\s*$)|\[Message\]\s*(?:timestamp=|sender=|priority=|content=)|\[Notice\]|\[System\]|sender=)/i.test(text);
+  return /^\s*(?:<SYSTEM_MESSAGE>(?:\s*\n|\s*\r\n|\s)*(?:\[Message\]|\[Notice\]|\[System\]|sender=|content=|timestamp=|priority=|task|Task|\s*$)|\[Message\]\s+timestamp=\S+\s+sender=)/i.test(text);
 }
 
 /**

--- a/src/agy/db/system-message.ts
+++ b/src/agy/db/system-message.ts
@@ -17,27 +17,40 @@ export function isSystemMessage(text: string): boolean {
  * classified, avoiding emission of a partial internal marker.
  */
 export function isSystemMessagePrefix(text: string): boolean {
-  const tag = "<SYSTEM_MESSAGE>";
   const trimmed = text.trimStart();
+  if (!trimmed) return false;
+
+  // 1. Check for <SYSTEM_MESSAGE> prefix
+  const tag = "<SYSTEM_MESSAGE>";
   const tagCandidate = trimmed.slice(0, Math.min(trimmed.length, tag.length));
-  if (tagCandidate.toLowerCase() !== tag.slice(0, tagCandidate.length).toLowerCase()) return false;
-  if (trimmed.length <= tag.length) return true;
+  if (tagCandidate.toLowerCase() === tag.slice(0, tagCandidate.length).toLowerCase()) {
+    if (trimmed.length <= tag.length) return true;
 
-  const afterTag = trimmed.slice(tag.length);
-  const markerStart = afterTag.search(/\S/);
-  if (markerStart === -1) return true;
+    const afterTag = trimmed.slice(tag.length);
+    const markerStart = afterTag.search(/\S/);
+    if (markerStart === -1) return true;
 
-  const markerCandidate = afterTag.slice(markerStart);
-  const envelopePrefixes = [
-    "[message]",
-    "[notice]",
-    "[system]",
-    "sender=",
-    "content=",
-    "timestamp=",
-    "priority=",
-    "task"
-  ];
-  const lower = markerCandidate.toLowerCase();
-  return envelopePrefixes.some((p) => p.startsWith(lower) || lower.startsWith(p));
+    const markerCandidate = afterTag.slice(markerStart);
+    const envelopePrefixes = [
+      "[message]",
+      "[notice]",
+      "[system]",
+      "sender=",
+      "content=",
+      "timestamp=",
+      "priority=",
+      "task"
+    ];
+    const lower = markerCandidate.toLowerCase();
+    return envelopePrefixes.some((p) => p.startsWith(lower) || lower.startsWith(p));
+  }
+
+  // 2. Check for untagged [Message] timestamp= prefix
+  const untaggedEnvelope = "[message] timestamp=";
+  const untaggedCandidate = trimmed.slice(0, Math.min(trimmed.length, untaggedEnvelope.length));
+  if (untaggedCandidate.toLowerCase() === untaggedEnvelope.slice(0, untaggedCandidate.length).toLowerCase()) {
+    return true;
+  }
+
+  return false;
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -980,6 +980,64 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("handles ANSI styling sequences splitting permission panel markers", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "ansi-permission");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    pty.emitPermissionPanelOnStart = false;
+    const session = interactiveSession(dir, pty);
+    let calls = 0;
+    const result = session.prompt("go", async () => {}, async () => {
+      calls++;
+      // Emit ANSI styled permission marker
+      pty.emitData("\x1b[1m\x1b[32mYes, and always allow\x1b[0m in this conversation\r\n");
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "ansi-permission.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 100);
+      return "agy-allow-conversation";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    expect(calls).toBe(1);
+    expect(pty.writes).toEqual(["\x1b[B", "\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("triggers permission prompt directly from SQLite without requiring terminal panel screen scraping", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "no-panel-stream");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    // Terminal never emits permission panel markers to stdout
+    pty.emitPermissionPanelOnStart = false;
+    pty.emitArrowRedraw = false;
+    const session = interactiveSession(dir, pty);
+    let calls = 0;
+    const result = session.prompt("go", async () => {}, async () => {
+      calls++;
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "no-panel-stream.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      setTimeout(() => pty.emitData("? for shortcuts"), 50);
+      return "agy-allow-once";
+    });
+
+    expect((await result).stopReason).toBe("end_turn");
+    expect(calls).toBe(1);
+    expect(pty.writes).toEqual(["\r"]);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("bridges manage_task status-9 interaction through full PTY turn loop", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const manageInput = JSON.stringify({ Action: "send_input", TaskId: "task-7", Input: "yes\n" });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -796,6 +796,67 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("does not prematurely quiesce on intermediate tool rows without conclusive turn ending", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-intermediate-tool-"));
+    let dbHandle: any;
+    const pty = new FakePty(() => {
+      dbHandle = createConversationDb(dir, "intermediate-tool");
+      // Intermediate tool completes (status 3), but agent response text is not ready yet
+      insertStep(dbHandle, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "git status", output: "clean" }) })
+      });
+      // Model thinks for 400ms before emitting final agent text
+      setTimeout(() => {
+        insertStep(dbHandle, {
+          idx: 2,
+          stepType: 15,
+          status: 3,
+          stepPayload: encodeStepPayload({ agentText: "Repository is clean." })
+        });
+        dbHandle.close();
+        setTimeout(() => pty.emitData("? for shortcuts"), 10);
+      }, 400);
+    });
+
+    const session = interactiveSession(dir, pty, "5s");
+    const updates: any[] = [];
+    const result = await session.prompt("status", async (u) => { updates.push(u); }, async () => "agy-allow-once");
+    expect(result.stopReason).toBe("end_turn");
+    // Ensure final agent text was delivered and not cut off by premature 300ms quiescence
+    expect(updates.some((u) => u.content?.type === "text" || u.kind === "agent_message" || JSON.stringify(u).includes("Repository is clean"))).toBe(true);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("detects alternate permission markers split across PTY chunks via multi-marker prefix tails", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-chunked-marker-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "chunked-marker");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    pty.emitPermissionPanelOnStart = false;
+    const session = interactiveSession(dir, pty);
+
+    // Split "Allow once" into two chunks: "\x1b[32mAllow " then "once\x1b[0m"
+    setTimeout(() => {
+      pty.emitData("\x1b[32mAllow ");
+      setTimeout(() => {
+        pty.emitData("once\x1b[0m\nSelect option:");
+      }, 30);
+    }, 50);
+
+    const pending = session.prompt("go", async () => {}, async () => "agy-allow-once");
+    // Should successfully detect the permission panel and send Enter (\r)
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(pty.writes).toContain("\r");
+    await session.cancel();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("maintains turn execution while background tasks are active until completed (gh#68)", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -499,6 +499,31 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("completes a tool-only turn promptly after quiescence without waiting for long printTimeout", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-tool-only-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "tool-only-quiescence");
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({
+          commandResult: encodeCommandResult({ command: "echo hello", output: "hello\n" })
+        })
+      });
+      db.close();
+    });
+    // Set a very long timeout (60s). Must resolve via quiescence in < 2s rather than waiting 60s.
+    const session = interactiveSession(dir, pty, "60s");
+    const startTime = Date.now();
+    const result = await session.prompt("echo hello", async () => {}, async () => "agy-allow-once");
+    const elapsed = Date.now() - startTime;
+    expect(result.stopReason).toBe("end_turn");
+    expect(elapsed).toBeLessThan(5000);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("captures assistant recovery commentary after a failed tool execution without premature turn cutoff", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1138,6 +1138,65 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("keeps turn open when cancelled background task (status 6) is the latest meaningful step until assistant responds", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-cancelled-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "bg-cancelled");
+      // Task launches
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "agy models | cat", output: "" }) }),
+        task: encodeTaskDetails({ taskId: "task-82", logUri: "", description: "agy models | cat" })
+      });
+      insertStep(db, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "Running models query..." })
+      });
+      db.close();
+
+      setTimeout(() => {
+        pty.emitData("? for shortcuts");
+        // Task cancelled (status 6) after 200ms — this row IS the latest meaningful step
+        setTimeout(async () => {
+          const db2 = new (await import("better-sqlite3")).default(path.join(dir, "bg-cancelled.db"));
+          insertStep(db2, {
+            idx: 3,
+            stepType: 21,
+            status: 6,
+            stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "agy models | cat", output: "cancelled" }) }),
+            task: encodeTaskDetails({ taskId: "task-82", logUri: "", description: "agy models | cat" })
+          });
+          // Model responds 250ms later with summary
+          setTimeout(() => {
+            insertStep(db2, {
+              idx: 4,
+              stepType: 15,
+              status: 3,
+              stepPayload: encodeStepPayload({ agentText: "The background task was cancelled." })
+            });
+            db2.close();
+            pty.emitData("? for shortcuts");
+          }, 250);
+        }, 200);
+      }, 30);
+    });
+
+    const session = interactiveSession(dir, pty);
+    const updates: any[] = [];
+    const outcome = await session.prompt("list models", async (update) => {
+      updates.push(update);
+    }, async () => "agy-allow-once");
+
+    expect(outcome.stopReason).toBe("end_turn");
+    expect(updates.some(u => JSON.stringify(u).includes("background task was cancelled"))).toBe(true);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("writes only the verbatim user prompt back to a reused interactive PTY", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-reuse-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -28,7 +28,7 @@ import {
 } from "../src/acp/tool-calls/permissions.js";
 import { requestPermissionV1, requestPermissionV2 } from "../src/acp/session/request-permission.js";
 import { createConversationDb, insertGenMetadata, insertStep, updateStep } from "./fixtures/conversation-db.js";
-import { encodeCommandResult, encodeGenMetadata, encodePermissions, encodeStepPayload, encodeTaskDetails, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
+import { encodeCommandResult, encodeGenMetadata, encodeModelProviderError, encodePermissions, encodeStepPayload, encodeTaskDetails, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 
 /** Collects updates via the `onUpdate` callback `AgyCliSession.prompt` takes. */
 async function collectUpdates(
@@ -854,6 +854,85 @@ describe("permission bridge", () => {
     await new Promise((resolve) => setTimeout(resolve, 200));
     expect(pty.writes).toContain("\r");
     await session.cancel();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("detects permission markers when ANSI escape is split across PTY chunks", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-split-ansi-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "split-ansi");
+      insertStep(db, pendingToolRow("run_command"));
+      db.close();
+    });
+    pty.emitPermissionPanelOnStart = false;
+    const session = interactiveSession(dir, pty);
+
+    // Split ANSI sequence "\x1b[" across chunk boundaries: "Select option:\nAllow \x1b[" then "32monce\x1b[0m"
+    setTimeout(() => {
+      pty.emitData("Select option:\nAllow \x1b[");
+      setTimeout(() => {
+        pty.emitData("32monce\x1b[0m");
+      }, 30);
+    }, 50);
+
+    const pending = session.prompt("go", async () => {}, async () => "agy-allow-once");
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(pty.writes).toContain("\r");
+    await session.cancel();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not trigger permission panel from generic labels in non-menu command output", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-generic-output-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "generic-output");
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "echo", output: "Please Allow once in your config file" }) })
+      });
+      insertStep(db, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "Done." })
+      });
+      db.close();
+    });
+    pty.emitPermissionPanelOnStart = false;
+    const session = interactiveSession(dir, pty);
+
+    // Normal command stdout contains phrase "Allow once" without menu context
+    pty.emitData("Please Allow once in your config file\nDone.\n");
+
+    const result = await session.prompt("check", async () => {}, async () => "agy-allow-once");
+    expect(result.stopReason).toBe("end_turn");
+    // Should NOT have sent premature permission keys
+    expect(pty.writes).not.toContain("\r");
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("concludes turn promptly when terminal step is a modelProviderError (stepType 17)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-provider-error-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "provider-error");
+      insertStep(db, {
+        idx: 1,
+        stepType: 17,
+        status: 3,
+        stepPayload: encodeStepPayload({ modelProviderError: encodeModelProviderError({ summary: "Rate limit exceeded" }) })
+      });
+      db.close();
+    });
+    const session = interactiveSession(dir, pty, "5s");
+    const start = Date.now();
+    const result = await session.prompt("ask", async () => {}, async () => "agy-allow-once");
+    const elapsed = Date.now() - start;
+    expect(result.stopReason).toBe("end_turn");
+    expect(elapsed).toBeLessThan(2_000);
+    await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -499,6 +499,98 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("captures assistant recovery commentary after a failed tool execution without premature turn cutoff", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "tool-fail-recovery");
+      // Prompt starts, tool executes and fails
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 7,
+        stepPayload: encodeStepPayload({
+          commandResult: encodeCommandResult({ command: "python script.py", output: "Traceback: error occurred" })
+        })
+      });
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const updates: any[] = [];
+    const result = session.prompt(
+      "run script",
+      async (update) => {
+        updates.push(update);
+      },
+      async () => "agy-allow-once"
+    );
+
+    // After tool fails, agy generates assistant recovery explanation before emitting idle marker
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    const db = new (await import("better-sqlite3")).default(path.join(dir, "tool-fail-recovery.db"));
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "The Python script failed with an error. I will analyze the traceback."
+      })
+    });
+    db.close();
+    setTimeout(() => pty.emitData("? for shortcuts"), 100);
+
+    expect((await result).stopReason).toBe("end_turn");
+    // Ensure the recovery explanation was delivered in updates
+    const textChunks = updates
+      .filter((u) => u.sessionUpdate === "agent_message_chunk")
+      .map((u) => u.content?.text ?? "");
+    expect(textChunks.join("")).toContain("The Python script failed with an error");
+
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("captures assistant explanation after a cancelled permission check without premature turn cutoff", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "permission-cancel-recovery");
+      insertStep(db, pendingToolRow("run_command", '{"CommandLine":"rm -rf /tmp/test"}'));
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const updates: any[] = [];
+    const result = session.prompt(
+      "clean directory",
+      async (update) => {
+        updates.push(update);
+      },
+      async () => {
+        // User rejects the permission, agy writes status 7 for tool and then explains
+        const db = new (await import("better-sqlite3")).default(path.join(dir, "permission-cancel-recovery.db"));
+        updateStep(db, 1, { status: 7 });
+        insertStep(db, {
+          idx: 2,
+          stepType: 15,
+          status: 3,
+          stepPayload: encodeStepPayload({
+            agentText: "Permission was denied. I will proceed without deleting the directory."
+          })
+        });
+        db.close();
+        setTimeout(() => pty.emitData("? for shortcuts"), 100);
+        return "agy-reject-once";
+      }
+    );
+
+    expect((await result).stopReason).toBe("end_turn");
+    const textChunks = updates
+      .filter((u) => u.sessionUpdate === "agent_message_chunk")
+      .map((u) => u.content?.text ?? "");
+    expect(textChunks.join("")).toContain("Permission was denied");
+
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("preserves permission panel visibility when intervening non-marker PTY data arrives before applying permission response", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -837,23 +837,28 @@ describe("permission bridge", () => {
       const db = createConversationDb(dir, "chunked-marker");
       insertStep(db, pendingToolRow("run_command"));
       db.close();
+      // Split "Allow once" into two chunks: "\x1b[32mAllow " then "once\x1b[0m\nSelect option:"
+      setTimeout(() => {
+        pty.emitData("\x1b[32mAllow ");
+        setTimeout(() => {
+          pty.emitData("once\x1b[0m\nSelect option:");
+        }, 10);
+      }, 10);
     });
     pty.emitPermissionPanelOnStart = false;
     const session = interactiveSession(dir, pty);
 
-    // Split "Allow once" into two chunks: "\x1b[32mAllow " then "once\x1b[0m"
-    setTimeout(() => {
-      pty.emitData("\x1b[32mAllow ");
-      setTimeout(() => {
-        pty.emitData("once\x1b[0m\nSelect option:");
-      }, 30);
-    }, 50);
+    const result = session.prompt("go", async () => {}, async () => {
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "chunked-marker.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      return "agy-allow-once";
+    });
 
-    const pending = session.prompt("go", async () => {}, async () => "agy-allow-once");
-    // Should successfully detect the permission panel and send Enter (\r)
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect((await result).stopReason).toBe("end_turn");
     expect(pty.writes).toContain("\r");
-    await session.cancel();
+    await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
@@ -863,22 +868,28 @@ describe("permission bridge", () => {
       const db = createConversationDb(dir, "split-ansi");
       insertStep(db, pendingToolRow("run_command"));
       db.close();
+      // Split ANSI sequence "\x1b[" across chunk boundaries: "Select option:\nAllow \x1b[" then "32monce\x1b[0m"
+      setTimeout(() => {
+        pty.emitData("Select option:\nAllow \x1b[");
+        setTimeout(() => {
+          pty.emitData("32monce\x1b[0m");
+        }, 10);
+      }, 10);
     });
     pty.emitPermissionPanelOnStart = false;
     const session = interactiveSession(dir, pty);
 
-    // Split ANSI sequence "\x1b[" across chunk boundaries: "Select option:\nAllow \x1b[" then "32monce\x1b[0m"
-    setTimeout(() => {
-      pty.emitData("Select option:\nAllow \x1b[");
-      setTimeout(() => {
-        pty.emitData("32monce\x1b[0m");
-      }, 30);
-    }, 50);
+    const result = session.prompt("go", async () => {}, async () => {
+      const db = new (await import("better-sqlite3")).default(path.join(dir, "split-ansi.db"));
+      updateStep(db, 1, { status: 3 });
+      insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      db.close();
+      return "agy-allow-once";
+    });
 
-    const pending = session.prompt("go", async () => {}, async () => "agy-allow-once");
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect((await result).stopReason).toBe("end_turn");
     expect(pty.writes).toContain("\r");
-    await session.cancel();
+    await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -831,6 +831,67 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("does not prematurely complete turn during consecutive tool executions when PTY emits prompt redraws between tools", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-consecutive-tools-"));
+    let dbHandle: any;
+    const pty = new FakePty(() => {
+      dbHandle = createConversationDb(dir, "consecutive-tools");
+      // Tool 1 executes & completes
+      insertStep(dbHandle, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "git diff src/agy/db/streaming.ts", output: "" }) })
+      });
+      insertStep(dbHandle, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "" })
+      });
+      // PTY redraws prompt bar between tool executions
+      setTimeout(() => pty.emitData("\n? for shortcuts\n"), 50);
+
+      // Tool 2 executes & completes 350ms later (exceeding QUIESCENT_SETTLE_MS if not protected by isConclusiveTurnEnd)
+      setTimeout(() => {
+        insertStep(dbHandle, {
+          idx: 3,
+          stepType: 21,
+          status: 3,
+          stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "git diff src/agy/cli.ts", output: "" }) })
+        });
+        insertStep(dbHandle, {
+          idx: 4,
+          stepType: 15,
+          status: 3,
+          stepPayload: encodeStepPayload({ agentText: "" })
+        });
+        // PTY redraws again
+        pty.emitData("\n? for shortcuts\n");
+
+        // Final assistant response arrives after another pause
+        setTimeout(() => {
+          insertStep(dbHandle, {
+            idx: 5,
+            stepType: 15,
+            status: 3,
+            stepPayload: encodeStepPayload({ agentText: "Both diffs inspected cleanly." })
+          });
+          dbHandle.close();
+          pty.emitData("\n? for shortcuts\n");
+        }, 350);
+      }, 350);
+    });
+
+    const session = interactiveSession(dir, pty, "5s");
+    const updates: any[] = [];
+    const result = await session.prompt("inspect diffs", async (u) => { updates.push(u); }, async () => "agy-allow-once");
+    expect(result.stopReason).toBe("end_turn");
+    expect(updates.some((u) => JSON.stringify(u).includes("Both diffs inspected cleanly"))).toBe(true);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("detects alternate permission markers split across PTY chunks via multi-marker prefix tails", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-chunked-marker-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -742,7 +742,7 @@ describe("permission bridge", () => {
             idx: 2,
             stepType: 101,
             status: 3,
-            stepPayload: encodeStepPayload({ lifecycle: "turn_end" })
+            stepPayload: encodeStepPayload({})
           });
           insertGenMetadata(
             dbHandle,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -722,6 +722,80 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("completes turn cleanly when trailing stepType 101 and gen_metadata commit after idle marker", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-trailing-"));
+    let dbHandle: any;
+    const pty = new FakePty(() => {
+      dbHandle = createConversationDb(dir, "trailing-meta");
+      insertStep(dbHandle, {
+        idx: 1,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "Final assistant answer." })
+      });
+      // Idle marker arrives
+      setTimeout(() => {
+        pty.emitData("? for shortcuts");
+        // Trailing stepType 101 and gen_metadata commit after the idle marker
+        setTimeout(() => {
+          insertStep(dbHandle, {
+            idx: 2,
+            stepType: 101,
+            status: 3,
+            stepPayload: encodeStepPayload({ lifecycle: "turn_end" })
+          });
+          insertGenMetadata(
+            dbHandle,
+            1,
+            encodeGenMetadata({
+              promptTokens: 100,
+              candidatesTokens: 50,
+              thoughtTokens: 20
+            })
+          );
+          dbHandle.close();
+        }, 10);
+      }, 20);
+    });
+
+    const session = interactiveSession(dir, pty);
+    const result = await session.prompt("ask question", async () => {}, async () => "agy-allow-once");
+    expect(result.stopReason).toBe("end_turn");
+    expect(result.usage).toEqual({
+      totalTokens: 170,
+      inputTokens: 100,
+      outputTokens: 50,
+      thoughtTokens: 20
+    });
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("settles cleanly via quiescence window when terminal DB rows exist even without PTY idle marker", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-quiescence-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "quiesce-test");
+      insertStep(db, {
+        idx: 1,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "Response ready." })
+      });
+      db.close();
+      // No PTY idle marker is emitted after spawn. Turn must complete via quiescence window (~300ms)
+      // rather than hanging until printTimeout (5s).
+    });
+
+    const session = interactiveSession(dir, pty, "5s");
+    const start = Date.now();
+    const result = await session.prompt("ask", async () => {}, async () => "agy-allow-once");
+    const elapsed = Date.now() - start;
+    expect(result.stopReason).toBe("end_turn");
+    expect(elapsed).toBeLessThan(2_000);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("maintains turn execution while background tasks are active until completed (gh#68)", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -574,6 +574,52 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("captures assistant recovery commentary arriving after the 300ms quiescence window", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-delayed-recovery-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "tool-fail-delayed-recovery");
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 7,
+        stepPayload: encodeStepPayload({
+          commandResult: encodeCommandResult({ command: "python script.py", output: "Traceback: error occurred" })
+        })
+      });
+      db.close();
+    });
+    const session = interactiveSession(dir, pty);
+    const updates: any[] = [];
+    const result = session.prompt(
+      "run script",
+      async (update) => {
+        updates.push(update);
+      },
+      async () => "agy-allow-once"
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    const db = new (await import("better-sqlite3")).default(path.join(dir, "tool-fail-delayed-recovery.db"));
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "The Python script failed. I will inspect the traceback."
+      })
+    });
+    db.close();
+
+    expect((await result).stopReason).toBe("end_turn");
+    const textChunks = updates
+      .filter((u) => u.sessionUpdate === "agent_message_chunk")
+      .map((u) => u.content?.text ?? "");
+    expect(textChunks.join("")).toContain("I will inspect the traceback");
+
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("captures assistant explanation after a cancelled permission check without premature turn cutoff", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {
@@ -664,11 +710,11 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("does not mistake the fresh TUI startup marker for turn completion", async () => {
+  it("does not complete from the fresh TUI startup marker while the latest SQLite row is still in progress", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {
       const db = createConversationDb(dir, "startup-marker");
-      insertStep(db, { idx: 1, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+      insertStep(db, { idx: 1, stepType: 15, status: 2, stepPayload: encodeStepPayload({ agentText: "" }) });
       db.close();
     });
     const session = interactiveSession(dir, pty);
@@ -680,7 +726,9 @@ describe("permission bridge", () => {
     pty.emitData("redraw without another marker");
     await new Promise((resolve) => setTimeout(resolve, 225));
     expect(resolved).toBe(false);
-    pty.emitData("? for shortcuts");
+    const db = new (await import("better-sqlite3")).default(path.join(dir, "startup-marker.db"));
+    updateStep(db, 1, { status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+    db.close();
     expect((await result).stopReason).toBe("end_turn");
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
@@ -1293,6 +1341,58 @@ describe("permission bridge", () => {
 
     expect(outcome.stopReason).toBe("end_turn");
     expect(updates.some(u => JSON.stringify(u).includes("Long job finished successfully"))).toBe(true);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("keeps turn open after a task-completion wake until a late assistant summary arrives", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-late-summary-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "bg-late-summary");
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "long_job &", output: "Started task-77" }) }),
+        task: encodeTaskDetails({ taskId: "task-77", logUri: "", description: "Long job" })
+      });
+      insertStep(db, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "Running task in background..." })
+      });
+      db.close();
+
+      setTimeout(async () => {
+        const db2 = new (await import("better-sqlite3")).default(path.join(dir, "bg-late-summary.db"));
+        insertStep(db2, {
+          idx: 3,
+          stepType: 21,
+          status: 3,
+          stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "long_job", output: "Done with job" }) }),
+          task: encodeTaskDetails({ taskId: "task-77", logUri: "", description: "Long job" })
+        });
+        setTimeout(() => {
+          insertStep(db2, {
+            idx: 4,
+            stepType: 15,
+            status: 3,
+            stepPayload: encodeStepPayload({ agentText: "Late summary: long job finished" })
+          });
+          db2.close();
+        }, 400);
+      }, 30);
+    });
+
+    const session = interactiveSession(dir, pty);
+    const updates: any[] = [];
+    const outcome = await session.prompt("run job", async (update) => {
+      updates.push(update);
+    }, async () => "agy-allow-once");
+
+    expect(outcome.stopReason).toBe("end_turn");
+    expect(updates.some((u) => JSON.stringify(u).includes("Late summary: long job finished"))).toBe(true);
     await session.close();
     fs.rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1708,6 +1708,39 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  for (const [choice, expectedWrites] of [
+    ["agy-allow-conversation", ["\x1b[B", "\r"]],
+    ["agy-allow-settings", ["\x1b[B", "\x1b[B", "\r"]],
+    ["agy-reject-once", ["\x1b[B", "\x1b[B", "\x1b[B", "\r"]]
+  ] as const) {
+    it(`sends ${choice} without a visible PTY panel and confirms via SQLite`, async () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-no-panel-"));
+      const pty = new FakePty(() => {
+        const db = createConversationDb(dir, "no-panel-choice");
+        insertStep(db, pendingToolRow("run_command"));
+        db.close();
+      });
+      pty.emitPermissionPanelOnStart = false;
+      pty.emitArrowRedraw = false;
+      const session = interactiveSession(dir, pty);
+      let calls = 0;
+      const result = session.prompt("go", async () => {}, async () => {
+        calls++;
+        const db = new (await import("better-sqlite3")).default(path.join(dir, "no-panel-choice.db"));
+        updateStep(db, 1, { status: 3 });
+        insertStep(db, { idx: 2, stepType: 15, status: 3, stepPayload: encodeStepPayload({ agentText: "done" }) });
+        db.close();
+        return choice;
+      });
+
+      expect((await result).stopReason).toBe("end_turn");
+      expect(calls).toBe(1);
+      expect(pty.writes).toEqual([...expectedWrites]);
+      await session.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+  }
+
   it("bridges manage_task status-9 interaction through full PTY turn loop", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const manageInput = JSON.stringify({ Action: "send_input", TaskId: "task-7", Input: "yes\n" });
@@ -2223,17 +2256,18 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("cancels cleanly while waiting for an arrow-key panel redraw", async () => {
+  it("cancels cleanly while sending a multi-key permission choice", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {
-      const db = createConversationDb(dir, "cancel-panel-redraw");
+      const db = createConversationDb(dir, "cancel-permission-keys");
       insertStep(db, pendingToolRow("run_command"));
       db.close();
     });
+    pty.emitPermissionPanelOnStart = false;
     pty.emitArrowRedraw = false;
     const session = interactiveSession(dir, pty);
     const pending = session.prompt("go", async () => {}, async () => {
-      setTimeout(() => void session.cancel(), 50);
+      setTimeout(() => void session.cancel(), 20);
       return "agy-allow-conversation";
     });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -980,6 +980,14 @@ describe("permission bridge", () => {
               agentText: '<SYSTEM_MESSAGE>\n[Message] sender=task-1 content=Task id "task-1" finished'
             })
           });
+          insertStep(db2, {
+            idx: 4,
+            stepType: 15,
+            status: 3,
+            stepPayload: encodeStepPayload({
+              agentText: "Background task task-1 finished."
+            })
+          });
           db2.close();
         }, 250);
       }, 20);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1080,6 +1080,64 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("keeps turn open when background task completes via task_details terminal row until assistant summary arrives", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-bg-task-row-"));
+    const pty = new FakePty(() => {
+      const db = createConversationDb(dir, "bg-task-row");
+      insertStep(db, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "long_job &", output: "Started task-99" }) }),
+        task: encodeTaskDetails({ taskId: "task-99", logUri: "", description: "Long job" })
+      });
+      insertStep(db, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "Running task in background..." })
+      });
+      db.close();
+
+      setTimeout(() => {
+        pty.emitData("? for shortcuts");
+        // Task finishes after 200ms with a terminal task_details row (no system message)
+        setTimeout(async () => {
+          const db2 = new (await import("better-sqlite3")).default(path.join(dir, "bg-task-row.db"));
+          insertStep(db2, {
+            idx: 3,
+            stepType: 21,
+            status: 3,
+            stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "long_job", output: "Done with job" }) }),
+            task: encodeTaskDetails({ taskId: "task-99", logUri: "", description: "Long job" })
+          });
+          // Model takes another 250ms to generate the summary response
+          setTimeout(() => {
+            insertStep(db2, {
+              idx: 4,
+              stepType: 15,
+              status: 3,
+              stepPayload: encodeStepPayload({ agentText: "Long job finished successfully with output: Done with job" })
+            });
+            db2.close();
+            pty.emitData("? for shortcuts");
+          }, 250);
+        }, 200);
+      }, 30);
+    });
+
+    const session = interactiveSession(dir, pty);
+    const updates: any[] = [];
+    const outcome = await session.prompt("run job", async (update) => {
+      updates.push(update);
+    }, async () => "agy-allow-once");
+
+    expect(outcome.stopReason).toBe("end_turn");
+    expect(updates.some(u => JSON.stringify(u).includes("Long job finished successfully"))).toBe(true);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("writes only the verbatim user prompt back to a reused interactive PTY", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-reuse-"));
     const pty = new FakePty(() => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1475,7 +1475,7 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("cancels cleanly while waiting for the permission panel to render", async () => {
+  it("cancels cleanly while waiting for the permission response", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-"));
     const pty = new FakePty(() => {
       const db = createConversationDb(dir, "cancel-panel-wait");
@@ -1484,7 +1484,10 @@ describe("permission bridge", () => {
     });
     pty.emitPermissionPanelOnStart = false;
     const session = interactiveSession(dir, pty);
-    const pending = session.prompt("go", async () => {}, async () => "agy-allow-once");
+    const pending = session.prompt("go", async () => {}, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      return "agy-allow-once";
+    });
     setTimeout(() => void session.cancel(), 50);
 
     expect((await pending).stopReason).toBe("cancelled");

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -984,6 +984,48 @@ describe("permission bridge", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("does not prematurely complete turn on empty agentText placeholder following tool run when PTY redraws (gh#114)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-placeholder-tool-"));
+    let dbHandle: any;
+    const pty = new FakePty(() => {
+      dbHandle = createConversationDb(dir, "placeholder-tool");
+      // Tool execution finishes
+      insertStep(dbHandle, {
+        idx: 1,
+        stepType: 21,
+        status: 3,
+        stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "git log -n 6 --oneline", output: "abc1234 Initial commit" }) })
+      });
+      // Empty agent text placeholder written while model prepares generation
+      insertStep(dbHandle, {
+        idx: 2,
+        stepType: 15,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "" })
+      });
+      // PTY emits prompt redraw / idle marker during the placeholder window
+      setTimeout(() => pty.emitData("\n? for shortcuts\n"), 40);
+
+      // Model takes 350ms to finish generating actual assistant text
+      setTimeout(() => {
+        updateStep(dbHandle, 2, {
+          status: 3,
+          stepPayload: encodeStepPayload({ agentText: "Found recent commit abc1234." })
+        });
+        dbHandle.close();
+        pty.emitData("\n? for shortcuts\n");
+      }, 350);
+    });
+
+    const session = interactiveSession(dir, pty, "5s");
+    const updates: any[] = [];
+    const result = await session.prompt("git log", async (u) => { updates.push(u); }, async () => "agy-allow-once");
+    expect(result.stopReason).toBe("end_turn");
+    expect(updates.some((u) => JSON.stringify(u).includes("Found recent commit abc1234"))).toBe(true);
+    await session.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("detects alternate permission markers split across PTY chunks via multi-marker prefix tails", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-pty-chunked-marker-"));
     const pty = new FakePty(() => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4355,10 +4355,58 @@ describe("isSystemMessage & isSystemMessagePrefix", () => {
     }
   });
 
-  it("identifies complete system message envelopes", () => {
+  it("identifies complete system message envelopes while preserving ordinary label-prefixed replies", () => {
+    // Tagged envelopes
     expect(isSystemMessage("<SYSTEM_MESSAGE>\nsender=system priority=low")).toBe(true);
     expect(isSystemMessage("<SYSTEM_MESSAGE>\n[Message] timestamp=123")).toBe(true);
+    expect(isSystemMessage("<SYSTEM_MESSAGE>\nTask task-1 finished")).toBe(true);
+
+    // Untagged structured envelopes
+    expect(isSystemMessage('[Message] timestamp=2026-08-18T11:16:56Z sender=conv/task-48 priority=MESSAGE_PRIORITY_HIGH content=Task id "task-48" finished')).toBe(true);
+    expect(isSystemMessage('[Message] timestamp=2026-07-27T05:55:21Z sender=system priority=MESSAGE_PRIORITY_LOW content=[Notice] All your subagents...')).toBe(true);
+
+    // Ordinary user/assistant text must NOT match
     expect(isSystemMessage("Regular text")).toBe(false);
+    expect(isSystemMessage("[Notice] Note that this file is read-only.")).toBe(false);
+    expect(isSystemMessage("[System] Architecture diagram is shown below:")).toBe(false);
+    expect(isSystemMessage("sender=user\nreceiver=agent")).toBe(false);
+    expect(isSystemMessage("[Message] from the user about something")).toBe(false);
+  });
+
+  it("emits ordinary label-prefixed replies ([Notice], [System], sender=) as regular text in Translator", () => {
+    const db = createConversationDb(dir, "conv-label-prefixed-text");
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "[Notice] Please note that this repository requires Node >= 22."
+      })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "sender=client\nreceiver=server\nport=8080"
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-label-prefixed-text")!;
+    const rows = conn.readAfter(-1);
+    conn.close();
+
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const updates = translator.translate(rows);
+
+    const texts = updates
+      .filter((u) => (u as any).sessionUpdate === "agent_message_chunk")
+      .map((u) => (u as any).content?.text);
+
+    const combinedText = texts.join("");
+    expect(combinedText).toContain("[Notice] Please note that this repository requires Node >= 22.");
+    expect(combinedText).toContain("sender=client\nreceiver=server\nport=8080");
   });
 });
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2908,10 +2908,43 @@ describe("StreamPoller", () => {
     expect(poller.turnCompleteCandidate).toBe(true);
     expect(poller.isConclusiveTurnEnd).toBe(true);
 
+    // 3. Model provider error wrapper (stepType 17, status 7) is also conclusive
+    const db3 = createConversationDb(dir, "conv-model-error-conclusive");
+    insertStep(db3, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Trigger model error" })
+    });
+    insertStep(db3, {
+      idx: 2,
+      stepType: 17,
+      status: 7,
+      stepPayload: encodeStepPayload({
+        modelProviderError: encodeModelProviderError({
+          summary: "Rate limit exceeded",
+          userMessage: "Rate limit exceeded",
+          responseJson: JSON.stringify({ error: { code: 429, status: "RESOURCE_EXHAUSTED", details: [{ reason: "QUOTA_EXHAUSTED" }] } })
+        })
+      })
+    });
+    const poller3 = new StreamPoller({
+      dir,
+      conversationId: "conv-model-error-conclusive",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+    expect(poller3.poll()).toHaveLength(1);
+    expect(poller3.turnCompleteCandidate).toBe(true);
+    expect(poller3.isConclusiveTurnEnd).toBe(true);
+
     poller.close();
     poller2.close();
+    poller3.close();
     db.close();
     db2.close();
+    db3.close();
   });
 
   it("does not treat empty stepType 15 (text: '' and no thought, status 3) as a turn completion candidate", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -3692,6 +3692,75 @@ describe("StreamPoller", () => {
     poller.close();
     db.close();
   });
+
+  it("does not retire current active tasks when receiving a notification for an unknown or older task id", () => {
+    const db = createConversationDb(dir, "conv-bg-unknown-task-notif");
+    // Current turn launches task-100
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "long-job &", output: "Task task-100 launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-100", logUri: "", description: "long-job" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Running long-job in background..."
+      })
+    });
+
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-unknown-task-notif",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    // Delayed notification arrives from an older task (task-40) not in the current poller scope
+    insertStep(db, {
+      idx: 3,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        taskNotification: encodeTaskNotification({
+          message: '[Message] timestamp=2026-08-18T11:16:56Z sender=conv/task-40 content=Task id "task-40" finished with result: OK',
+          type: "task_notification"
+        })
+      })
+    });
+
+    poller.poll();
+    // task-100 MUST still be active and not prematurely closed by the unknown task notification
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    // Now task-100 actually completes
+    insertStep(db, {
+      idx: 4,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        taskNotification: encodeTaskNotification({
+          message: '[Message] timestamp=2026-08-18T11:17:10Z sender=conv/task-100 content=Task id "task-100" finished with result: OK',
+          type: "task_notification"
+        })
+      })
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
 });
 
 describe("ReplayCache", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4329,8 +4329,10 @@ describe("subagent_info metadata propagation", () => {
 });
 
 describe("isSystemMessage & isSystemMessagePrefix", () => {
-  it("buffers every accepted system-message prefix form", () => {
+  it("buffers every accepted system-message prefix form including untagged [Message] timestamp=", () => {
     const prefixes = [
+      "<",
+      "<system",
       "<SYSTEM_MESSAGE>",
       "<SYSTEM_MESSAGE>\n",
       "<SYSTEM_MESSAGE>\n[Mes",
@@ -4339,7 +4341,14 @@ describe("isSystemMessage & isSystemMessagePrefix", () => {
       "<SYSTEM_MESSAGE>\ncontent=hello",
       "<SYSTEM_MESSAGE>\ntimestamp=123",
       "<SYSTEM_MESSAGE>\npriority=high",
-      "<SYSTEM_MESSAGE>\ntask"
+      "<SYSTEM_MESSAGE>\ntask",
+      "[",
+      "[M",
+      "[Mess",
+      "[Message]",
+      "[Message] ",
+      "[Message] time",
+      "[Message] timestamp="
     ];
     for (const p of prefixes) {
       expect(isSystemMessagePrefix(p)).toBe(true);
@@ -4348,7 +4357,11 @@ describe("isSystemMessage & isSystemMessagePrefix", () => {
     const nonPrefixes = [
       "Hello world",
       "<SYSTEM_MESSAGE>\nHello world",
-      "<SYSTEM_MESSAGE>\nsome random text"
+      "<SYSTEM_MESSAGE>\nsome random text",
+      "[Notice] Note that this is read-only",
+      "[System] Architecture diagram",
+      "sender=user\nreceiver=agent",
+      "[Message] from the user"
     ];
     for (const p of nonPrefixes) {
       expect(isSystemMessagePrefix(p)).toBe(false);

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2939,12 +2939,62 @@ describe("StreamPoller", () => {
     expect(poller3.turnCompleteCandidate).toBe(true);
     expect(poller3.isConclusiveTurnEnd).toBe(true);
 
+    // 4. StepType 17 carrying a routed tool call (without modelProviderError) is NOT conclusive
+    const db4 = createConversationDb(dir, "conv-steptype17-tool-inconclusive");
+    insertStep(db4, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Generate an image" })
+    });
+    insertStep(db4, {
+      idx: 2,
+      stepType: 17,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        toolRun: encodeToolRun({
+          call: encodeToolCall({ callId: "c1", namePrimary: "generate_image", rawInputJson: '{"Prompt":"a test image"}' })
+        })
+      })
+    });
+    const poller4 = new StreamPoller({
+      dir,
+      conversationId: "conv-steptype17-tool-inconclusive",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+    expect(poller4.poll()).toHaveLength(1);
+    expect(poller4.turnCompleteCandidate).toBe(true);
+    expect(poller4.isConclusiveTurnEnd).toBe(false);
+
+    // 5. Earlier model error in conversation does not make subsequent intermediate tool steps conclusive
+    insertStep(db3, {
+      idx: 3,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Follow up with tool" })
+    });
+    insertStep(db3, {
+      idx: 4,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "ls", output: "file1" })
+      })
+    });
+    expect(poller3.poll()).toHaveLength(1);
+    expect(poller3.turnCompleteCandidate).toBe(true);
+    expect(poller3.isConclusiveTurnEnd).toBe(false);
+
     poller.close();
     poller2.close();
     poller3.close();
+    poller4.close();
     db.close();
     db2.close();
     db3.close();
+    db4.close();
   });
 
   it("does not treat empty stepType 15 (text: '' and no thought, status 3) as a turn completion candidate", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -23,6 +23,7 @@ import {
   encodeStepPayload,
   encodeSubagentInfo,
   encodeTaskDetails,
+  encodeTaskNotification,
   encodeToolCall,
   encodeToolRun,
   encodeUrlContentResult,
@@ -3538,6 +3539,155 @@ describe("StreamPoller", () => {
 
     poller.poll();
     expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
+
+  it("tracks background task completion when task notification is received on stepType 101 (field 114)", () => {
+    const db = createConversationDb(dir, "conv-bg-steptype101-notification");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "npm test", output: "Task task-48 launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-48", logUri: "", description: "npm test" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Running tests in the background..."
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-steptype101-notification",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+    expect(poller.turnCompleteCandidate).toBe(true);
+
+    // agy records task completion notification on stepType 101 in field 114 with null task_details
+    insertStep(db, {
+      idx: 3,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        taskNotification: encodeTaskNotification({
+          message: '[Message] timestamp=2026-08-18T11:16:56Z sender=conv-bg/task-48 priority=MESSAGE_PRIORITY_HIGH content=Task id "task-48" finished with result:\n\nOutput: 14 passed',
+          details: 'Run tests finished Task id "task-48" finished with result',
+          type: "task_notification"
+        })
+      })
+    });
+
+    const updates = poller.poll();
+    // Step 101 lifecycle notifications are filtered from client stream updates
+    expect(updates.some((u) => (u as { sessionUpdate?: string }).sessionUpdate === "agent_message_chunk")).toBe(false);
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+    // Before follow-up assistant response, turn is not yet conclusively ended
+    expect(poller.isConclusiveTurnEnd).toBe(false);
+
+    // Assistant emits summary response beyond the task completion wake
+    insertStep(db, {
+      idx: 4,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "All 14 test files passed successfully."
+      })
+    });
+
+    const finalUpdates = poller.poll();
+    expect(finalUpdates.some((u) => (u as { sessionUpdate?: string }).sessionUpdate === "agent_message_chunk")).toBe(true);
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+    expect(poller.turnCompleteCandidate).toBe(true);
+    expect(poller.isConclusiveTurnEnd).toBe(true);
+
+    poller.close();
+    db.close();
+  });
+
+  it("handles background command alongside scheduled timer without leaving turn hanging", () => {
+    const db = createConversationDb(dir, "conv-bg-command-and-timer");
+    // 1. Long running command launches task-10
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "vitest run", output: "Task task-10 launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-10", logUri: "", description: "vitest run" })
+    });
+    // 2. Schedule tool launches timer task-11
+    insertStep(db, {
+      idx: 2,
+      stepType: 132,
+      status: 3,
+      stepPayload: encodeStepPayload({}),
+      task: encodeTaskDetails({ taskId: "task-11", logUri: "", description: "Timer: 60s" })
+    });
+    // 3. Assistant interim text
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Waiting for test execution to complete..."
+      })
+    });
+
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-command-and-timer",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    // task-10 is active (task-11 stepType 132 completed at step 2)
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    // 4. When task-10 completes via stepType 101 field 114
+    insertStep(db, {
+      idx: 4,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        taskNotification: encodeTaskNotification({
+          message: '[Message] timestamp=2026-08-18T11:16:56Z sender=conv/task-10 content=Task id "task-10" finished with result: OK',
+          type: "task_notification"
+        })
+      })
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    // 5. Follow-up assistant text
+    insertStep(db, {
+      idx: 5,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Tests passed cleanly."
+      })
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+    expect(poller.turnCompleteCandidate).toBe(true);
+    expect(poller.isConclusiveTurnEnd).toBe(true);
 
     poller.close();
     db.close();

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2833,9 +2833,85 @@ describe("StreamPoller", () => {
     });
     expect(poller.poll()).toHaveLength(1);
     expect(poller.turnCompleteCandidate).toBe(true);
+    expect(poller.isConclusiveTurnEnd).toBe(true);
 
     poller.close();
     db.close();
+  });
+
+  it("does not treat failed (status 7), cancelled (status 6), or successful (status 3) tool steps as conclusive turn ends", () => {
+    const db = createConversationDb(dir, "conv-tool-inconclusive");
+    insertStep(db, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Run a test command" })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-tool-inconclusive",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    // 1. Tool step runs and fails (status 7)
+    insertStep(db, {
+      idx: 2,
+      stepType: 21,
+      status: 7,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "false", output: "exit status 1" })
+      })
+    });
+    expect(poller.poll()).toHaveLength(1);
+    // turnCompleteCandidate is true (valid terminal step), but isConclusiveTurnEnd must be false
+    // so agy-acp does not bypass the settle/marker wait and cut off subsequent assistant recovery text.
+    expect(poller.turnCompleteCandidate).toBe(true);
+    expect(poller.isConclusiveTurnEnd).toBe(false);
+
+    // 2. Cancelled tool step (status 6)
+    const db2 = createConversationDb(dir, "conv-tool-cancelled");
+    insertStep(db2, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Run another command" })
+    });
+    insertStep(db2, {
+      idx: 2,
+      stepType: 21,
+      status: 6,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "cat", output: "cancelled by user" })
+      })
+    });
+    const poller2 = new StreamPoller({
+      dir,
+      conversationId: "conv-tool-cancelled",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+    expect(poller2.poll()).toHaveLength(1);
+    expect(poller2.turnCompleteCandidate).toBe(true);
+    expect(poller2.isConclusiveTurnEnd).toBe(false);
+
+    // When assistant adds recovery text, isConclusiveTurnEnd becomes true
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({ agentText: "The command failed with exit status 1. Let me try an alternative." })
+    });
+    expect(poller.poll()).toHaveLength(1);
+    expect(poller.turnCompleteCandidate).toBe(true);
+    expect(poller.isConclusiveTurnEnd).toBe(true);
+
+    poller.close();
+    poller2.close();
+    db.close();
+    db2.close();
   });
 
   it("does not treat empty stepType 15 (text: '' and no thought, status 3) as a turn completion candidate", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2870,6 +2870,7 @@ describe("StreamPoller", () => {
     // so agy-acp does not bypass the settle/marker wait and cut off subsequent assistant recovery text.
     expect(poller.turnCompleteCandidate).toBe(true);
     expect(poller.isConclusiveTurnEnd).toBe(false);
+    expect(poller.isSuccessfulToolOnlyEnd).toBe(false);
 
     // 2. Cancelled tool step (status 6)
     const db2 = createConversationDb(dir, "conv-tool-cancelled");
@@ -2897,6 +2898,7 @@ describe("StreamPoller", () => {
     expect(poller2.poll()).toHaveLength(1);
     expect(poller2.turnCompleteCandidate).toBe(true);
     expect(poller2.isConclusiveTurnEnd).toBe(false);
+    expect(poller2.isSuccessfulToolOnlyEnd).toBe(false);
 
     // When assistant adds recovery text, isConclusiveTurnEnd becomes true
     insertStep(db, {
@@ -2968,6 +2970,7 @@ describe("StreamPoller", () => {
     expect(poller4.poll()).toHaveLength(1);
     expect(poller4.turnCompleteCandidate).toBe(true);
     expect(poller4.isConclusiveTurnEnd).toBe(false);
+    expect(poller4.isSuccessfulToolOnlyEnd).toBe(true);
 
     // 5. Earlier model error in conversation does not make subsequent intermediate tool steps conclusive
     insertStep(db3, {
@@ -2987,6 +2990,7 @@ describe("StreamPoller", () => {
     expect(poller3.poll()).toHaveLength(1);
     expect(poller3.turnCompleteCandidate).toBe(true);
     expect(poller3.isConclusiveTurnEnd).toBe(false);
+    expect(poller3.isSuccessfulToolOnlyEnd).toBe(true);
 
     poller.close();
     poller2.close();
@@ -2996,6 +3000,37 @@ describe("StreamPoller", () => {
     db2.close();
     db3.close();
     db4.close();
+  });
+
+  it("treats a successful terminal tool with no follow-up as a tool-only end", () => {
+    const db = createConversationDb(dir, "conv-tool-only-end");
+    insertStep(db, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "echo hello" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "echo hello", output: "hello\n" })
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-tool-only-end",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+    expect(poller.poll()).toHaveLength(1);
+    expect(poller.turnCompleteCandidate).toBe(true);
+    expect(poller.isConclusiveTurnEnd).toBe(false);
+    expect(poller.isSuccessfulToolOnlyEnd).toBe(true);
+    poller.close();
+    db.close();
   });
 
   it("does not treat empty stepType 15 (text: '' and no thought, status 3) as a turn completion candidate", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2985,6 +2985,52 @@ describe("StreamPoller", () => {
     db.close();
   });
 
+  it("does not treat empty stepType 15 placeholders after tool execution as conclusive turn end (gh#114)", () => {
+    const db = createConversationDb(dir, "conv-tool-empty-placeholder");
+    insertStep(db, {
+      idx: 1,
+      stepType: 14,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "Check git log" })
+    });
+    // Tool execution finishes with status 3
+    insertStep(db, {
+      idx: 2,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({ commandResult: encodeCommandResult({ command: "git log -n 6 --oneline", output: "commit abc" }) })
+    });
+    // agy writes an empty stepType 15 placeholder while model prepares the summary
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({ agentText: "" })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-tool-empty-placeholder",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    // Although the tool step is terminal, the empty placeholder prevents conclusive turn ending
+    expect(poller.isConclusiveTurnEnd).toBe(false);
+
+    // When the model writes the actual summary, it becomes a conclusive turn end
+    updateStep(db, 3, {
+      status: 3,
+      stepPayload: encodeStepPayload({ agentText: "Here are the last 6 commits on this branch." })
+    });
+    poller.poll();
+    expect(poller.isConclusiveTurnEnd).toBe(true);
+
+    poller.close();
+    db.close();
+  });
+
   it("does not treat early lifecycle steps (stepType 90, 98, 101, status 3) as turn completion candidates", () => {
     const db = createConversationDb(dir, "conv-early-lifecycle");
     insertStep(db, {

--- a/tests/fixtures/conversation-db.ts
+++ b/tests/fixtures/conversation-db.ts
@@ -8,9 +8,9 @@ export function createConversationDb(dir: string, id: string): Database.Database
   fs.mkdirSync(dir, { recursive: true });
   const db = new Database(path.join(dir, `${id}.db`));
   db.exec(
-    "CREATE TABLE steps (idx INTEGER PRIMARY KEY, step_type INTEGER, status INTEGER, " +
+    "CREATE TABLE IF NOT EXISTS steps (idx INTEGER PRIMARY KEY, step_type INTEGER, status INTEGER, " +
       "step_payload BLOB, error_details BLOB, permissions BLOB, task_details BLOB);\n" +
-    "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);"
+    "CREATE TABLE IF NOT EXISTS gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);"
   );
   return db;
 }

--- a/tests/fixtures/step-encoder.ts
+++ b/tests/fixtures/step-encoder.ts
@@ -216,6 +216,18 @@ export function encodePermissions(info: { kind?: string; value?: string; decisio
   return w.finish();
 }
 
+export function encodeTaskNotification(notif: {
+  message?: string;
+  details?: string;
+  type?: string;
+}): Uint8Array {
+  const w = new BinaryWriter();
+  if (notif.message) w.tag(1, 2).string(notif.message);
+  if (notif.details) w.tag(2, 2).string(notif.details);
+  if (notif.type) w.tag(3, 2).string(notif.type);
+  return w.finish();
+}
+
 export function encodeStepPayload(opts: {
   toolRun?: Uint8Array;
   agentText?: string | { text?: string; thought?: string } | Uint8Array;
@@ -228,6 +240,7 @@ export function encodeStepPayload(opts: {
   urlContent?: Uint8Array;
   modelProviderError?: Uint8Array;
   subagentInfo?: Uint8Array;
+  taskNotification?: Uint8Array;
 }): Uint8Array {
   const w = new BinaryWriter();
   if (opts.toolRun) submessage(w, 5, opts.toolRun);
@@ -243,6 +256,7 @@ export function encodeStepPayload(opts: {
   if (opts.titleUpdate !== undefined) submessage(w, 30, encodeTitleUpdate(opts.titleUpdate));
   if (opts.urlContent) submessage(w, 40, opts.urlContent);
   if (opts.webSearch) submessage(w, 42, opts.webSearch);
+  if (opts.taskNotification) submessage(w, 114, opts.taskNotification);
   if (opts.subagentInfo) submessage(w, 127, opts.subagentInfo);
   return w.finish();
 }

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -552,15 +552,27 @@ describe("queue and steer-by-cancel", () => {
           updates.push(ctx.params.update as Record<string, unknown>);
         }
       );
+      let turn = 0;
+      const turnSteps = [
+        [
+          { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt 1" }) },
+          { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ans 1" }) }
+        ],
+        [
+          { idx: 2, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt 2" }) },
+          { idx: 3, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ans 2" }) }
+        ]
+      ];
       const connection = client.connect(
         createAcpV2App({
           ...printModeOptions({ conversationsDir: dir, stateDir: dir }),
-          spawnProcess: spawnAgyWritingConversation(dir, "conv-v2-queue", [
-            { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt 1" }) },
-            { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ans 1" }) },
-            { idx: 2, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt 2" }) },
-            { idx: 3, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ans 2" }) }
-          ])
+          spawnProcess: ((command: string, args: string[]) => {
+            if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+            const db = createConversationDb(dir, "conv-v2-queue");
+            for (const step of turnSteps[turn++] ?? []) insertStep(db, step);
+            db.close();
+            return new FakeProcess([]);
+          }) as unknown as SpawnFactory
         })
       );
       try {
@@ -591,7 +603,7 @@ describe("queue and steer-by-cancel", () => {
         await waitFor(() => {
           const idleCount = updates.filter((u) => u.sessionUpdate === "state_update" && u.state === "idle").length;
           return idleCount >= 2;
-        });
+        }, 5000);
 
         const userMessages = updates.filter((u) => u.sessionUpdate === "user_message");
         expect(userMessages.length).toBe(2);

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -13,6 +13,8 @@ import {
   createAcpV2App
 } from "../src/agent.js";
 import { forkConversation } from "../src/agy/db/fork.js";
+import { SessionStore } from "../src/acp/session/store.js";
+import { KeyedAsyncLock } from "../src/acp/session/setup-lock.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 import * as installer from "../src/agy/installer.js";
@@ -122,7 +124,8 @@ describe("forkConversation", () => {
       fs.writeFileSync(path.join(srcBrainPath, "plan.md"), "# Initial Plan\n- [ ] Task 1");
 
       // 3. Fork conversation
-      await forkConversation(convDir, srcId, targetId, brainDir);
+      const forked = await forkConversation(convDir, srcId, targetId, brainDir);
+      expect(forked.maxStepIdx).toBe(1);
 
       // 4. Verify target conversation DB
       const targetDbPath = path.join(convDir, `${targetId}.db`);
@@ -166,6 +169,53 @@ describe("forkConversation", () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("KeyedAsyncLock", () => {
+  it("runs same-key callbacks one at a time and leaves other keys concurrent", async () => {
+    const lock = new KeyedAsyncLock();
+    const order: string[] = [];
+    let releaseA: (() => void) | undefined;
+    const aGate = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+
+    const a = lock.run("same", async () => {
+      order.push("a-start");
+      await aGate;
+      order.push("a-end");
+      return "a";
+    });
+    const b = lock.run("same", async () => {
+      order.push("b");
+      return "b";
+    });
+    const other = lock.run("other", async () => {
+      order.push("other");
+      return "other";
+    });
+
+    await vi.waitFor(() => {
+      expect(order).toContain("a-start");
+      expect(order).toContain("other");
+    });
+    expect(order).not.toContain("b");
+
+    releaseA!();
+    await expect(Promise.all([a, b, other])).resolves.toEqual(["a", "b", "other"]);
+    expect(order.indexOf("b")).toBeGreaterThan(order.indexOf("a-end"));
+    expect(order).toContain("other");
+  });
+
+  it("still runs the next waiter after a rejected holder", async () => {
+    const lock = new KeyedAsyncLock();
+    const first = lock.run("k", async () => {
+      throw new Error("holder failed");
+    });
+    const second = lock.run("k", async () => "ok");
+    await expect(first).rejects.toThrow("holder failed");
+    await expect(second).resolves.toBe("ok");
   });
 });
 
@@ -320,8 +370,12 @@ describe("ACP v1 session/fork", () => {
       expect(fs.existsSync(forkedDbPath)).toBe(true);
 
       const forkedDb = new Database(forkedDbPath, { readonly: true });
-      const forkedSteps = forkedDb.prepare("SELECT idx, step_type FROM steps ORDER BY idx").all();
+      const forkedSteps = forkedDb.prepare("SELECT idx, step_type FROM steps ORDER BY idx").all() as Array<{
+        idx: number;
+      }>;
       expect(forkedSteps).toHaveLength(2);
+      const snapshotMaxIdx = Math.max(...forkedSteps.map((step) => step.idx));
+      expect(storeAfterFork.sessions[forked.sessionId].lastStepIdx).toBe(snapshotMaxIdx);
       forkedDb.close();
     } finally {
       installSpy.mockRestore();
@@ -491,6 +545,217 @@ describe("ACP v1 session/fork", () => {
       installSpy.mockRestore();
       connection.close();
       fs.rmSync(tmpStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("forks a persisted parent that is no longer in the active-session map", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-cold-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const parentConvId = "cold-parent-conv";
+    const spawnProcess = spawnAgyWritingConversation(convDir, parentConvId, [
+      { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "cold parent" }) }
+    ]);
+
+    const agent = new AcpAgent({
+      stateDir,
+      conversationsDir: convDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+      await connection.agent.request(methods.agent.session.prompt, {
+        sessionId: parent.sessionId,
+        prompt: [{ type: "text", text: "seed history" }]
+      });
+
+      await connection.agent.request(methods.agent.session.close, {
+        sessionId: parent.sessionId
+      });
+
+      const forked = (await connection.agent.request(methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/workspace"
+      })) as V1ForkSessionResponse;
+      expect(forked.sessionId).not.toBe(parent.sessionId);
+
+      const storeAfterFork = JSON.parse(fs.readFileSync(path.join(stateDir, "sessions.json"), "utf-8"));
+      const forkedConvId = storeAfterFork.sessions[forked.sessionId].conversationId;
+      expect(forkedConvId).toBeDefined();
+      expect(forkedConvId).not.toBe(parentConvId);
+      expect(storeAfterFork.sessions[forked.sessionId].lastStepIdx).toBe(1);
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("binds the child cursor to the copied db when the stored parent cursor is stale", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-stale-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const parentConvId = "stale-parent-conv";
+    const spawnProcess = spawnAgyWritingConversation(convDir, parentConvId, [
+      { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "one" }) },
+      { idx: 2, stepType: 15, stepPayload: encodeStepPayload({ agentText: "two" }) }
+    ]);
+
+    const agent = new AcpAgent({
+      stateDir,
+      conversationsDir: convDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+      await connection.agent.request(methods.agent.session.prompt, {
+        sessionId: parent.sessionId,
+        prompt: [{ type: "text", text: "seed history" }]
+      });
+      await connection.agent.request(methods.agent.session.close, {
+        sessionId: parent.sessionId
+      });
+
+      const storePath = path.join(stateDir, "sessions.json");
+      const store = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+      store.sessions[parent.sessionId].lastStepIdx = 0;
+      fs.writeFileSync(storePath, JSON.stringify(store, null, 2));
+
+      const forked = (await connection.agent.request(methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/workspace"
+      })) as V1ForkSessionResponse;
+
+      const storeAfterFork = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+      expect(storeAfterFork.sessions[forked.sessionId].lastStepIdx).toBe(2);
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("serializes fork of a persisted parent against a concurrent resume", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-lock-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const parentConvId = "locked-parent-conv";
+    const spawnProcess = spawnAgyWritingConversation(convDir, parentConvId, [
+      { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "locked" }) }
+    ]);
+
+    const agent = new AcpAgent({
+      stateDir,
+      conversationsDir: convDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    let releaseRestore: (() => void) | undefined;
+    const restoreGate = new Promise<void>((resolve) => {
+      releaseRestore = resolve;
+    });
+    let restoreCalls = 0;
+    const originalRestore = SessionStore.prototype.restore;
+    let restoreSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+      await connection.agent.request(methods.agent.session.prompt, {
+        sessionId: parent.sessionId,
+        prompt: [{ type: "text", text: "seed history" }]
+      });
+      await connection.agent.request(methods.agent.session.close, {
+        sessionId: parent.sessionId
+      });
+
+      restoreSpy = vi.spyOn(SessionStore.prototype, "restore").mockImplementation(async function (
+        this: SessionStore,
+        sessionId: string
+      ) {
+        restoreCalls += 1;
+        if (restoreCalls === 1) await restoreGate;
+        return originalRestore.call(this, sessionId);
+      });
+
+      const forkPromise = connection.agent.request(methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/workspace"
+      });
+      await vi.waitFor(() => {
+        expect(restoreCalls).toBeGreaterThan(0);
+      });
+
+      let resumeSettled = false;
+      const resumePromise = connection.agent.request(methods.agent.session.resume, {
+        sessionId: parent.sessionId,
+        cwd: "/workspace",
+        mcpServers: []
+      }).then((result) => {
+        resumeSettled = true;
+        return result;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(resumeSettled).toBe(false);
+      expect(restoreCalls).toBe(1);
+
+      releaseRestore!();
+      const forked = (await forkPromise) as V1ForkSessionResponse;
+      await resumePromise;
+      expect(forked.sessionId).not.toBe(parent.sessionId);
+      expect(resumeSettled).toBe(true);
+    } finally {
+      restoreSpy?.mockRestore();
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -1,0 +1,425 @@
+import { EventEmitter } from "node:events";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Readable, Writable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { client as acpClient, methods, PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
+import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
+import {
+  AcpAgent,
+  createAcpApp,
+  createAcpV2App
+} from "../src/agent.js";
+import { forkConversation } from "../src/agy/db/fork.js";
+import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
+import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
+import * as installer from "../src/agy/installer.js";
+import type { ForkSessionResponse as V1ForkSessionResponse } from "@agentclientprotocol/sdk";
+import type { ForkSessionResponse as V2ForkSessionResponse } from "@agentclientprotocol/sdk/experimental/v2";
+import type { SpawnFactory } from "../src/agy/cli.js";
+
+class FakeProcess extends EventEmitter {
+  stdin = new Writable({ write: (_chunk, _encoding, callback) => callback() });
+  stdout: Readable;
+  stderr: Readable;
+  exitCode = 0;
+  pid = 1;
+
+  constructor(
+    chunks: string[],
+    options: { exitCode?: number; stderr?: string } = {}
+  ) {
+    super();
+    this.exitCode = options.exitCode ?? 0;
+    this.stdout = Readable.from(chunks);
+    this.stderr = Readable.from(options.stderr ? [options.stderr] : []);
+    queueMicrotask(() => this.emit("exit", this.exitCode, null));
+  }
+
+  kill() {
+    this.exitCode = -15;
+    this.emit("exit", -15, "SIGTERM");
+    return true;
+  }
+}
+
+const TEST_MODELS = "gemini-2.5-flash\ngemini-3.7-pro\n";
+
+function makeSpawnProcess() {
+  return (_command: string, args: string[]) => {
+    if (args[0] === "models") {
+      return new FakeProcess([TEST_MODELS]);
+    }
+    return new FakeProcess(["ok"]);
+  };
+}
+
+function spawnAgyWritingConversation(
+  dir: string,
+  conversationId: string,
+  steps: Parameters<typeof insertStep>[1][]
+): SpawnFactory {
+  return ((command: string, args: string[]) => {
+    if (args[0] === "models") {
+      return new FakeProcess([TEST_MODELS]);
+    }
+    const db = createConversationDb(dir, conversationId);
+    for (const step of steps) insertStep(db, step);
+    db.close();
+    return new FakeProcess([]);
+  }) as unknown as SpawnFactory;
+}
+
+function flushDeferredNotifications(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("forkConversation", () => {
+  it("duplicates sqlite conversation db, updates trajectory_meta, and copies brain artifacts", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const brainDir = path.join(tmpDir, "brain");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(brainDir, { recursive: true });
+
+    try {
+      const srcId = "src-conv-1234";
+      const targetId = "target-conv-5678";
+
+      // 1. Create source conversation DB with steps and trajectory_meta
+      createConversationDb(convDir, srcId);
+      const srcDbPath = path.join(convDir, `${srcId}.db`);
+      const srcDb = new Database(srcDbPath);
+      srcDb.exec(`
+        CREATE TABLE IF NOT EXISTS trajectory_meta (
+          trajectory_id text,
+          cascade_id text,
+          trajectory_type integer,
+          source integer,
+          PRIMARY KEY (trajectory_id)
+        );
+        INSERT INTO trajectory_meta VALUES ('traj-1', '${srcId}', 4, 17);
+      `);
+      insertStep(srcDb, {
+        idx: 0,
+        stepType: 1,
+        status: 3,
+        stepPayload: encodeStepPayload({ userPrompt: "initial prompt" })
+      });
+      insertStep(srcDb, {
+        idx: 1,
+        stepType: 2,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "agent response" })
+      });
+      srcDb.close();
+
+      // 2. Create source brain directory with artifacts
+      const srcBrainPath = path.join(brainDir, srcId);
+      fs.mkdirSync(srcBrainPath, { recursive: true });
+      fs.writeFileSync(path.join(srcBrainPath, "plan.md"), "# Initial Plan\n- [ ] Task 1");
+
+      // 3. Fork conversation
+      await forkConversation(convDir, srcId, targetId, brainDir);
+
+      // 4. Verify target conversation DB
+      const targetDbPath = path.join(convDir, `${targetId}.db`);
+      expect(fs.existsSync(targetDbPath)).toBe(true);
+
+      const targetDb = new Database(targetDbPath, { readonly: true });
+      const targetMeta = targetDb.prepare("SELECT * FROM trajectory_meta").all() as Array<{
+        cascade_id: string;
+        trajectory_id: string;
+      }>;
+      expect(targetMeta).toHaveLength(1);
+      expect(targetMeta[0]?.cascade_id).toBe(targetId);
+
+      const targetSteps = targetDb.prepare("SELECT idx, step_type FROM steps ORDER BY idx").all() as Array<{
+        idx: number;
+        step_type: number;
+      }>;
+      expect(targetSteps).toEqual([
+        { idx: 0, step_type: 1 },
+        { idx: 1, step_type: 2 }
+      ]);
+      targetDb.close();
+
+      // 5. Verify target brain directory
+      const targetBrainPath = path.join(brainDir, targetId);
+      expect(fs.existsSync(targetBrainPath)).toBe(true);
+      expect(fs.readFileSync(path.join(targetBrainPath, "plan.md"), "utf-8")).toBe(
+        "# Initial Plan\n- [ ] Task 1"
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("handles non-existent source conversation db gracefully", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
+    try {
+      await expect(
+        forkConversation(path.join(tmpDir, "conv"), "non-existent-src", "target-id", path.join(tmpDir, "brain"))
+      ).resolves.toBeUndefined();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("ACP v1 session/fork", () => {
+  it("advertises fork capability in v1 initialize response", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const connection = acpClient({ name: "test-client" }).connect(
+      createAcpApp({
+        argv: ["--no-interactive-permissions"],
+        spawnProcess: makeSpawnProcess() as unknown as SpawnFactory
+      })
+    );
+    try {
+      const response = await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+      expect(response.agentCapabilities?.sessionCapabilities?.fork).toEqual({});
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+    }
+  });
+
+  it("forks an idle unstarted session into a new independent session", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-state-"));
+    const agent = new AcpAgent({
+      stateDir: tmpStateDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess: makeSpawnProcess() as unknown as SpawnFactory
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      // Create parent session
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/parent/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+
+      // Change config on parent session
+      await connection.agent.request(methods.agent.session.setConfigOption, {
+        sessionId: parent.sessionId,
+        configId: "model",
+        value: "gemini-3.7-pro"
+      });
+
+      // Fork parent session
+      const forked = (await connection.agent.request(methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/forked/workspace"
+      })) as V1ForkSessionResponse;
+      await flushDeferredNotifications();
+
+      expect(forked.sessionId).toBeDefined();
+      expect(forked.sessionId).not.toBe(parent.sessionId);
+
+      // Verify inherited config options on forked session
+      const modelOption = forked.configOptions?.find((opt) => opt.id === "model");
+      expect(modelOption?.id).toBe("model");
+      expect(modelOption?.currentValue).toMatch(/gemini-3.7-pro|Gemini 3.7 Pro/i);
+
+      // Verify sessions are listed separately
+      const list = await connection.agent.request(methods.agent.session.list, {});
+      expect(list.sessions).toHaveLength(2);
+      expect(list.sessions.map((s) => s.sessionId)).toContain(parent.sessionId);
+      expect(list.sessions.map((s) => s.sessionId)).toContain(forked.sessionId);
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("forks an active conversation session and duplicates conversation history", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-active-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const parentConvId = "parent-conv-uuid";
+    const spawnProcess = spawnAgyWritingConversation(convDir, parentConvId, [
+      {
+        idx: 1,
+        stepType: 8,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "view-1",
+              namePrimary: "view_file",
+              rawInputJson: '{"AbsolutePath":"/repo/README.md"}'
+            })
+          })
+        })
+      },
+      { idx: 2, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hello from agent" }) }
+    ]);
+
+    const agent = new AcpAgent({
+      stateDir,
+      conversationsDir: convDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess
+    });
+
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      // Create parent session and execute first prompt turn to bind to parentConvId
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+
+      await connection.agent.request(methods.agent.session.prompt, {
+        sessionId: parent.sessionId,
+        prompt: [{ type: "text", text: "tell me a joke" }]
+      });
+
+      // Fork parent session
+      const forked = (await connection.agent.request(methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/forked-workspace"
+      })) as V1ForkSessionResponse;
+      await flushDeferredNotifications();
+
+      expect(forked.sessionId).toBeDefined();
+      expect(forked.sessionId).not.toBe(parent.sessionId);
+
+      // Verify forked session's conversation ID on disk is a new UUID and contains parent steps
+      const storeAfterFork = JSON.parse(fs.readFileSync(path.join(stateDir, "sessions.json"), "utf-8"));
+      const forkedConvId = storeAfterFork.sessions[forked.sessionId].conversationId;
+      expect(forkedConvId).toBeDefined();
+      expect(forkedConvId).not.toBe(parentConvId);
+
+      const forkedDbPath = path.join(convDir, `${forkedConvId}.db`);
+      expect(fs.existsSync(forkedDbPath)).toBe(true);
+
+      const forkedDb = new Database(forkedDbPath, { readonly: true });
+      const forkedSteps = forkedDb.prepare("SELECT idx, step_type FROM steps ORDER BY idx").all();
+      expect(forkedSteps).toHaveLength(2);
+      forkedDb.close();
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns an error when forking a non-existent session", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const connection = acpClient({ name: "test-client" }).connect(
+      createAcpApp({
+        argv: ["--no-interactive-permissions"],
+        spawnProcess: makeSpawnProcess() as unknown as SpawnFactory
+      })
+    );
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      await expect(
+        connection.agent.request(methods.agent.session.fork, {
+          sessionId: "unknown-session-id"
+        })
+      ).rejects.toThrow();
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+    }
+  });
+});
+
+describe("ACP v2 session/fork", () => {
+  it("advertises fork capability in v2 initialize response", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const connection = acpV2.client({ name: "test-client" }).connect(
+      createAcpV2App({
+        argv: ["--no-interactive-permissions"],
+        spawnProcess: makeSpawnProcess() as unknown as SpawnFactory
+      })
+    );
+    try {
+      const response = (await connection.agent.request(acpV2.methods.agent.initialize, {
+        protocolVersion: acpV2.PROTOCOL_VERSION,
+        info: { name: "test-client-v2", version: "0.0.0" },
+        capabilities: {}
+      })) as acpV2.InitializeResponse;
+      expect(response.capabilities?.session).toMatchObject({
+        fork: {}
+      });
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+    }
+  });
+
+  it("forks a session in v2 returning sessionId and configOptions", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v2-state-"));
+    const agent = new AcpAgent({
+      stateDir: tmpStateDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess: makeSpawnProcess() as unknown as SpawnFactory
+    });
+    const connection = acpV2.client({ name: "test-client" }).connect(createAcpV2App(agent));
+
+    try {
+      await connection.agent.request(acpV2.methods.agent.initialize, {
+        protocolVersion: acpV2.PROTOCOL_VERSION,
+        info: { name: "test-client-v2", version: "0.0.0" },
+        capabilities: {}
+      });
+
+      const parent = await connection.agent.request(acpV2.methods.agent.session.new, {
+        cwd: "/v2/workspace"
+      });
+      await flushDeferredNotifications();
+
+      const forked = (await connection.agent.request(acpV2.methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/v2/forked-workspace"
+      })) as V2ForkSessionResponse;
+      await flushDeferredNotifications();
+
+      expect(forked.sessionId).toBeDefined();
+      expect(forked.sessionId).not.toBe(parent.sessionId);
+      expect(forked.configOptions?.length).toBeGreaterThan(0);
+
+      const modelOption = forked.configOptions?.find((opt) => opt.configId === "model");
+      expect(modelOption).toMatchObject({
+        configId: "model"
+      });
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpStateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -157,12 +157,12 @@ describe("forkConversation", () => {
     }
   });
 
-  it("handles non-existent source conversation db gracefully", async () => {
+  it("rejects fork when source conversation db does not exist", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
     try {
       await expect(
         forkConversation(path.join(tmpDir, "conv"), "non-existent-src", "target-id", path.join(tmpDir, "brain"))
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow("Source conversation database not found: non-existent-src");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -327,6 +327,66 @@ describe("ACP v1 session/fork", () => {
       installSpy.mockRestore();
       connection.close();
       fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects fork when parent session turn is active", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-busy-"));
+
+    const hangingProcess = new EventEmitter() as any;
+    hangingProcess.stdin = new Writable({ write: (_c, _e, cb) => cb() });
+    hangingProcess.stdout = new Readable({ read() {} });
+    hangingProcess.stderr = new Readable({ read() {} });
+    hangingProcess.exitCode = 0;
+    hangingProcess.pid = 123;
+    hangingProcess.kill = () => true;
+
+    const spawnProcess = ((command: string, args: string[]) => {
+      if (args[0] === "models") return new FakeProcess([TEST_MODELS]);
+      return hangingProcess;
+    }) as unknown as SpawnFactory;
+
+    const agent = new AcpAgent({
+      stateDir: tmpStateDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/parent/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+
+      // Start prompt turn without awaiting completion
+      const promptPromise = connection.agent.request(methods.agent.session.prompt, {
+        sessionId: parent.sessionId,
+        prompt: [{ type: "text", text: "run slow task" }]
+      });
+
+      // Attempt to fork parent session while turn is active
+      await expect(
+        connection.agent.request(methods.agent.session.fork, {
+          sessionId: parent.sessionId,
+          cwd: "/forked/workspace"
+        })
+      ).rejects.toThrow();
+
+      // Terminate hanging turn
+      hangingProcess.emit("exit", 0, null);
+      await promptPromise.catch(() => {});
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpStateDir, { recursive: true, force: true });
     }
   });
 

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -12,9 +12,11 @@ import {
   createAcpApp,
   createAcpV2App
 } from "../src/agent.js";
-import { forkConversation } from "../src/agy/db/fork.js";
+import { discardForkedConversation, forkConversation } from "../src/agy/db/fork.js";
+import { forkSession } from "../src/acp/session/setup.js";
 import { SessionStore } from "../src/acp/session/store.js";
 import { KeyedAsyncLock } from "../src/acp/session/setup-lock.js";
+import type { AgyCliBackend } from "../src/agy/cli.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 import * as installer from "../src/agy/installer.js";
@@ -196,6 +198,85 @@ describe("forkConversation", () => {
       await expect(
         forkConversation(path.join(tmpDir, "conv"), "non-existent-src", "target-id", path.join(tmpDir, "brain"))
       ).rejects.toThrow("Source conversation database not found: non-existent-src");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("discardForkedConversation removes dest db and brain artifacts", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const brainDir = path.join(tmpDir, "brain");
+    fs.mkdirSync(path.join(brainDir, "child-id"), { recursive: true });
+    fs.writeFileSync(path.join(brainDir, "child-id", "plan.md"), "x");
+    createConversationDb(convDir, "child-id").close();
+    try {
+      discardForkedConversation(convDir, "child-id", brainDir);
+      expect(fs.existsSync(path.join(convDir, "child-id.db"))).toBe(false);
+      expect(fs.existsSync(path.join(brainDir, "child-id"))).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("forkSession artifact cleanup", () => {
+  it("discards copied conversation artifacts if child setup fails after snapshot", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-cleanup-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const brainDir = path.join(tmpDir, "brain");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(brainDir, { recursive: true });
+
+    const srcId = "src-cleanup";
+    const srcDb = createConversationDb(convDir, srcId);
+    insertStep(srcDb, {
+      idx: 0,
+      stepType: 1,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "prompt" })
+    });
+    srcDb.close();
+    fs.mkdirSync(path.join(brainDir, srcId), { recursive: true });
+    fs.writeFileSync(path.join(brainDir, srcId, "plan.md"), "# plan");
+
+    const parentId = "parent-cleanup";
+    const store = new SessionStore(stateDir);
+    await store.persist(parentId, {
+      cwd: "/workspace",
+      additionalDirectories: [],
+      conversationId: srcId,
+      lastStepIdx: 0,
+      model: "gemini-2.5-flash",
+      reasoningEffort: "",
+      v2UserMessageIdsByStep: {},
+      updatedAt: new Date().toISOString()
+    });
+
+    try {
+      await expect(
+        forkSession(parentId, "/workspace", [], {
+          env: process.env,
+          argv: ["--no-interactive-permissions"],
+          backend: { startSession: async () => {
+            throw new Error("start failed");
+          } } as unknown as AgyCliBackend,
+          getModelOptions: async () => {
+            throw new Error("catalog failed");
+          },
+          conversationsDir: convDir,
+          store,
+          sessions: new Map(),
+          maxActiveSessions: 8,
+          persistSession: async () => {},
+          setupLocks: new KeyedAsyncLock()
+        })
+      ).rejects.toThrow("catalog failed");
+
+      const leftoverDbs = fs.readdirSync(convDir).filter((name) => name.endsWith(".db"));
+      expect(leftoverDbs).toEqual([`${srcId}.db`]);
+      expect(fs.readdirSync(brainDir)).toEqual([srcId]);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -13,7 +13,7 @@ import {
   createAcpV2App
 } from "../src/agent.js";
 import { discardForkedConversation, forkConversation } from "../src/agy/db/fork.js";
-import { forkSession } from "../src/acp/session/setup.js";
+import { forkSession, persistSession } from "../src/acp/session/setup.js";
 import { SessionStore } from "../src/acp/session/store.js";
 import { KeyedAsyncLock } from "../src/acp/session/setup-lock.js";
 import type { AgyCliBackend } from "../src/agy/cli.js";
@@ -353,7 +353,75 @@ describe("forkSession artifact cleanup", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
-});
+
+  it("rolls back a fork when SessionStore.persist cannot write the state directory", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-store-unwritable-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const brainDir = path.join(tmpDir, "brain");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(brainDir, { recursive: true });
+
+    const srcId = "src-unwritable";
+    const srcDb = createConversationDb(convDir, srcId);
+    insertStep(srcDb, {
+      idx: 0,
+      stepType: 1,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "prompt" })
+    });
+    srcDb.close();
+    fs.mkdirSync(path.join(brainDir, srcId), { recursive: true });
+    fs.writeFileSync(path.join(brainDir, srcId, "plan.md"), "# plan");
+
+    const parentId = "parent-unwritable";
+    const store = new SessionStore(stateDir);
+    await store.persist(parentId, {
+      cwd: "/workspace",
+      additionalDirectories: [],
+      conversationId: srcId,
+      lastStepIdx: 0,
+      model: "gemini-2.5-flash",
+      reasoningEffort: "",
+      v2UserMessageIdsByStep: {},
+      updatedAt: new Date().toISOString()
+    });
+
+    const activeSessions = new Map();
+    fs.chmodSync(stateDir, 0o555);
+    try {
+      await expect(
+        forkSession(parentId, "/workspace", [], {
+          env: process.env,
+          argv: ["--no-interactive-permissions"],
+          backend: {
+            startSession: async () => ({
+              restoreConversation: () => {},
+              setModel: () => {},
+              setEffort: () => {},
+              setMode: () => {},
+              close: async () => {}
+            })
+          } as unknown as AgyCliBackend,
+          getModelOptions: async () => ["gemini-2.5-flash"],
+          conversationsDir: convDir,
+          store,
+          sessions: activeSessions,
+          maxActiveSessions: 8,
+          persistSession: (sessionId, session) => persistSession(store, sessionId, session),
+          setupLocks: new KeyedAsyncLock()
+        })
+      ).rejects.toThrow();
+
+      expect(activeSessions.size).toBe(0);
+      const leftoverDbs = fs.readdirSync(convDir).filter((name) => name.endsWith(".db"));
+      expect(leftoverDbs).toEqual([`${srcId}.db`]);
+      expect(fs.readdirSync(brainDir)).toEqual([srcId]);
+    } finally {
+      try { fs.chmodSync(stateDir, 0o755); } catch {}
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 
 describe("KeyedAsyncLock", () => {
   it("runs same-key callbacks one at a time and leaves other keys concurrent", async () => {

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -203,6 +203,39 @@ describe("forkConversation", () => {
     }
   });
 
+  it("rejects fork and discards dest db when brain artifact copy fails", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-brain-fail-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const brainDir = path.join(tmpDir, "brain");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(brainDir, { recursive: true });
+
+    try {
+      const srcId = "src-brain-fail";
+      const targetId = "target-brain-fail";
+      const srcDb = createConversationDb(convDir, srcId);
+      insertStep(srcDb, {
+        idx: 0,
+        stepType: 1,
+        status: 3,
+        stepPayload: encodeStepPayload({ userPrompt: "prompt" })
+      });
+      srcDb.close();
+      fs.mkdirSync(path.join(brainDir, srcId), { recursive: true });
+      fs.writeFileSync(path.join(brainDir, srcId, "plan.md"), "# plan");
+      fs.writeFileSync(path.join(brainDir, targetId), "not-a-directory");
+
+      await expect(forkConversation(convDir, srcId, targetId, brainDir)).rejects.toThrow(
+        /Failed to copy brain artifacts/
+      );
+      expect(fs.existsSync(path.join(convDir, `${targetId}.db`))).toBe(false);
+      expect(fs.existsSync(path.join(brainDir, targetId))).toBe(false);
+      expect(fs.existsSync(path.join(brainDir, srcId, "plan.md"))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("discardForkedConversation removes dest db and brain artifacts", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
     const convDir = path.join(tmpDir, "conversations");

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -390,6 +390,49 @@ describe("ACP v1 session/fork", () => {
     }
   });
 
+  it("holds turn reservation on parent session during fork and releases cleanly", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-res-"));
+
+    const agent = new AcpAgent({
+      stateDir: tmpStateDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess: makeSpawnProcess() as unknown as SpawnFactory
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/parent/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+
+      const forked = (await connection.agent.request(methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/forked/workspace"
+      })) as V1ForkSessionResponse;
+      expect(forked.sessionId).toBeDefined();
+
+      // Ensure parent session is completely idle and clean after fork
+      await expect(
+        connection.agent.request(methods.agent.session.prompt, {
+          sessionId: parent.sessionId,
+          prompt: [{ type: "text", text: "hello after fork" }]
+        })
+      ).resolves.toBeDefined();
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpStateDir, { recursive: true, force: true });
+    }
+  });
+
   it("returns an error when forking a non-existent session", async () => {
     const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
     const connection = acpClient({ name: "test-client" }).connect(

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -281,6 +281,78 @@ describe("forkSession artifact cleanup", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("rolls back registered child session and cleans up artifacts if persistSession fails", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-persist-fail-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const brainDir = path.join(tmpDir, "brain");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(brainDir, { recursive: true });
+
+    const srcId = "src-persist-fail";
+    const srcDb = createConversationDb(convDir, srcId);
+    insertStep(srcDb, {
+      idx: 0,
+      stepType: 1,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "prompt" })
+    });
+    srcDb.close();
+    fs.mkdirSync(path.join(brainDir, srcId), { recursive: true });
+    fs.writeFileSync(path.join(brainDir, srcId, "plan.md"), "# plan");
+
+    const parentId = "parent-persist-fail";
+    const store = new SessionStore(stateDir);
+    await store.persist(parentId, {
+      cwd: "/workspace",
+      additionalDirectories: [],
+      conversationId: srcId,
+      lastStepIdx: 0,
+      model: "gemini-2.5-flash",
+      reasoningEffort: "",
+      v2UserMessageIdsByStep: {},
+      updatedAt: new Date().toISOString()
+    });
+
+    const activeSessions = new Map();
+    try {
+      await expect(
+        forkSession(parentId, "/workspace", [], {
+          env: process.env,
+          argv: ["--no-interactive-permissions"],
+          backend: {
+            startSession: async () => ({
+              restoreConversation: () => {},
+              setModel: () => {},
+              setEffort: () => {},
+              setMode: () => {},
+              close: async () => {}
+            })
+          } as unknown as AgyCliBackend,
+          getModelOptions: async () => ["gemini-2.5-flash"],
+          conversationsDir: convDir,
+          store,
+          sessions: activeSessions,
+          maxActiveSessions: 8,
+          persistSession: async () => {
+            throw new Error("disk full on persist");
+          },
+          setupLocks: new KeyedAsyncLock()
+        })
+      ).rejects.toThrow("disk full on persist");
+
+      // Child session must not remain in the active sessions map
+      expect(activeSessions.size).toBe(0);
+
+      // Copied conversation db and brain directory must be removed
+      const leftoverDbs = fs.readdirSync(convDir).filter((name) => name.endsWith(".db"));
+      expect(leftoverDbs).toEqual([`${srcId}.db`]);
+      expect(fs.readdirSync(brainDir)).toEqual([srcId]);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("KeyedAsyncLock", () => {

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -13,7 +13,7 @@ import {
   createAcpV2App
 } from "../src/agent.js";
 import { discardForkedConversation, forkConversation } from "../src/agy/db/fork.js";
-import { forkSession, persistSession } from "../src/acp/session/setup.js";
+import { forkSession, persistSession, reloadSession } from "../src/acp/session/setup.js";
 import { SessionStore } from "../src/acp/session/store.js";
 import { KeyedAsyncLock } from "../src/acp/session/setup-lock.js";
 import type { AgyCliBackend } from "../src/agy/cli.js";
@@ -455,6 +455,95 @@ describe("forkSession artifact cleanup", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("evicts the claimed parent when forking at the active-session cap", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-cap-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const brainDir = path.join(tmpDir, "brain");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(brainDir, { recursive: true });
+
+    const srcId = "src-cap";
+    const srcDb = createConversationDb(convDir, srcId);
+    insertStep(srcDb, {
+      idx: 0,
+      stepType: 1,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "prompt" })
+    });
+    srcDb.close();
+
+    const parentId = "parent-cap";
+    const store = new SessionStore(stateDir);
+    await store.persist(parentId, {
+      cwd: "/workspace",
+      additionalDirectories: [],
+      conversationId: srcId,
+      lastStepIdx: 0,
+      model: "gemini-2.5-flash",
+      reasoningEffort: "",
+      v2UserMessageIdsByStep: {},
+      updatedAt: new Date().toISOString()
+    });
+
+    const closed: string[] = [];
+    const backend = {
+      startSession: async () => ({
+        conversationId: srcId,
+        lastStepIdx: 0,
+        config: { mode: "default" },
+        restoreConversation: () => {},
+        setModel: () => {},
+        setEffort: () => {},
+        setMode: () => {},
+        close: async () => {
+          closed.push("closed");
+        }
+      })
+    } as unknown as AgyCliBackend;
+
+    const activeSessions = new Map();
+    const { session: parentSession } = await reloadSession(parentId, "/workspace", [], {
+      env: process.env,
+      argv: ["--no-interactive-permissions"],
+      backend,
+      getModelOptions: async () => ["gemini-2.5-flash"],
+      conversationsDir: convDir,
+      store,
+      sessions: activeSessions,
+      maxActiveSessions: 1,
+      setupLocks: new KeyedAsyncLock()
+    });
+
+    try {
+      const forked = await forkSession(parentId, "/workspace", [], {
+        env: process.env,
+        argv: ["--no-interactive-permissions"],
+        backend,
+        getModelOptions: async () => ["gemini-2.5-flash"],
+        conversationsDir: convDir,
+        store,
+        sessions: activeSessions,
+        maxActiveSessions: 1,
+        persistSession: async () => {},
+        setupLocks: new KeyedAsyncLock()
+      });
+
+      expect(activeSessions.size).toBe(1);
+      expect(activeSessions.has(parentId)).toBe(false);
+      expect(activeSessions.get(forked.childSessionId)).toBe(forked.childSession);
+      expect(parentSession.closed).toBe(true);
+      expect(closed.length).toBeGreaterThan(0);
+    } finally {
+      for (const session of activeSessions.values()) {
+        session.closed = true;
+        await session.agy.close().catch(() => {});
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("KeyedAsyncLock", () => {
   it("runs same-key callbacks one at a time and leaves other keys concurrent", async () => {

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -160,6 +160,36 @@ describe("forkConversation", () => {
     }
   });
 
+  it("rejects fork and discards dest db when cascade_id cannot be rebound", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
+    const convDir = path.join(tmpDir, "conversations");
+    fs.mkdirSync(convDir, { recursive: true });
+
+    try {
+      const srcId = "src-bad-meta";
+      const targetId = "target-bad-meta";
+      const srcDb = createConversationDb(convDir, srcId);
+      srcDb.exec(`
+        CREATE TABLE trajectory_meta (foo text);
+        INSERT INTO trajectory_meta VALUES ('x');
+      `);
+      insertStep(srcDb, {
+        idx: 0,
+        stepType: 1,
+        status: 3,
+        stepPayload: encodeStepPayload({ userPrompt: "prompt" })
+      });
+      srcDb.close();
+
+      await expect(forkConversation(convDir, srcId, targetId)).rejects.toThrow(
+        /Failed to rebind forked conversation database/
+      );
+      expect(fs.existsSync(path.join(convDir, `${targetId}.db`))).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects fork when source conversation db does not exist", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
     try {

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -433,6 +433,67 @@ describe("ACP v1 session/fork", () => {
     }
   });
 
+  it("rejects session replacement while turn or fork claim is active", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-replace-"));
+
+    const hangingProcess = new EventEmitter() as any;
+    hangingProcess.stdin = new Writable({ write: (_c, _e, cb) => cb() });
+    hangingProcess.stdout = new Readable({ read() {} });
+    hangingProcess.stderr = new Readable({ read() {} });
+    hangingProcess.exitCode = 0;
+    hangingProcess.pid = 123;
+    hangingProcess.kill = () => true;
+
+    const spawnProcess = ((command: string, args: string[]) => {
+      if (args[0] === "models") return new FakeProcess([TEST_MODELS]);
+      return hangingProcess;
+    }) as unknown as SpawnFactory;
+
+    const agent = new AcpAgent({
+      stateDir: tmpStateDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      const session = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/parent/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+
+      // Start prompt turn to make session busy
+      const promptPromise = connection.agent.request(methods.agent.session.prompt, {
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "run slow task" }]
+      });
+
+      // Attempt to load/resume and replace the busy session
+      await expect(
+        connection.agent.request(methods.agent.session.load, {
+          sessionId: session.sessionId,
+          cwd: "/parent/workspace",
+          mcpServers: []
+        })
+      ).rejects.toThrow();
+
+      // Clean up hanging turn
+      hangingProcess.emit("exit", 0, null);
+      await promptPromise.catch(() => {});
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpStateDir, { recursive: true, force: true });
+    }
+  });
+
   it("returns an error when forking a non-existent session", async () => {
     const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
     const connection = acpClient({ name: "test-client" }).connect(

--- a/tests/session-store.test.ts
+++ b/tests/session-store.test.ts
@@ -1,0 +1,52 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { SessionStore, type StoredSession } from "../src/acp/session/store.js";
+
+function sampleSession(overrides: Partial<StoredSession> = {}): StoredSession {
+  return {
+    cwd: "/workspace",
+    additionalDirectories: [],
+    conversationId: "conv-1",
+    lastStepIdx: 0,
+    model: "gemini-2.5-flash",
+    reasoningEffort: "",
+    v2UserMessageIdsByStep: {},
+    updatedAt: new Date().toISOString(),
+    ...overrides
+  };
+}
+
+describe("SessionStore.persist", () => {
+  it("rejects when the state directory cannot be created", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-store-"));
+    const blocker = path.join(tmpDir, "not-a-dir");
+    fs.writeFileSync(blocker, "x");
+    const store = new SessionStore(blocker);
+    try {
+      await expect(store.persist("child-1", sampleSession())).rejects.toThrow();
+      expect(await store.restore("child-1")).toBeNull();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the write chain healthy after a rejected persist", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-store-chain-"));
+    const store = new SessionStore(stateDir);
+    try {
+      await store.persist("ok-1", sampleSession({ conversationId: "c1" }));
+      fs.chmodSync(stateDir, 0o555);
+      await expect(store.persist("fail-1", sampleSession({ conversationId: "c-fail" }))).rejects.toThrow();
+      fs.chmodSync(stateDir, 0o755);
+      await store.persist("ok-2", sampleSession({ conversationId: "c2" }));
+      expect(await store.restore("ok-1")).toMatchObject({ conversationId: "c1" });
+      expect(await store.restore("fail-1")).toBeNull();
+      expect(await store.restore("ok-2")).toMatchObject({ conversationId: "c2" });
+    } finally {
+      try { fs.chmodSync(stateDir, 0o755); } catch {}
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Description

Release version 0.5.2:

### Added
- Support `session/fork` across ACP v1 and v2: duplicate conversation history using atomic SQLite backup, clone brain directory artifacts, rebind trajectory metadata, and inherit active configuration options and working directory. (#58)

### Fixed
- Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and pure SQLite database polling. (#113)
- Trigger ACP permission prompts directly from SQLite `steps.status = 9` instead of requiring stdout screen-scraping, eliminating unobserved errors and timeouts during permission panel detection. (#122)
- Buffer incomplete ANSI escape sequences, strip ANSI codes before matching permission menu markers, require independent menu context for permission detection, and extend `PERMISSION_REDRAW_TIMEOUT_MS` to 2,500ms for slow TUI redraws. (#113, #122)
- Keep turns active following failed tool executions (`status 7`) or cancelled permissions (`status 6`) so assistant recovery commentary and error explanations are delivered without premature turn completion. (#115)
- Decouple turn completion from intermediate PTY prompt redraws during multi-tool execution chains, preventing premature turn endings when `agy` redraws the prompt bar between tool executions. (#117)
- Trim text and thought strings when evaluating `isEmptyAgentTextStep` so whitespace-only placeholder tokens are not treated as meaningful responses. (#117)
- Track background task completion step indices in `StreamPoller` upon receiving terminal `task_details` rows (including cancelled tasks with status 6), keeping turns open across background task executions and wake notices until the assistant follow-up summary response is produced. (#120)
- Ignore empty `stepType 15` (`agentText: ""`) placeholder steps committed after tool executions from triggering conclusive turn completion, keeping turns open until non-empty assistant text arrives. (#114)
- Require model provider error payload before concluding step type 17 turn ends so routed tool calls without text are not prematurely treated as conclusive turn endings. (#115)
- Restart the quiescence settle window after awaiting client permission callbacks and update emissions. (#113)
- Refine `_busy` calculation in `StreamPoller` to evaluate `latestMeaningful` step status rather than raw trailing rows (such as lifecycle `stepType 101` or `gen_metadata` records), ensuring trailing metadata does not prevent clean turn completion. (#113)
- Decode protobuf payload field 114 (task completion notifications) on lifecycle `stepType 101` rows and expand `isSystemMessage()` to recognize un-tagged message envelopes (`[Message]`, `[Notice]`, `[System]`, `sender=`), ensuring background task completions properly retire active tasks in `StreamPoller` without hanging turns or leaving orphan timers. (#131, #132)
- Restrict untagged system message matching to structured envelopes, buffer prefix fragments in `isSystemMessagePrefix()`, and only retire active background tasks when task notifications match known tasks. (#132)
- Serialize `session/fork` against `session/resume` and `session/load` for the same parent session ID — including persisted-but-inactive parents — and bind the child's `lastStepIdx` to the copied conversation snapshot so inherited agy step rows cannot be emitted as the child's first-turn output. (#58)
- Fail `session/fork` and delete the partial child database when rebinding `trajectory_meta.cascade_id` or reading the snapshot cursor fails, instead of returning a child that still carries the source conversation identity. (#58)
- Delete the copied child conversation database and brain directory if `session/fork` is aborted or fails after the snapshot is taken and before the child is registered. (#58)
- Reject `session/fork` while a parent turn is active, reserve parent session turn slots during snapshot creation, and serialize session replacement against active turn claims. (#58)

## Related Issues

- Fixes #58
- Fixes #113
- Fixes #114
- Fixes #115
- Fixes #117
- Fixes #120
- Fixes #122
- Fixes #131
- Fixes #132

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring / Code cleanup
- [x] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `pnpm run build` and it completed without errors
- [x] I have executed `pnpm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`README.md`, `CHANGELOG.md`, etc.) if relevant
- [x] I confirmed no generated build output, local logs, or API keys are committed
