### PR TITLE
Interactive turn remains active after background tasks finish due to unparsed stepType 101 task notices and cancelled timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 - Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and ANSI-resilient permission panel detection. (#113)
 - Refine `_busy` calculation in `StreamPoller` to evaluate `latestMeaningful` step status rather than raw trailing rows (such as lifecycle `stepType 101` or `gen_metadata` records), ensuring trailing metadata does not prevent clean turn completion. (#113)
+- Decode protobuf payload field 114 (task completion notifications) on lifecycle `stepType 101` rows and expand `isSystemMessage()` to recognize un-tagged message envelopes (`[Message]`, `[Notice]`, `[System]`, `sender=`), ensuring background task completions properly retire active tasks in `StreamPoller` without hanging turns. (#131)
 
 ## [0.5.1] - 2026-08-15
 

--- a/src/agy/db/step-payload.ts
+++ b/src/agy/db/step-payload.ts
@@ -153,6 +153,19 @@ export interface SubagentInfo {
   type?: string;
 }
 
+/**
+ * Step-payload field 114 — task_notification / system message wrapper.
+ * Field numbers from observed conversation DBs:
+ *   1 = message string ([Message] timestamp=... sender=... content=...)
+ *   2 = details / status
+ *   3 = notification type ("task_notification" / etc.)
+ */
+export interface TaskNotification {
+  message: string;
+  details?: string;
+  type?: string;
+}
+
 /** The blob in the `task_details` column. */
 export interface TaskDetails {
   taskId: string;
@@ -177,6 +190,7 @@ export interface StepPayload {
   urlContent: UrlContentResult | undefined;
   modelProviderError: ModelProviderError | undefined;
   subagentInfo: SubagentInfo | undefined;
+  taskNotification: TaskNotification | undefined;
 }
 
 function decodeToolCall(bytes: Uint8Array): ToolCall {
@@ -468,6 +482,18 @@ export function decodeSubagentInfo(bytes: Uint8Array): SubagentInfo {
   );
 }
 
+export function decodeTaskNotification(bytes: Uint8Array): TaskNotification {
+  return readMessage<TaskNotification>(
+    bytes,
+    { message: "", details: "", type: "" },
+    {
+      1: (m, r) => (m.message = r.string()),
+      2: (m, r) => (m.details = r.string()),
+      3: (m, r) => (m.type = r.string())
+    }
+  );
+}
+
 export function decodeStepPayload(bytes: Uint8Array): StepPayload {
   return readMessage<StepPayload>(
     bytes,
@@ -485,7 +511,8 @@ export function decodeStepPayload(bytes: Uint8Array): StepPayload {
       webSearch: undefined,
       urlContent: undefined,
       modelProviderError: undefined,
-      subagentInfo: undefined
+      subagentInfo: undefined,
+      taskNotification: undefined
     },
     {
       1: (m, r) => (m.validityCheck = readInt(r)),
@@ -501,6 +528,7 @@ export function decodeStepPayload(bytes: Uint8Array): StepPayload {
       30: (m, r) => (m.titleUpdate = readSubmessage(r, decodeTitleUpdate)),
       40: (m, r) => (m.urlContent = readSubmessage(r, decodeUrlContentResult)),
       42: (m, r) => (m.webSearch = readSubmessage(r, decodeWebSearchResult)),
+      114: (m, r) => (m.taskNotification = readSubmessage(r, decodeTaskNotification)),
       127: (m, r) => (m.subagentInfo = readSubmessage(r, decodeSubagentInfo))
     }
   );

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -334,7 +334,10 @@ export class StreamPoller {
       if (row.task?.taskId && !this._launchedTaskIdxs.has(row.task.taskId)) {
         this._launchedTaskIdxs.set(row.task.taskId, row.idx);
       }
-      const text = row.stepPayload.agentText?.text ?? "";
+      const notification = row.stepPayload.taskNotification;
+      const text =
+        row.stepPayload.agentText?.text ??
+        (notification ? `${notification.message} ${notification.details ?? ""}`.trim() : "");
       // Defer completion tracking until a system message is terminal so a
       // still-streaming system-message envelope cannot close the wait early.
       // Generic stepType 101 turn-end markers without a system message payload

--- a/src/agy/db/streaming.ts
+++ b/src/agy/db/streaming.ts
@@ -374,10 +374,15 @@ export class StreamPoller {
             matchedTask = true;
           }
         }
+        // If the notification/message explicitly referenced an external or older task not
+        // in launchedBefore, do not let the close-all fallback retire currently running tasks.
+        const referencedTaskOrSender = extractTaskOrSenderId(text);
+        const hasUnmatchedExplicitTask = referencedTaskOrSender !== null && !matchedTask;
+
         // Lifecycle/system wake without an embedded task id (common for system message
         // wakes): close every still-pending launch so the turn cannot hang
         // forever waiting for a match that never arrives.
-        if (!matchedTask) {
+        if (!matchedTask && !hasUnmatchedExplicitTask) {
           for (const taskId of launchedBefore) {
             this._completedTaskIds.add(taskId);
           }
@@ -552,4 +557,25 @@ function textMentionsTaskId(text: string, taskId: string): boolean {
     from = index + 1;
   }
   return false;
+}
+
+/**
+ * Extracts explicit task or sender ID token from a notification or system message text.
+ * Returns null if the text is genuinely ID-less (e.g. sender=system or generic wake).
+ */
+function extractTaskOrSenderId(text: string): string | null {
+  if (!text) return null;
+  const taskIdMatch = text.match(/Task id ["'](?:[^"'/]+\/)?([^"']+)["']/i);
+  if (taskIdMatch && taskIdMatch[1]) {
+    return taskIdMatch[1];
+  }
+  const senderMatch = text.match(/sender=(?:[^\s/]+\/)?([^\s]+)/i);
+  if (senderMatch && senderMatch[1] && senderMatch[1].toLowerCase() !== "system") {
+    return senderMatch[1];
+  }
+  const taskTokenMatch = text.match(/\b(task-\d+)\b/i);
+  if (taskTokenMatch && taskTokenMatch[1]) {
+    return taskTokenMatch[1];
+  }
+  return null;
 }

--- a/src/agy/db/system-message.ts
+++ b/src/agy/db/system-message.ts
@@ -5,10 +5,10 @@
 
 /**
  * True if the text matches an internal agy system message envelope
- * (starts with `<SYSTEM_MESSAGE>\n[Message]`).
+ * (e.g. `<SYSTEM_MESSAGE>\n[Message]...` or `[Message] timestamp=... sender=...`).
  */
 export function isSystemMessage(text: string): boolean {
-  return /^\s*<SYSTEM_MESSAGE>(?:\s*\n|\s*\r\n|\s)*(?:\[Message\]|\[Notice\]|\[System\]|sender=|content=|timestamp=|priority=|task|Task|\s*$)/i.test(text);
+  return /^\s*(?:<SYSTEM_MESSAGE>(?:\s*\n|\s*\r\n|\s)*(?:\[Message\]|\[Notice\]|\[System\]|sender=|content=|timestamp=|priority=|task|Task|\s*$)|\[Message\]\s*(?:timestamp=|sender=|priority=|content=)|\[Notice\]|\[System\]|sender=)/i.test(text);
 }
 
 /**

--- a/src/agy/db/system-message.ts
+++ b/src/agy/db/system-message.ts
@@ -8,7 +8,7 @@
  * (e.g. `<SYSTEM_MESSAGE>\n[Message]...` or `[Message] timestamp=... sender=...`).
  */
 export function isSystemMessage(text: string): boolean {
-  return /^\s*(?:<SYSTEM_MESSAGE>(?:\s*\n|\s*\r\n|\s)*(?:\[Message\]|\[Notice\]|\[System\]|sender=|content=|timestamp=|priority=|task|Task|\s*$)|\[Message\]\s*(?:timestamp=|sender=|priority=|content=)|\[Notice\]|\[System\]|sender=)/i.test(text);
+  return /^\s*(?:<SYSTEM_MESSAGE>(?:\s*\n|\s*\r\n|\s)*(?:\[Message\]|\[Notice\]|\[System\]|sender=|content=|timestamp=|priority=|task|Task|\s*$)|\[Message\]\s+timestamp=\S+\s+sender=)/i.test(text);
 }
 
 /**

--- a/src/agy/db/system-message.ts
+++ b/src/agy/db/system-message.ts
@@ -17,27 +17,40 @@ export function isSystemMessage(text: string): boolean {
  * classified, avoiding emission of a partial internal marker.
  */
 export function isSystemMessagePrefix(text: string): boolean {
-  const tag = "<SYSTEM_MESSAGE>";
   const trimmed = text.trimStart();
+  if (!trimmed) return false;
+
+  // 1. Check for <SYSTEM_MESSAGE> prefix
+  const tag = "<SYSTEM_MESSAGE>";
   const tagCandidate = trimmed.slice(0, Math.min(trimmed.length, tag.length));
-  if (tagCandidate.toLowerCase() !== tag.slice(0, tagCandidate.length).toLowerCase()) return false;
-  if (trimmed.length <= tag.length) return true;
+  if (tagCandidate.toLowerCase() === tag.slice(0, tagCandidate.length).toLowerCase()) {
+    if (trimmed.length <= tag.length) return true;
 
-  const afterTag = trimmed.slice(tag.length);
-  const markerStart = afterTag.search(/\S/);
-  if (markerStart === -1) return true;
+    const afterTag = trimmed.slice(tag.length);
+    const markerStart = afterTag.search(/\S/);
+    if (markerStart === -1) return true;
 
-  const markerCandidate = afterTag.slice(markerStart);
-  const envelopePrefixes = [
-    "[message]",
-    "[notice]",
-    "[system]",
-    "sender=",
-    "content=",
-    "timestamp=",
-    "priority=",
-    "task"
-  ];
-  const lower = markerCandidate.toLowerCase();
-  return envelopePrefixes.some((p) => p.startsWith(lower) || lower.startsWith(p));
+    const markerCandidate = afterTag.slice(markerStart);
+    const envelopePrefixes = [
+      "[message]",
+      "[notice]",
+      "[system]",
+      "sender=",
+      "content=",
+      "timestamp=",
+      "priority=",
+      "task"
+    ];
+    const lower = markerCandidate.toLowerCase();
+    return envelopePrefixes.some((p) => p.startsWith(lower) || lower.startsWith(p));
+  }
+
+  // 2. Check for untagged [Message] timestamp= prefix
+  const untaggedEnvelope = "[message] timestamp=";
+  const untaggedCandidate = trimmed.slice(0, Math.min(trimmed.length, untaggedEnvelope.length));
+  if (untaggedCandidate.toLowerCase() === untaggedEnvelope.slice(0, untaggedCandidate.length).toLowerCase()) {
+    return true;
+  }
+
+  return false;
 }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4355,10 +4355,58 @@ describe("isSystemMessage & isSystemMessagePrefix", () => {
     }
   });
 
-  it("identifies complete system message envelopes", () => {
+  it("identifies complete system message envelopes while preserving ordinary label-prefixed replies", () => {
+    // Tagged envelopes
     expect(isSystemMessage("<SYSTEM_MESSAGE>\nsender=system priority=low")).toBe(true);
     expect(isSystemMessage("<SYSTEM_MESSAGE>\n[Message] timestamp=123")).toBe(true);
+    expect(isSystemMessage("<SYSTEM_MESSAGE>\nTask task-1 finished")).toBe(true);
+
+    // Untagged structured envelopes
+    expect(isSystemMessage('[Message] timestamp=2026-08-18T11:16:56Z sender=conv/task-48 priority=MESSAGE_PRIORITY_HIGH content=Task id "task-48" finished')).toBe(true);
+    expect(isSystemMessage('[Message] timestamp=2026-07-27T05:55:21Z sender=system priority=MESSAGE_PRIORITY_LOW content=[Notice] All your subagents...')).toBe(true);
+
+    // Ordinary user/assistant text must NOT match
     expect(isSystemMessage("Regular text")).toBe(false);
+    expect(isSystemMessage("[Notice] Note that this file is read-only.")).toBe(false);
+    expect(isSystemMessage("[System] Architecture diagram is shown below:")).toBe(false);
+    expect(isSystemMessage("sender=user\nreceiver=agent")).toBe(false);
+    expect(isSystemMessage("[Message] from the user about something")).toBe(false);
+  });
+
+  it("emits ordinary label-prefixed replies ([Notice], [System], sender=) as regular text in Translator", () => {
+    const db = createConversationDb(dir, "conv-label-prefixed-text");
+    insertStep(db, {
+      idx: 1,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "[Notice] Please note that this repository requires Node >= 22."
+      })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "sender=client\nreceiver=server\nport=8080"
+      })
+    });
+    db.close();
+
+    const conn = ConversationDb.open(dir, "conv-label-prefixed-text")!;
+    const rows = conn.readAfter(-1);
+    conn.close();
+
+    const translator = new Translator({ mode: "stream", skipNarration: false });
+    const updates = translator.translate(rows);
+
+    const texts = updates
+      .filter((u) => (u as any).sessionUpdate === "agent_message_chunk")
+      .map((u) => (u as any).content?.text);
+
+    const combinedText = texts.join("");
+    expect(combinedText).toContain("[Notice] Please note that this repository requires Node >= 22.");
+    expect(combinedText).toContain("sender=client\nreceiver=server\nport=8080");
   });
 });
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -3692,6 +3692,75 @@ describe("StreamPoller", () => {
     poller.close();
     db.close();
   });
+
+  it("does not retire current active tasks when receiving a notification for an unknown or older task id", () => {
+    const db = createConversationDb(dir, "conv-bg-unknown-task-notif");
+    // Current turn launches task-100
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "long-job &", output: "Task task-100 launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-100", logUri: "", description: "long-job" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Running long-job in background..."
+      })
+    });
+
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-unknown-task-notif",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    // Delayed notification arrives from an older task (task-40) not in the current poller scope
+    insertStep(db, {
+      idx: 3,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        taskNotification: encodeTaskNotification({
+          message: '[Message] timestamp=2026-08-18T11:16:56Z sender=conv/task-40 content=Task id "task-40" finished with result: OK',
+          type: "task_notification"
+        })
+      })
+    });
+
+    poller.poll();
+    // task-100 MUST still be active and not prematurely closed by the unknown task notification
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    // Now task-100 actually completes
+    insertStep(db, {
+      idx: 4,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        taskNotification: encodeTaskNotification({
+          message: '[Message] timestamp=2026-08-18T11:17:10Z sender=conv/task-100 content=Task id "task-100" finished with result: OK',
+          type: "task_notification"
+        })
+      })
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
 });
 
 describe("ReplayCache", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4329,8 +4329,10 @@ describe("subagent_info metadata propagation", () => {
 });
 
 describe("isSystemMessage & isSystemMessagePrefix", () => {
-  it("buffers every accepted system-message prefix form", () => {
+  it("buffers every accepted system-message prefix form including untagged [Message] timestamp=", () => {
     const prefixes = [
+      "<",
+      "<system",
       "<SYSTEM_MESSAGE>",
       "<SYSTEM_MESSAGE>\n",
       "<SYSTEM_MESSAGE>\n[Mes",
@@ -4339,7 +4341,14 @@ describe("isSystemMessage & isSystemMessagePrefix", () => {
       "<SYSTEM_MESSAGE>\ncontent=hello",
       "<SYSTEM_MESSAGE>\ntimestamp=123",
       "<SYSTEM_MESSAGE>\npriority=high",
-      "<SYSTEM_MESSAGE>\ntask"
+      "<SYSTEM_MESSAGE>\ntask",
+      "[",
+      "[M",
+      "[Mess",
+      "[Message]",
+      "[Message] ",
+      "[Message] time",
+      "[Message] timestamp="
     ];
     for (const p of prefixes) {
       expect(isSystemMessagePrefix(p)).toBe(true);
@@ -4348,7 +4357,11 @@ describe("isSystemMessage & isSystemMessagePrefix", () => {
     const nonPrefixes = [
       "Hello world",
       "<SYSTEM_MESSAGE>\nHello world",
-      "<SYSTEM_MESSAGE>\nsome random text"
+      "<SYSTEM_MESSAGE>\nsome random text",
+      "[Notice] Note that this is read-only",
+      "[System] Architecture diagram",
+      "sender=user\nreceiver=agent",
+      "[Message] from the user"
     ];
     for (const p of nonPrefixes) {
       expect(isSystemMessagePrefix(p)).toBe(false);

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -23,6 +23,7 @@ import {
   encodeStepPayload,
   encodeSubagentInfo,
   encodeTaskDetails,
+  encodeTaskNotification,
   encodeToolCall,
   encodeToolRun,
   encodeUrlContentResult,
@@ -3538,6 +3539,155 @@ describe("StreamPoller", () => {
 
     poller.poll();
     expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    poller.close();
+    db.close();
+  });
+
+  it("tracks background task completion when task notification is received on stepType 101 (field 114)", () => {
+    const db = createConversationDb(dir, "conv-bg-steptype101-notification");
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "npm test", output: "Task task-48 launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-48", logUri: "", description: "npm test" })
+    });
+    insertStep(db, {
+      idx: 2,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Running tests in the background..."
+      })
+    });
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-steptype101-notification",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+    expect(poller.turnCompleteCandidate).toBe(true);
+
+    // agy records task completion notification on stepType 101 in field 114 with null task_details
+    insertStep(db, {
+      idx: 3,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        taskNotification: encodeTaskNotification({
+          message: '[Message] timestamp=2026-08-18T11:16:56Z sender=conv-bg/task-48 priority=MESSAGE_PRIORITY_HIGH content=Task id "task-48" finished with result:\n\nOutput: 14 passed',
+          details: 'Run tests finished Task id "task-48" finished with result',
+          type: "task_notification"
+        })
+      })
+    });
+
+    const updates = poller.poll();
+    // Step 101 lifecycle notifications are filtered from client stream updates
+    expect(updates.some((u) => (u as { sessionUpdate?: string }).sessionUpdate === "agent_message_chunk")).toBe(false);
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+    // Before follow-up assistant response, turn is not yet conclusively ended
+    expect(poller.isConclusiveTurnEnd).toBe(false);
+
+    // Assistant emits summary response beyond the task completion wake
+    insertStep(db, {
+      idx: 4,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "All 14 test files passed successfully."
+      })
+    });
+
+    const finalUpdates = poller.poll();
+    expect(finalUpdates.some((u) => (u as { sessionUpdate?: string }).sessionUpdate === "agent_message_chunk")).toBe(true);
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+    expect(poller.turnCompleteCandidate).toBe(true);
+    expect(poller.isConclusiveTurnEnd).toBe(true);
+
+    poller.close();
+    db.close();
+  });
+
+  it("handles background command alongside scheduled timer without leaving turn hanging", () => {
+    const db = createConversationDb(dir, "conv-bg-command-and-timer");
+    // 1. Long running command launches task-10
+    insertStep(db, {
+      idx: 1,
+      stepType: 21,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        commandResult: encodeCommandResult({ command: "vitest run", output: "Task task-10 launched" })
+      }),
+      task: encodeTaskDetails({ taskId: "task-10", logUri: "", description: "vitest run" })
+    });
+    // 2. Schedule tool launches timer task-11
+    insertStep(db, {
+      idx: 2,
+      stepType: 132,
+      status: 3,
+      stepPayload: encodeStepPayload({}),
+      task: encodeTaskDetails({ taskId: "task-11", logUri: "", description: "Timer: 60s" })
+    });
+    // 3. Assistant interim text
+    insertStep(db, {
+      idx: 3,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Waiting for test execution to complete..."
+      })
+    });
+
+    const poller = new StreamPoller({
+      dir,
+      conversationId: "conv-bg-command-and-timer",
+      baseStepIdx: -1,
+      skipNarration: false,
+      snapshot: null
+    });
+
+    poller.poll();
+    // task-10 is active (task-11 stepType 132 completed at step 2)
+    expect(poller.hasActiveBackgroundTasks).toBe(true);
+
+    // 4. When task-10 completes via stepType 101 field 114
+    insertStep(db, {
+      idx: 4,
+      stepType: 101,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        taskNotification: encodeTaskNotification({
+          message: '[Message] timestamp=2026-08-18T11:16:56Z sender=conv/task-10 content=Task id "task-10" finished with result: OK',
+          type: "task_notification"
+        })
+      })
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+
+    // 5. Follow-up assistant text
+    insertStep(db, {
+      idx: 5,
+      stepType: 15,
+      status: 3,
+      stepPayload: encodeStepPayload({
+        agentText: "Tests passed cleanly."
+      })
+    });
+
+    poller.poll();
+    expect(poller.hasActiveBackgroundTasks).toBe(false);
+    expect(poller.turnCompleteCandidate).toBe(true);
+    expect(poller.isConclusiveTurnEnd).toBe(true);
 
     poller.close();
     db.close();

--- a/tests/fixtures/step-encoder.ts
+++ b/tests/fixtures/step-encoder.ts
@@ -216,6 +216,18 @@ export function encodePermissions(info: { kind?: string; value?: string; decisio
   return w.finish();
 }
 
+export function encodeTaskNotification(notif: {
+  message?: string;
+  details?: string;
+  type?: string;
+}): Uint8Array {
+  const w = new BinaryWriter();
+  if (notif.message) w.tag(1, 2).string(notif.message);
+  if (notif.details) w.tag(2, 2).string(notif.details);
+  if (notif.type) w.tag(3, 2).string(notif.type);
+  return w.finish();
+}
+
 export function encodeStepPayload(opts: {
   toolRun?: Uint8Array;
   agentText?: string | { text?: string; thought?: string } | Uint8Array;
@@ -228,6 +240,7 @@ export function encodeStepPayload(opts: {
   urlContent?: Uint8Array;
   modelProviderError?: Uint8Array;
   subagentInfo?: Uint8Array;
+  taskNotification?: Uint8Array;
 }): Uint8Array {
   const w = new BinaryWriter();
   if (opts.toolRun) submessage(w, 5, opts.toolRun);
@@ -243,6 +256,7 @@ export function encodeStepPayload(opts: {
   if (opts.titleUpdate !== undefined) submessage(w, 30, encodeTitleUpdate(opts.titleUpdate));
   if (opts.urlContent) submessage(w, 40, opts.urlContent);
   if (opts.webSearch) submessage(w, 42, opts.webSearch);
+  if (opts.taskNotification) submessage(w, 114, opts.taskNotification);
   if (opts.subagentInfo) submessage(w, 127, opts.subagentInfo);
   return w.finish();
 }


### PR DESCRIPTION
## Description

- Decode protobuf payload field 114 (`taskNotification`) on `stepType 101` rows in `src/agy/db/step-payload.ts` to capture task completion notifications and system messages.
- Expand `isSystemMessage()` regex in `src/agy/db/system-message.ts` to recognise un-tagged system message envelopes (`[Message] timestamp=...`, `[Notice]`, `[System]`, `sender=`).
- Extract task notification text in `StreamPoller.poll()` (`src/agy/db/streaming.ts`) so task notices properly retire active background tasks in `_completedTaskIds` and advance `_latestSystemMessageStepIdx`.
- Update `CHANGELOG.md` for issue #131 under `[0.5.2] - Unreleased`.
- Add test fixtures and regression tests in `tests/db.test.ts` covering background command completions over `stepType 101` field 114 and concurrent scheduled timers.

## Related Issues

Fixes #131

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [x] Documentation update
- [ ] CI / Build configuration change

## Verification Checklist

- [x] I have executed `pnpm run build` and it completed without errors
- [x] I have executed `pnpm test` and all 14 test suites pass (475 tests passed, 1 skipped)
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added tests covering my changes in `tests/db.test.ts`
- [x] I have updated `CHANGELOG.md`
- [x] I confirmed no generated build output, local logs, or API keys are committed