### PR TITLE
Support session/fork for both ACP v1 and v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 - Serialize `session/fork` against `session/resume` and `session/load` for the same parent session ID — including persisted-but-inactive parents — and bind the child's `lastStepIdx` to the copied conversation snapshot so inherited agy step rows cannot be emitted as the child's first-turn output. (#58)
 - Fail `session/fork` and delete the partial child database when rebinding `trajectory_meta.cascade_id` or reading the snapshot cursor fails, instead of returning a child that still carries the source conversation identity. (#58)
+- Delete the copied child conversation database and brain directory if `session/fork` is aborted or fails after the snapshot is taken and before the child is registered. (#58)
 - Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and ANSI-resilient permission panel detection. (#113)
 - Refine `_busy` calculation in `StreamPoller` to evaluate `latestMeaningful` step status rather than raw trailing rows (such as lifecycle `stepType 101` or `gen_metadata` records), ensuring trailing metadata does not prevent clean turn completion. (#113)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ### Fixed
 
+- Serialize `session/fork` against `session/resume` and `session/load` for the same parent session ID — including persisted-but-inactive parents — and bind the child's `lastStepIdx` to the copied conversation snapshot so inherited agy step rows cannot be emitted as the child's first-turn output. (#58)
 - Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and ANSI-resilient permission panel detection. (#113)
 - Refine `_busy` calculation in `StreamPoller` to evaluate `latestMeaningful` step status rather than raw trailing rows (such as lifecycle `stepType 101` or `gen_metadata` records), ensuring trailing metadata does not prevent clean turn completion. (#113)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ for draft v2 may still change before ACP v2 stabilizes.
 
 ## [0.5.2] - Unreleased
 
+### Added
+
+- Support `session/fork` across ACP v1 and v2: duplicate conversation history using atomic SQLite backup, clone brain directory artifacts, rebind trajectory metadata, and inherit active configuration options and working directory. (#58)
+
 ### Fixed
 
 - Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and ANSI-resilient permission panel detection. (#113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ for draft v2 may still change before ACP v2 stabilizes.
 ### Fixed
 
 - Serialize `session/fork` against `session/resume` and `session/load` for the same parent session ID — including persisted-but-inactive parents — and bind the child's `lastStepIdx` to the copied conversation snapshot so inherited agy step rows cannot be emitted as the child's first-turn output. (#58)
+- Fail `session/fork` and delete the partial child database when rebinding `trajectory_meta.cascade_id` or reading the snapshot cursor fails, instead of returning a child that still carries the source conversation identity. (#58)
 - Fix interactive turn completion hanging indefinitely until the 5-minute `printTimeout` expires when `agy` completes the turn, adding a 300ms quiescence settle window fallback and ANSI-resilient permission panel detection. (#113)
 - Refine `_busy` calculation in `StreamPoller` to evaluate `latestMeaningful` step status rather than raw trailing rows (such as lifecycle `stepType 101` or `gen_metadata` records), ensuring trailing metadata does not prevent clean turn completion. (#113)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,7 @@ Gaps relative to ACP v1 as exposed by `@agentclientprotocol/sdk`.
 - [x] [`session/new`](https://agentclientprotocol.com/protocol/v1/session-setup): create session with persisted bindings
 - [x] [`session/load`](https://agentclientprotocol.com/protocol/v1/session-setup): restore and replay conversation history
 - [x] [`session/resume`](https://agentclientprotocol.com/rfds/session-resume): reattach without replaying history
+- [x] [`session/fork`](https://agentclientprotocol.com/rfds/session-fork): fork conversation into a new independent session
 - [x] [`session/close`](https://agentclientprotocol.com/rfds/session-close): close active session
 - [x] [`session/delete`](https://agentclientprotocol.com/protocol/v1/session-delete): delete persisted session binding from session store
 - [x] [`session/list`](https://agentclientprotocol.com/protocol/v1/session-list): list sessions from the session store
@@ -74,7 +75,6 @@ Need interactive agy control plane or client terminal protocol beyond DB polling
 
 ### Medium priority
 
-- [ ] [`session/fork`](https://agentclientprotocol.com/rfds/session-fork): fork when useful for clients
 - [ ] [`usage_update`](https://agentclientprotocol.com/rfds/session-usage): when token/usage data is available from agy
 - [ ] [`usage`](https://agentclientprotocol.com/rfds/end-turn-token-usage): prompt-response field when available
 - [ ] [`stopReason`](https://agentclientprotocol.com/protocol/v1/prompt-turn#stop-reasons): richer values (`max_tokens`, `refusal`, `max_turn_requests`) when agy exposes them (today: `end_turn` or `cancelled`)
@@ -115,6 +115,7 @@ differs or is incomplete.
 - [x] [`session/new`](https://agentclientprotocol.com/protocol/v2/session-setup): create session
 - [x] [`session/list`](https://agentclientprotocol.com/protocol/v2/session-list): list sessions
 - [x] [`session/resume`](https://agentclientprotocol.com/protocol/v2/session-setup): optional `replayFrom: { "type": "start" }` ([replay RFD](https://agentclientprotocol.com/rfds/v2/session-resume-replay))
+- [x] [`session/fork`](https://agentclientprotocol.com/rfds/session-fork): fork conversation into a new independent session
 - [x] [`session/close`](https://agentclientprotocol.com/protocol/v2/session-setup): close session
 - [x] [`session/delete`](https://agentclientprotocol.com/protocol/v2/session-delete): delete persisted session binding from session store
 - [x] [`session/prompt`](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle): accept with `{}` immediately
@@ -145,7 +146,6 @@ differs or is incomplete.
 
 ### Medium priority
 
-- [ ] [`session/fork`](https://agentclientprotocol.com/rfds/session-fork): when useful
 - [ ] [`usage_update`](https://agentclientprotocol.com/rfds/session-usage): when token data is available from agy
 - [ ] [`stopReason`](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle): richer values on idle `state_update` when agy exposes them
 - [ ] [`agent_message`](https://agentclientprotocol.com/rfds/v2/message-updates): optional full-message updates (+ `agent_thought`) in addition to chunks

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -102,6 +102,7 @@ import {
   reloadSession,
   replayConversation,
   persistSession,
+  KeyedAsyncLock,
   type SessionBuildDeps
 } from "./session/setup.js";
 import { deferAfterResponse, handleNewSessionV1, handleNewSessionV2, type NewSessionDeps } from "./session/new.js";
@@ -202,6 +203,7 @@ export class AcpAgent {
   readonly #argv: string[];
   readonly #backend: AgyCliBackend;
   readonly #sessions = new Map<string, SessionState>();
+  readonly #setupLocks = new KeyedAsyncLock();
   readonly #store: SessionStore;
   readonly #replayCache = new ReplayCache(REPLAY_CACHE_CAPACITY);
   readonly #modelCacheFile: string;
@@ -742,7 +744,8 @@ export class AcpAgent {
       ...this.sessionBuildDeps(),
       store: this.#store,
       sessions: this.#sessions,
-      maxActiveSessions: this.#maxActiveSessions
+      maxActiveSessions: this.#maxActiveSessions,
+      setupLocks: this.#setupLocks
     });
     this.reconcileSessionCatalog(result.session);
     return result;
@@ -758,7 +761,8 @@ export class AcpAgent {
       store: this.#store,
       sessions: this.#sessions,
       maxActiveSessions: this.#maxActiveSessions,
-      persistSession: (sessionId, session) => this.persistSession(sessionId, session)
+      persistSession: (sessionId, session) => this.persistSession(sessionId, session),
+      setupLocks: this.#setupLocks
     });
     this.reconcileSessionCatalog(result.childSession);
     return result;

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -97,6 +97,7 @@ import { handleSetConfigOptionV1, handleSetConfigOptionV2 } from "./session/set-
 import {
   buildSession,
   createSession,
+  forkSession,
   registerSession,
   reloadSession,
   replayConversation,
@@ -104,6 +105,15 @@ import {
   type SessionBuildDeps
 } from "./session/setup.js";
 import { deferAfterResponse, handleNewSessionV1, handleNewSessionV2, type NewSessionDeps } from "./session/new.js";
+import {
+  handleForkSessionV1,
+  handleForkSessionV2,
+  type ForkSessionDeps,
+  type V1ForkSessionRequest,
+  type V1ForkSessionResponse,
+  type V2ForkSessionRequest,
+  type V2ForkSessionResponse
+} from "./session/fork.js";
 import { handleLoadSession } from "./session/load.js";
 import { handleResumeSessionV1, handleResumeSessionV2 } from "./session/resume.js";
 import { handleSetSessionMode } from "./session/set-mode.js";
@@ -350,6 +360,27 @@ export class AcpAgent {
   newSessionV2(params: V2NewSessionRequest, client?: V2AgentContext): Promise<V2NewSessionResponse> {
     return handleNewSessionV2(params, client, {
       ...this.newSessionDeps(),
+      notifyAvailableCommandsV2
+    });
+  }
+
+  private forkSessionDeps(): ForkSessionDeps {
+    return {
+      requireAuthenticated: (cwd) => this.requireAuthenticated(cwd),
+      forkSession: (parentSessionId, cwd, dirs) => this.forkSession(parentSessionId, cwd, dirs)
+    };
+  }
+
+  forkSessionV1(params: V1ForkSessionRequest, client?: V1AgentContext): Promise<V1ForkSessionResponse> {
+    return handleForkSessionV1(params, client, {
+      ...this.forkSessionDeps(),
+      notifyAvailableCommandsV1
+    });
+  }
+
+  forkSessionV2(params: V2ForkSessionRequest, client?: V2AgentContext): Promise<V2ForkSessionResponse> {
+    return handleForkSessionV2(params, client, {
+      ...this.forkSessionDeps(),
       notifyAvailableCommandsV2
     });
   }
@@ -717,6 +748,22 @@ export class AcpAgent {
     return result;
   }
 
+  private async forkSession(
+    parentSessionId: string,
+    requestedCwd: string | undefined,
+    requestedDirs: string[] | undefined
+  ): Promise<{ childSession: SessionState; cwd: string; childSessionId: string }> {
+    const result = await forkSession(parentSessionId, requestedCwd, requestedDirs, {
+      ...this.sessionBuildDeps(),
+      store: this.#store,
+      sessions: this.#sessions,
+      maxActiveSessions: this.#maxActiveSessions,
+      persistSession: (sessionId, session) => this.persistSession(sessionId, session)
+    });
+    this.reconcileSessionCatalog(result.childSession);
+    return result;
+  }
+
   private reconcileSessionCatalog(session: SessionState): void {
     const key = session.agy.config.agyPath;
     const cached = this.#modelOptionsCache.get(key);
@@ -759,6 +806,7 @@ export function createAcpApp(options: AcpAgentOptions | AcpAgent = {}): V1AgentA
     .onRequest(v1.methods.agent.session.list, (ctx) => agent.listSessions(ctx.params))
     .onRequest(v1.methods.agent.session.load, (ctx) => agent.loadSession(ctx.params, ctx.client))
     .onRequest(v1.methods.agent.session.resume, (ctx) => agent.resumeSessionV1(ctx.params, ctx.client))
+    .onRequest(v1.methods.agent.session.fork, (ctx) => agent.forkSessionV1(ctx.params, ctx.client))
     .onRequest(v1.methods.agent.session.setMode, (ctx) => agent.setSessionMode(ctx.params, ctx.client))
     .onRequest(v1.methods.agent.session.setConfigOption, (ctx) =>
       agent.setConfigOptionV1(ctx.params, ctx.client)
@@ -783,6 +831,7 @@ export function createAcpV2App(options: AcpAgentOptions | AcpAgent = {}): V2Agen
     .onRequest(v2.methods.agent.session.new, (ctx) => agent.newSessionV2(ctx.params, ctx.client))
     .onRequest(v2.methods.agent.session.list, (ctx) => agent.listSessions(ctx.params))
     .onRequest(v2.methods.agent.session.resume, (ctx) => agent.resumeSessionV2(ctx.params, ctx.client))
+    .onRequest(v2.methods.agent.session.fork, (ctx) => agent.forkSessionV2(ctx.params, ctx.client))
     .onRequest(v2.methods.agent.session.setConfigOption, (ctx) => agent.setConfigOptionV2(ctx.params))
     .onRequest(v2.methods.agent.session.prompt, (ctx) => agent.promptV2(ctx.params, ctx.client))
     .onRequest(v2.methods.agent.session.close, (ctx) => agent.closeSession(ctx.params))

--- a/src/acp/initialize.ts
+++ b/src/acp/initialize.ts
@@ -105,7 +105,8 @@ export function handleInitializeV1(
           list: {},
           additionalDirectories: {},
           resume: {},
-          close: {}
+          close: {},
+          fork: {}
         },
         auth: {
           logout: {}
@@ -140,7 +141,8 @@ export function handleInitializeV2(
             image: {},
             embeddedContext: {}
           },
-          additionalDirectories: {}
+          additionalDirectories: {},
+          fork: {}
         },
         auth: {},
         toolCallName: {},

--- a/src/acp/session/fork.ts
+++ b/src/acp/session/fork.ts
@@ -1,0 +1,75 @@
+// ACP session/fork: create a new session branching off an existing session's history and configuration.
+// Docs: https://agentclientprotocol.com/rfds/session-fork
+
+import type {
+  AgentContext as V1AgentContext,
+  ForkSessionRequest as V1ForkSessionRequest,
+  ForkSessionResponse as V1ForkSessionResponse
+} from "@agentclientprotocol/sdk";
+import type {
+  AgentContext as V2AgentContext,
+  ForkSessionRequest as V2ForkSessionRequest,
+  ForkSessionResponse as V2ForkSessionResponse
+} from "@agentclientprotocol/sdk/experimental/v2";
+import { sessionConfigOptionsV1, sessionConfigOptionsV2 } from "./config-options.js";
+import { sessionModeState } from "./modes.js";
+import { deferAfterResponse } from "./new.js";
+import type { SessionState } from "./types.js";
+
+export type { V1ForkSessionRequest, V1ForkSessionResponse, V2ForkSessionRequest, V2ForkSessionResponse };
+
+export interface ForkSessionDeps {
+  requireAuthenticated(cwd?: string): Promise<void>;
+  forkSession(
+    parentSessionId: string,
+    cwd: string | undefined,
+    additionalDirectories: string[] | undefined
+  ): Promise<{ childSession: SessionState; cwd: string; childSessionId: string }>;
+}
+
+export async function handleForkSessionV1(
+  params: V1ForkSessionRequest,
+  client: V1AgentContext | undefined,
+  deps: ForkSessionDeps & {
+    notifyAvailableCommandsV1(client: V1AgentContext, sessionId: string): Promise<void>;
+  }
+): Promise<V1ForkSessionResponse> {
+  await deps.requireAuthenticated(params.cwd);
+  const { childSession, childSessionId } = await deps.forkSession(
+    params.sessionId,
+    params.cwd,
+    params.additionalDirectories
+  );
+  if (client) {
+    childSession.v1Client = client;
+    deferAfterResponse(() => deps.notifyAvailableCommandsV1(client, childSessionId));
+  }
+  return {
+    sessionId: childSessionId,
+    modes: sessionModeState(childSession.agy.config.mode),
+    configOptions: sessionConfigOptionsV1(childSession)
+  };
+}
+
+export async function handleForkSessionV2(
+  params: V2ForkSessionRequest,
+  client: V2AgentContext | undefined,
+  deps: ForkSessionDeps & {
+    notifyAvailableCommandsV2(client: V2AgentContext, sessionId: string): Promise<void>;
+  }
+): Promise<V2ForkSessionResponse> {
+  await deps.requireAuthenticated(params.cwd);
+  const { childSession, childSessionId } = await deps.forkSession(
+    params.sessionId,
+    params.cwd,
+    params.additionalDirectories
+  );
+  if (client) {
+    childSession.v2Client = client;
+    deferAfterResponse(() => deps.notifyAvailableCommandsV2(client, childSessionId));
+  }
+  return {
+    sessionId: childSessionId,
+    configOptions: sessionConfigOptionsV2(childSession)
+  };
+}

--- a/src/acp/session/setup-lock.ts
+++ b/src/acp/session/setup-lock.ts
@@ -1,0 +1,23 @@
+// Per-session-ID mutex for setup RPCs (fork / load / resume).
+//
+// Turn claims only exist on an in-memory SessionState. Fork of a persisted
+// but inactive parent has no SessionState, so resume/load can register that
+// parent and start writing its conversation DB while the fork is still
+// snapshotting. A keyed lock serializes those setup paths regardless of
+// whether the session is currently in the active map.
+
+export class KeyedAsyncLock {
+  readonly #tails = new Map<string, Promise<unknown>>();
+
+  run<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.#tails.get(key) ?? Promise.resolve();
+    const next: Promise<T> = prev.catch(() => undefined).then(() => fn());
+    this.#tails.set(key, next);
+    void next
+      .finally(() => {
+        if (this.#tails.get(key) === next) this.#tails.delete(key);
+      })
+      .catch(() => {});
+    return next;
+  }
+}

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -80,6 +80,9 @@ export async function registerSession(
 ): Promise<void> {
   const replaced = sessions.get(sessionId);
   if (replaced && replaced !== session) {
+    if (sessionTurnBusy(replaced)) {
+      throw new Error(`Cannot replace session while a turn is active: ${sessionId}`);
+    }
     sessions.delete(sessionId);
     replaced.closed = true;
     turnsOf(replaced).close();
@@ -188,6 +191,7 @@ export async function forkSession(
       childConversationId = randomUUID();
       const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
       await forkConversation(convDir, parentStored.conversationId, childConversationId);
+      claim?.throwIfAborted();
     }
 
     const childStored: StoredSession = {
@@ -203,6 +207,7 @@ export async function forkSession(
     };
 
     const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
+    claim?.throwIfAborted();
     childSession.sessionId = childSessionId;
     await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
     await deps.persistSession(childSessionId, childSession);

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -161,6 +161,9 @@ export async function forkSession(
   }
 ): Promise<{ childSession: SessionState; cwd: string; childSessionId: string }> {
   const activeParent = deps.sessions.get(parentSessionId);
+  if (activeParent && sessionTurnBusy(activeParent)) {
+    throw new Error(`Cannot fork session while a turn is active: ${parentSessionId}`);
+  }
   const parentStored = activeParent
     ? sessionRecord(activeParent)
     : await deps.store.restore(parentSessionId);

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -5,10 +5,12 @@ import { randomUUID } from "node:crypto";
 import type * as v1 from "@agentclientprotocol/sdk";
 import {
   configFromEnv,
+  DEFAULT_CONVERSATIONS_DIR,
   isSessionModeId,
   type AgyCliBackend,
   type AgyCliConfig
 } from "../../agy/cli.js";
+import { forkConversation } from "../../agy/db/fork.js";
 import type { ReplayCache } from "../../agy/db/replay.js";
 import { buildModelCatalog } from "../../agy/model/catalog.js";
 import { applyModelSelection, initialModelSelection, restoredModelSelection } from "../../agy/model/selection.js";
@@ -144,6 +146,59 @@ export async function reloadSession(
   session.sessionId = sessionId;
   await registerSession(sessionId, session, deps.sessions, deps.maxActiveSessions);
   return { session, cwd, stored };
+}
+
+/** Fork an existing session into a new independent session binding. */
+export async function forkSession(
+  parentSessionId: string,
+  requestedCwd: string | undefined,
+  requestedDirs: string[] | undefined,
+  deps: SessionBuildDeps & {
+    store: SessionStore;
+    sessions: Map<string, SessionState>;
+    maxActiveSessions: number;
+    persistSession(sessionId: string, session: SessionState): Promise<void>;
+  }
+): Promise<{ childSession: SessionState; cwd: string; childSessionId: string }> {
+  const activeParent = deps.sessions.get(parentSessionId);
+  const parentStored = activeParent
+    ? sessionRecord(activeParent)
+    : await deps.store.restore(parentSessionId);
+  if (!parentStored) {
+    throw new Error(`Unknown session: ${parentSessionId}`);
+  }
+
+  const cwd = requestedCwd || parentStored.cwd;
+  const additionalDirectories = dedupe(requestedDirs ?? parentStored.additionalDirectories);
+  const childSessionId = randomUUID();
+
+  let childConversationId: string | null = null;
+  const childLastStepIdx = parentStored.lastStepIdx;
+
+  if (parentStored.conversationId) {
+    childConversationId = randomUUID();
+    const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
+    await forkConversation(convDir, parentStored.conversationId, childConversationId);
+  }
+
+  const childStored: StoredSession = {
+    cwd,
+    additionalDirectories,
+    conversationId: childConversationId,
+    lastStepIdx: childLastStepIdx,
+    model: parentStored.model,
+    reasoningEffort: parentStored.reasoningEffort,
+    mode: parentStored.mode,
+    v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
+    updatedAt: new Date().toISOString()
+  };
+
+  const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
+  childSession.sessionId = childSessionId;
+  await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
+  await deps.persistSession(childSessionId, childSession);
+
+  return { childSession, cwd, childSessionId };
 }
 
 export function sessionRecord(session: SessionState): StoredSession {

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -18,7 +18,10 @@ import type { SessionStore, StoredSession } from "./store.js";
 import type { SessionState } from "./types.js";
 import { cancelQueuedPrompts } from "./cancel.js";
 import { notifyIdleAndDrainQueue, sessionTurnBusy } from "./prompt.js";
+import { KeyedAsyncLock } from "./setup-lock.js";
 import { type TurnClaim, turnsOf } from "./turn-scheduler.js";
+
+export { KeyedAsyncLock } from "./setup-lock.js";
 
 export interface SessionBuildDeps {
   env: NodeJS.ProcessEnv;
@@ -136,19 +139,22 @@ export async function reloadSession(
     store: SessionStore;
     sessions: Map<string, SessionState>;
     maxActiveSessions: number;
+    setupLocks: KeyedAsyncLock;
   }
 ): Promise<{ session: SessionState; cwd: string; stored: StoredSession }> {
-  const stored = await deps.store.restore(sessionId);
-  if (!stored) {
-    throw new Error(`Unknown session: ${sessionId}`);
-  }
-  const cwd = requestedCwd || stored.cwd;
-  const additionalDirectories = dedupe(requestedDirs ?? stored.additionalDirectories);
+  return deps.setupLocks.run(sessionId, async () => {
+    const stored = await deps.store.restore(sessionId);
+    if (!stored) {
+      throw new Error(`Unknown session: ${sessionId}`);
+    }
+    const cwd = requestedCwd || stored.cwd;
+    const additionalDirectories = dedupe(requestedDirs ?? stored.additionalDirectories);
 
-  const session = await buildSession(cwd, additionalDirectories, stored, deps);
-  session.sessionId = sessionId;
-  await registerSession(sessionId, session, deps.sessions, deps.maxActiveSessions);
-  return { session, cwd, stored };
+    const session = await buildSession(cwd, additionalDirectories, stored, deps);
+    session.sessionId = sessionId;
+    await registerSession(sessionId, session, deps.sessions, deps.maxActiveSessions);
+    return { session, cwd, stored };
+  });
 }
 
 /** Fork an existing session into a new independent session binding. */
@@ -161,64 +167,71 @@ export async function forkSession(
     sessions: Map<string, SessionState>;
     maxActiveSessions: number;
     persistSession(sessionId: string, session: SessionState): Promise<void>;
+    setupLocks: KeyedAsyncLock;
   }
 ): Promise<{ childSession: SessionState; cwd: string; childSessionId: string }> {
-  const activeParent = deps.sessions.get(parentSessionId);
-  let claim: TurnClaim | undefined;
-  if (activeParent) {
-    if (sessionTurnBusy(activeParent)) {
-      throw new Error(`Cannot fork session while a turn is active: ${parentSessionId}`);
-    }
-    claim = turnsOf(activeParent).claimIdle("foreground");
-  }
-
-  try {
-    const parentStored = activeParent
-      ? sessionRecord(activeParent)
-      : await deps.store.restore(parentSessionId);
-    if (!parentStored) {
-      throw new Error(`Unknown session: ${parentSessionId}`);
+  return deps.setupLocks.run(parentSessionId, async () => {
+    const activeParent = deps.sessions.get(parentSessionId);
+    let claim: TurnClaim | undefined;
+    if (activeParent) {
+      if (sessionTurnBusy(activeParent)) {
+        throw new Error(`Cannot fork session while a turn is active: ${parentSessionId}`);
+      }
+      claim = turnsOf(activeParent).claimIdle("foreground");
     }
 
-    const cwd = requestedCwd || parentStored.cwd;
-    const additionalDirectories = dedupe(requestedDirs ?? parentStored.additionalDirectories);
-    const childSessionId = randomUUID();
+    try {
+      const parentStored = activeParent
+        ? sessionRecord(activeParent)
+        : await deps.store.restore(parentSessionId);
+      if (!parentStored) {
+        throw new Error(`Unknown session: ${parentSessionId}`);
+      }
 
-    let childConversationId: string | null = null;
-    const childLastStepIdx = parentStored.lastStepIdx;
+      const cwd = requestedCwd || parentStored.cwd;
+      const additionalDirectories = dedupe(requestedDirs ?? parentStored.additionalDirectories);
+      const childSessionId = randomUUID();
 
-    if (parentStored.conversationId) {
-      childConversationId = randomUUID();
-      const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
-      await forkConversation(convDir, parentStored.conversationId, childConversationId);
+      let childConversationId: string | null = null;
+      let childLastStepIdx = parentStored.lastStepIdx;
+
+      if (parentStored.conversationId) {
+        childConversationId = randomUUID();
+        const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
+        const forked = await forkConversation(convDir, parentStored.conversationId, childConversationId);
+        // Bind the child cursor to the copied snapshot so inherited rows cannot
+        // be emitted as the child's first-turn output. agy resumes via
+        // `--conversation <id>` and StreamPoller emits idx > lastStepIdx.
+        childLastStepIdx = Math.max(parentStored.lastStepIdx, forked.maxStepIdx);
+        claim?.throwIfAborted();
+      }
+
+      const childStored: StoredSession = {
+        cwd,
+        additionalDirectories,
+        conversationId: childConversationId,
+        lastStepIdx: childLastStepIdx,
+        model: parentStored.model,
+        reasoningEffort: parentStored.reasoningEffort,
+        mode: parentStored.mode,
+        v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
+        updatedAt: new Date().toISOString()
+      };
+
+      const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
       claim?.throwIfAborted();
+      childSession.sessionId = childSessionId;
+      await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
+      await deps.persistSession(childSessionId, childSession);
+
+      return { childSession, cwd, childSessionId };
+    } finally {
+      if (activeParent && claim) {
+        turnsOf(activeParent).release(claim);
+        notifyIdleAndDrainQueue(activeParent);
+      }
     }
-
-    const childStored: StoredSession = {
-      cwd,
-      additionalDirectories,
-      conversationId: childConversationId,
-      lastStepIdx: childLastStepIdx,
-      model: parentStored.model,
-      reasoningEffort: parentStored.reasoningEffort,
-      mode: parentStored.mode,
-      v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
-      updatedAt: new Date().toISOString()
-    };
-
-    const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
-    claim?.throwIfAborted();
-    childSession.sessionId = childSessionId;
-    await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
-    await deps.persistSession(childSessionId, childSession);
-
-    return { childSession, cwd, childSessionId };
-  } finally {
-    if (activeParent && claim) {
-      turnsOf(activeParent).release(claim);
-      notifyIdleAndDrainQueue(activeParent);
-    }
-  }
+  });
 }
 
 export function sessionRecord(session: SessionState): StoredSession {

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -10,7 +10,7 @@ import {
   type AgyCliBackend,
   type AgyCliConfig
 } from "../../agy/cli.js";
-import { forkConversation } from "../../agy/db/fork.js";
+import { discardForkedConversation, forkConversation } from "../../agy/db/fork.js";
 import type { ReplayCache } from "../../agy/db/replay.js";
 import { buildModelCatalog } from "../../agy/model/catalog.js";
 import { applyModelSelection, initialModelSelection, restoredModelSelection } from "../../agy/model/selection.js";
@@ -193,38 +193,55 @@ export async function forkSession(
       const childSessionId = randomUUID();
 
       let childConversationId: string | null = null;
+      let convDir: string | undefined;
       let childLastStepIdx = parentStored.lastStepIdx;
+      let childSession: SessionState | undefined;
+      let registered = false;
 
-      if (parentStored.conversationId) {
-        childConversationId = randomUUID();
-        const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
-        const forked = await forkConversation(convDir, parentStored.conversationId, childConversationId);
-        // Bind the child cursor to the copied snapshot so inherited rows cannot
-        // be emitted as the child's first-turn output. agy resumes via
-        // `--conversation <id>` and StreamPoller emits idx > lastStepIdx.
-        childLastStepIdx = Math.max(parentStored.lastStepIdx, forked.maxStepIdx);
+      try {
+        if (parentStored.conversationId) {
+          childConversationId = randomUUID();
+          convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
+          const forked = await forkConversation(convDir, parentStored.conversationId, childConversationId);
+          // Bind the child cursor to the copied snapshot so inherited rows cannot
+          // be emitted as the child's first-turn output. agy resumes via
+          // `--conversation <id>` and StreamPoller emits idx > lastStepIdx.
+          childLastStepIdx = Math.max(parentStored.lastStepIdx, forked.maxStepIdx);
+          claim?.throwIfAborted();
+        }
+
+        const childStored: StoredSession = {
+          cwd,
+          additionalDirectories,
+          conversationId: childConversationId,
+          lastStepIdx: childLastStepIdx,
+          model: parentStored.model,
+          reasoningEffort: parentStored.reasoningEffort,
+          mode: parentStored.mode,
+          v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
+          updatedAt: new Date().toISOString()
+        };
+
+        childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
         claim?.throwIfAborted();
+        childSession.sessionId = childSessionId;
+        await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
+        registered = true;
+        await deps.persistSession(childSessionId, childSession);
+
+        return { childSession, cwd, childSessionId };
+      } finally {
+        if (!registered) {
+          if (childSession) {
+            childSession.closed = true;
+            turnsOf(childSession).close();
+            await childSession.agy.close().catch(() => {});
+          }
+          if (childConversationId && convDir) {
+            discardForkedConversation(convDir, childConversationId);
+          }
+        }
       }
-
-      const childStored: StoredSession = {
-        cwd,
-        additionalDirectories,
-        conversationId: childConversationId,
-        lastStepIdx: childLastStepIdx,
-        model: parentStored.model,
-        reasoningEffort: parentStored.reasoningEffort,
-        mode: parentStored.mode,
-        v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
-        updatedAt: new Date().toISOString()
-      };
-
-      const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
-      claim?.throwIfAborted();
-      childSession.sessionId = childSessionId;
-      await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
-      await deps.persistSession(childSessionId, childSession);
-
-      return { childSession, cwd, childSessionId };
     } finally {
       if (activeParent && claim) {
         turnsOf(activeParent).release(claim);

--- a/src/acp/session/setup.ts
+++ b/src/acp/session/setup.ts
@@ -17,8 +17,8 @@ import { applyModelSelection, initialModelSelection, restoredModelSelection } fr
 import type { SessionStore, StoredSession } from "./store.js";
 import type { SessionState } from "./types.js";
 import { cancelQueuedPrompts } from "./cancel.js";
-import { sessionTurnBusy } from "./prompt.js";
-import { turnsOf } from "./turn-scheduler.js";
+import { notifyIdleAndDrainQueue, sessionTurnBusy } from "./prompt.js";
+import { type TurnClaim, turnsOf } from "./turn-scheduler.js";
 
 export interface SessionBuildDeps {
   env: NodeJS.ProcessEnv;
@@ -161,47 +161,59 @@ export async function forkSession(
   }
 ): Promise<{ childSession: SessionState; cwd: string; childSessionId: string }> {
   const activeParent = deps.sessions.get(parentSessionId);
-  if (activeParent && sessionTurnBusy(activeParent)) {
-    throw new Error(`Cannot fork session while a turn is active: ${parentSessionId}`);
-  }
-  const parentStored = activeParent
-    ? sessionRecord(activeParent)
-    : await deps.store.restore(parentSessionId);
-  if (!parentStored) {
-    throw new Error(`Unknown session: ${parentSessionId}`);
+  let claim: TurnClaim | undefined;
+  if (activeParent) {
+    if (sessionTurnBusy(activeParent)) {
+      throw new Error(`Cannot fork session while a turn is active: ${parentSessionId}`);
+    }
+    claim = turnsOf(activeParent).claimIdle("foreground");
   }
 
-  const cwd = requestedCwd || parentStored.cwd;
-  const additionalDirectories = dedupe(requestedDirs ?? parentStored.additionalDirectories);
-  const childSessionId = randomUUID();
+  try {
+    const parentStored = activeParent
+      ? sessionRecord(activeParent)
+      : await deps.store.restore(parentSessionId);
+    if (!parentStored) {
+      throw new Error(`Unknown session: ${parentSessionId}`);
+    }
 
-  let childConversationId: string | null = null;
-  const childLastStepIdx = parentStored.lastStepIdx;
+    const cwd = requestedCwd || parentStored.cwd;
+    const additionalDirectories = dedupe(requestedDirs ?? parentStored.additionalDirectories);
+    const childSessionId = randomUUID();
 
-  if (parentStored.conversationId) {
-    childConversationId = randomUUID();
-    const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
-    await forkConversation(convDir, parentStored.conversationId, childConversationId);
+    let childConversationId: string | null = null;
+    const childLastStepIdx = parentStored.lastStepIdx;
+
+    if (parentStored.conversationId) {
+      childConversationId = randomUUID();
+      const convDir = deps.conversationsDir ?? DEFAULT_CONVERSATIONS_DIR;
+      await forkConversation(convDir, parentStored.conversationId, childConversationId);
+    }
+
+    const childStored: StoredSession = {
+      cwd,
+      additionalDirectories,
+      conversationId: childConversationId,
+      lastStepIdx: childLastStepIdx,
+      model: parentStored.model,
+      reasoningEffort: parentStored.reasoningEffort,
+      mode: parentStored.mode,
+      v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
+      updatedAt: new Date().toISOString()
+    };
+
+    const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
+    childSession.sessionId = childSessionId;
+    await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
+    await deps.persistSession(childSessionId, childSession);
+
+    return { childSession, cwd, childSessionId };
+  } finally {
+    if (activeParent && claim) {
+      turnsOf(activeParent).release(claim);
+      notifyIdleAndDrainQueue(activeParent);
+    }
   }
-
-  const childStored: StoredSession = {
-    cwd,
-    additionalDirectories,
-    conversationId: childConversationId,
-    lastStepIdx: childLastStepIdx,
-    model: parentStored.model,
-    reasoningEffort: parentStored.reasoningEffort,
-    mode: parentStored.mode,
-    v2UserMessageIdsByStep: { ...(parentStored.v2UserMessageIdsByStep ?? {}) },
-    updatedAt: new Date().toISOString()
-  };
-
-  const childSession = await buildSession(cwd, additionalDirectories, childStored, deps);
-  childSession.sessionId = childSessionId;
-  await registerSession(childSessionId, childSession, deps.sessions, deps.maxActiveSessions);
-  await deps.persistSession(childSessionId, childSession);
-
-  return { childSession, cwd, childSessionId };
 }
 
 export function sessionRecord(session: SessionState): StoredSession {

--- a/src/agy/db/fork.ts
+++ b/src/agy/db/fork.ts
@@ -44,7 +44,8 @@ export async function forkConversation(
   }
 
   // 2. Rebind trajectory_meta.cascade_id (agy identity for this file) and
-  //    read the snapshot cursor from the copied steps table.
+  //    read the snapshot cursor from the copied steps table. A child that
+  //    still carries the source cascade_id is not an independent conversation.
   let maxStepIdx = -1;
   try {
     const destDb = new Database(destDbPath);
@@ -58,18 +59,20 @@ export async function forkConversation(
       if (names.has("trajectory_meta")) {
         destDb.prepare("UPDATE trajectory_meta SET cascade_id = ?").run(targetConversationId);
       }
-      if (names.has("steps")) {
-        const row = destDb.prepare("SELECT MAX(idx) AS maxIdx FROM steps").get() as
-          | { maxIdx: number | null }
-          | undefined;
-        if (typeof row?.maxIdx === "number") maxStepIdx = row.maxIdx;
+      if (!names.has("steps")) {
+        throw new Error(`forked conversation database is missing steps table: ${targetConversationId}`);
       }
+      const row = destDb.prepare("SELECT MAX(idx) AS maxIdx FROM steps").get() as
+        | { maxIdx: number | null }
+        | undefined;
+      if (typeof row?.maxIdx === "number") maxStepIdx = row.maxIdx;
     } finally {
       destDb.close();
     }
   } catch (error) {
-    console.error(
-      `[agy-acp] WARN: failed to update trajectory_meta in forked db ${targetConversationId}: ${(error as Error).message}`
+    removeConversationFiles(destDbPath);
+    throw new Error(
+      `Failed to rebind forked conversation database ${targetConversationId}: ${(error as Error).message}`
     );
   }
 
@@ -90,4 +93,14 @@ export async function forkConversation(
   }
 
   return { maxStepIdx };
+}
+
+function removeConversationFiles(dbPath: string): void {
+  for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+    try {
+      fs.unlinkSync(`${dbPath}${suffix}`);
+    } catch {
+      // Sidecars are absent unless the copy used WAL/journal mode.
+    }
+  }
 }

--- a/src/agy/db/fork.ts
+++ b/src/agy/db/fork.ts
@@ -20,7 +20,7 @@ export async function forkConversation(
   const destDbPath = conversationDbPath(conversationsDir, targetConversationId);
 
   if (!fs.existsSync(srcDbPath)) {
-    return;
+    throw new Error(`Source conversation database not found: ${sourceConversationId}`);
   }
 
   await fs.promises.mkdir(conversationsDir, { recursive: true });

--- a/src/agy/db/fork.ts
+++ b/src/agy/db/fork.ts
@@ -95,6 +95,24 @@ export async function forkConversation(
   return { maxStepIdx };
 }
 
+/** Remove a forked conversation DB (and brain dir) that never became a live session. */
+export function discardForkedConversation(
+  conversationsDir: string,
+  conversationId: string,
+  brainBaseDir?: string
+): void {
+  removeConversationFiles(conversationDbPath(conversationsDir, conversationId));
+  const destBrainDir = path.join(
+    brainBaseDir ?? path.join(path.dirname(conversationsDir), "brain"),
+    conversationId
+  );
+  try {
+    fs.rmSync(destBrainDir, { recursive: true, force: true });
+  } catch {
+    // Destination brain may not have been copied.
+  }
+}
+
 function removeConversationFiles(dbPath: string): void {
   for (const suffix of ["", "-wal", "-shm", "-journal"]) {
     try {

--- a/src/agy/db/fork.ts
+++ b/src/agy/db/fork.ts
@@ -1,0 +1,74 @@
+// Fork an agy conversation database and associated brain artifacts.
+// Used by ACP session/fork to create an independent branch of an existing session.
+
+import Database from "better-sqlite3";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { conversationDbPath } from "./database.js";
+
+/**
+ * Fork an existing agy conversation database and brain artifacts directory into a new conversation ID.
+ * Uses SQLite's online backup API for an atomic, consistent snapshot without torn reads.
+ */
+export async function forkConversation(
+  conversationsDir: string,
+  sourceConversationId: string,
+  targetConversationId: string,
+  brainBaseDir?: string
+): Promise<void> {
+  const srcDbPath = conversationDbPath(conversationsDir, sourceConversationId);
+  const destDbPath = conversationDbPath(conversationsDir, targetConversationId);
+
+  if (!fs.existsSync(srcDbPath)) {
+    return;
+  }
+
+  await fs.promises.mkdir(conversationsDir, { recursive: true });
+
+  // 1. Safe atomic snapshot of SQLite DB
+  const srcDb = new Database(srcDbPath, { readonly: true, fileMustExist: true });
+  try {
+    await srcDb.backup(destDbPath);
+  } finally {
+    srcDb.close();
+  }
+
+  // 2. Update trajectory_meta in destination DB
+  try {
+    const destDb = new Database(destDbPath);
+    try {
+      const hasMeta = destDb
+        .prepare(
+          "SELECT COUNT(*) > 0 AS present FROM sqlite_master WHERE type='table' AND name='trajectory_meta'"
+        )
+        .get() as { present: number } | undefined;
+      if (hasMeta?.present) {
+        destDb
+          .prepare("UPDATE trajectory_meta SET cascade_id = ?")
+          .run(targetConversationId);
+      }
+    } finally {
+      destDb.close();
+    }
+  } catch (error) {
+    console.error(
+      `[agy-acp] WARN: failed to update trajectory_meta in forked db ${targetConversationId}: ${(error as Error).message}`
+    );
+  }
+
+  // 3. Copy brain artifacts directory if present
+  const resolvedBrainBase =
+    brainBaseDir ?? path.join(path.dirname(conversationsDir), "brain");
+  const srcBrainDir = path.join(resolvedBrainBase, sourceConversationId);
+  const destBrainDir = path.join(resolvedBrainBase, targetConversationId);
+
+  try {
+    if (fs.existsSync(srcBrainDir)) {
+      await fs.promises.cp(srcBrainDir, destBrainDir, { recursive: true });
+    }
+  } catch (error) {
+    console.error(
+      `[agy-acp] WARN: failed to copy brain artifacts for forked conversation ${targetConversationId}: ${(error as Error).message}`
+    );
+  }
+}

--- a/src/agy/db/fork.ts
+++ b/src/agy/db/fork.ts
@@ -6,16 +6,26 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { conversationDbPath } from "./database.js";
 
+export interface ForkedConversation {
+  /** Highest `steps.idx` present in the copied database, or -1 if none. */
+  maxStepIdx: number;
+}
+
 /**
  * Fork an existing agy conversation database and brain artifacts directory into a new conversation ID.
  * Uses SQLite's online backup API for an atomic, consistent snapshot without torn reads.
+ *
+ * `agy` has no fork flag — it resumes a conversation by `--conversation <id>`
+ * against `~/.gemini/antigravity-cli/conversations/<id>.db`. The child must
+ * therefore be a new conversation id whose DB is a consistent snapshot, and
+ * whose ACP cursor is not behind that snapshot.
  */
 export async function forkConversation(
   conversationsDir: string,
   sourceConversationId: string,
   targetConversationId: string,
   brainBaseDir?: string
-): Promise<void> {
+): Promise<ForkedConversation> {
   const srcDbPath = conversationDbPath(conversationsDir, sourceConversationId);
   const destDbPath = conversationDbPath(conversationsDir, targetConversationId);
 
@@ -33,19 +43,26 @@ export async function forkConversation(
     srcDb.close();
   }
 
-  // 2. Update trajectory_meta in destination DB
+  // 2. Rebind trajectory_meta.cascade_id (agy identity for this file) and
+  //    read the snapshot cursor from the copied steps table.
+  let maxStepIdx = -1;
   try {
     const destDb = new Database(destDbPath);
     try {
-      const hasMeta = destDb
+      const tables = destDb
         .prepare(
-          "SELECT COUNT(*) > 0 AS present FROM sqlite_master WHERE type='table' AND name='trajectory_meta'"
+          "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('trajectory_meta', 'steps')"
         )
-        .get() as { present: number } | undefined;
-      if (hasMeta?.present) {
-        destDb
-          .prepare("UPDATE trajectory_meta SET cascade_id = ?")
-          .run(targetConversationId);
+        .all() as Array<{ name: string }>;
+      const names = new Set(tables.map((table) => table.name));
+      if (names.has("trajectory_meta")) {
+        destDb.prepare("UPDATE trajectory_meta SET cascade_id = ?").run(targetConversationId);
+      }
+      if (names.has("steps")) {
+        const row = destDb.prepare("SELECT MAX(idx) AS maxIdx FROM steps").get() as
+          | { maxIdx: number | null }
+          | undefined;
+        if (typeof row?.maxIdx === "number") maxStepIdx = row.maxIdx;
       }
     } finally {
       destDb.close();
@@ -71,4 +88,6 @@ export async function forkConversation(
       `[agy-acp] WARN: failed to copy brain artifacts for forked conversation ${targetConversationId}: ${(error as Error).message}`
     );
   }
+
+  return { maxStepIdx };
 }

--- a/tests/fixtures/conversation-db.ts
+++ b/tests/fixtures/conversation-db.ts
@@ -8,9 +8,9 @@ export function createConversationDb(dir: string, id: string): Database.Database
   fs.mkdirSync(dir, { recursive: true });
   const db = new Database(path.join(dir, `${id}.db`));
   db.exec(
-    "CREATE TABLE steps (idx INTEGER PRIMARY KEY, step_type INTEGER, status INTEGER, " +
+    "CREATE TABLE IF NOT EXISTS steps (idx INTEGER PRIMARY KEY, step_type INTEGER, status INTEGER, " +
       "step_payload BLOB, error_details BLOB, permissions BLOB, task_details BLOB);\n" +
-    "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);"
+    "CREATE TABLE IF NOT EXISTS gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);"
   );
   return db;
 }

--- a/tests/queue-steer.test.ts
+++ b/tests/queue-steer.test.ts
@@ -552,15 +552,27 @@ describe("queue and steer-by-cancel", () => {
           updates.push(ctx.params.update as Record<string, unknown>);
         }
       );
+      let turn = 0;
+      const turnSteps = [
+        [
+          { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt 1" }) },
+          { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ans 1" }) }
+        ],
+        [
+          { idx: 2, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt 2" }) },
+          { idx: 3, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ans 2" }) }
+        ]
+      ];
       const connection = client.connect(
         createAcpV2App({
           ...printModeOptions({ conversationsDir: dir, stateDir: dir }),
-          spawnProcess: spawnAgyWritingConversation(dir, "conv-v2-queue", [
-            { idx: 0, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt 1" }) },
-            { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ans 1" }) },
-            { idx: 2, stepType: 14, stepPayload: encodeStepPayload({ userPrompt: "prompt 2" }) },
-            { idx: 3, stepType: 15, stepPayload: encodeStepPayload({ agentText: "ans 2" }) }
-          ])
+          spawnProcess: ((command: string, args: string[]) => {
+            if (args[0] === "models") return new FakeProcess([TEST_MODELS_OUTPUT]);
+            const db = createConversationDb(dir, "conv-v2-queue");
+            for (const step of turnSteps[turn++] ?? []) insertStep(db, step);
+            db.close();
+            return new FakeProcess([]);
+          }) as unknown as SpawnFactory
         })
       );
       try {
@@ -591,7 +603,7 @@ describe("queue and steer-by-cancel", () => {
         await waitFor(() => {
           const idleCount = updates.filter((u) => u.sessionUpdate === "state_update" && u.state === "idle").length;
           return idleCount >= 2;
-        });
+        }, 5000);
 
         const userMessages = updates.filter((u) => u.sessionUpdate === "user_message");
         expect(userMessages.length).toBe(2);

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -13,6 +13,8 @@ import {
   createAcpV2App
 } from "../src/agent.js";
 import { forkConversation } from "../src/agy/db/fork.js";
+import { SessionStore } from "../src/acp/session/store.js";
+import { KeyedAsyncLock } from "../src/acp/session/setup-lock.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 import * as installer from "../src/agy/installer.js";
@@ -122,7 +124,8 @@ describe("forkConversation", () => {
       fs.writeFileSync(path.join(srcBrainPath, "plan.md"), "# Initial Plan\n- [ ] Task 1");
 
       // 3. Fork conversation
-      await forkConversation(convDir, srcId, targetId, brainDir);
+      const forked = await forkConversation(convDir, srcId, targetId, brainDir);
+      expect(forked.maxStepIdx).toBe(1);
 
       // 4. Verify target conversation DB
       const targetDbPath = path.join(convDir, `${targetId}.db`);
@@ -166,6 +169,53 @@ describe("forkConversation", () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("KeyedAsyncLock", () => {
+  it("runs same-key callbacks one at a time and leaves other keys concurrent", async () => {
+    const lock = new KeyedAsyncLock();
+    const order: string[] = [];
+    let releaseA: (() => void) | undefined;
+    const aGate = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+
+    const a = lock.run("same", async () => {
+      order.push("a-start");
+      await aGate;
+      order.push("a-end");
+      return "a";
+    });
+    const b = lock.run("same", async () => {
+      order.push("b");
+      return "b";
+    });
+    const other = lock.run("other", async () => {
+      order.push("other");
+      return "other";
+    });
+
+    await vi.waitFor(() => {
+      expect(order).toContain("a-start");
+      expect(order).toContain("other");
+    });
+    expect(order).not.toContain("b");
+
+    releaseA!();
+    await expect(Promise.all([a, b, other])).resolves.toEqual(["a", "b", "other"]);
+    expect(order.indexOf("b")).toBeGreaterThan(order.indexOf("a-end"));
+    expect(order).toContain("other");
+  });
+
+  it("still runs the next waiter after a rejected holder", async () => {
+    const lock = new KeyedAsyncLock();
+    const first = lock.run("k", async () => {
+      throw new Error("holder failed");
+    });
+    const second = lock.run("k", async () => "ok");
+    await expect(first).rejects.toThrow("holder failed");
+    await expect(second).resolves.toBe("ok");
   });
 });
 
@@ -320,8 +370,12 @@ describe("ACP v1 session/fork", () => {
       expect(fs.existsSync(forkedDbPath)).toBe(true);
 
       const forkedDb = new Database(forkedDbPath, { readonly: true });
-      const forkedSteps = forkedDb.prepare("SELECT idx, step_type FROM steps ORDER BY idx").all();
+      const forkedSteps = forkedDb.prepare("SELECT idx, step_type FROM steps ORDER BY idx").all() as Array<{
+        idx: number;
+      }>;
       expect(forkedSteps).toHaveLength(2);
+      const snapshotMaxIdx = Math.max(...forkedSteps.map((step) => step.idx));
+      expect(storeAfterFork.sessions[forked.sessionId].lastStepIdx).toBe(snapshotMaxIdx);
       forkedDb.close();
     } finally {
       installSpy.mockRestore();
@@ -491,6 +545,217 @@ describe("ACP v1 session/fork", () => {
       installSpy.mockRestore();
       connection.close();
       fs.rmSync(tmpStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("forks a persisted parent that is no longer in the active-session map", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-cold-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const parentConvId = "cold-parent-conv";
+    const spawnProcess = spawnAgyWritingConversation(convDir, parentConvId, [
+      { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "cold parent" }) }
+    ]);
+
+    const agent = new AcpAgent({
+      stateDir,
+      conversationsDir: convDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+      await connection.agent.request(methods.agent.session.prompt, {
+        sessionId: parent.sessionId,
+        prompt: [{ type: "text", text: "seed history" }]
+      });
+
+      await connection.agent.request(methods.agent.session.close, {
+        sessionId: parent.sessionId
+      });
+
+      const forked = (await connection.agent.request(methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/workspace"
+      })) as V1ForkSessionResponse;
+      expect(forked.sessionId).not.toBe(parent.sessionId);
+
+      const storeAfterFork = JSON.parse(fs.readFileSync(path.join(stateDir, "sessions.json"), "utf-8"));
+      const forkedConvId = storeAfterFork.sessions[forked.sessionId].conversationId;
+      expect(forkedConvId).toBeDefined();
+      expect(forkedConvId).not.toBe(parentConvId);
+      expect(storeAfterFork.sessions[forked.sessionId].lastStepIdx).toBe(1);
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("binds the child cursor to the copied db when the stored parent cursor is stale", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-stale-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const parentConvId = "stale-parent-conv";
+    const spawnProcess = spawnAgyWritingConversation(convDir, parentConvId, [
+      { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "one" }) },
+      { idx: 2, stepType: 15, stepPayload: encodeStepPayload({ agentText: "two" }) }
+    ]);
+
+    const agent = new AcpAgent({
+      stateDir,
+      conversationsDir: convDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+      await connection.agent.request(methods.agent.session.prompt, {
+        sessionId: parent.sessionId,
+        prompt: [{ type: "text", text: "seed history" }]
+      });
+      await connection.agent.request(methods.agent.session.close, {
+        sessionId: parent.sessionId
+      });
+
+      const storePath = path.join(stateDir, "sessions.json");
+      const store = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+      store.sessions[parent.sessionId].lastStepIdx = 0;
+      fs.writeFileSync(storePath, JSON.stringify(store, null, 2));
+
+      const forked = (await connection.agent.request(methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/workspace"
+      })) as V1ForkSessionResponse;
+
+      const storeAfterFork = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+      expect(storeAfterFork.sessions[forked.sessionId].lastStepIdx).toBe(2);
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("serializes fork of a persisted parent against a concurrent resume", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-lock-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const parentConvId = "locked-parent-conv";
+    const spawnProcess = spawnAgyWritingConversation(convDir, parentConvId, [
+      { idx: 1, stepType: 15, stepPayload: encodeStepPayload({ agentText: "locked" }) }
+    ]);
+
+    const agent = new AcpAgent({
+      stateDir,
+      conversationsDir: convDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    let releaseRestore: (() => void) | undefined;
+    const restoreGate = new Promise<void>((resolve) => {
+      releaseRestore = resolve;
+    });
+    let restoreCalls = 0;
+    const originalRestore = SessionStore.prototype.restore;
+    let restoreSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+      await connection.agent.request(methods.agent.session.prompt, {
+        sessionId: parent.sessionId,
+        prompt: [{ type: "text", text: "seed history" }]
+      });
+      await connection.agent.request(methods.agent.session.close, {
+        sessionId: parent.sessionId
+      });
+
+      restoreSpy = vi.spyOn(SessionStore.prototype, "restore").mockImplementation(async function (
+        this: SessionStore,
+        sessionId: string
+      ) {
+        restoreCalls += 1;
+        if (restoreCalls === 1) await restoreGate;
+        return originalRestore.call(this, sessionId);
+      });
+
+      const forkPromise = connection.agent.request(methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/workspace"
+      });
+      await vi.waitFor(() => {
+        expect(restoreCalls).toBeGreaterThan(0);
+      });
+
+      let resumeSettled = false;
+      const resumePromise = connection.agent.request(methods.agent.session.resume, {
+        sessionId: parent.sessionId,
+        cwd: "/workspace",
+        mcpServers: []
+      }).then((result) => {
+        resumeSettled = true;
+        return result;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(resumeSettled).toBe(false);
+      expect(restoreCalls).toBe(1);
+
+      releaseRestore!();
+      const forked = (await forkPromise) as V1ForkSessionResponse;
+      await resumePromise;
+      expect(forked.sessionId).not.toBe(parent.sessionId);
+      expect(resumeSettled).toBe(true);
+    } finally {
+      restoreSpy?.mockRestore();
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -1,0 +1,425 @@
+import { EventEmitter } from "node:events";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Readable, Writable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { client as acpClient, methods, PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
+import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
+import {
+  AcpAgent,
+  createAcpApp,
+  createAcpV2App
+} from "../src/agent.js";
+import { forkConversation } from "../src/agy/db/fork.js";
+import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
+import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
+import * as installer from "../src/agy/installer.js";
+import type { ForkSessionResponse as V1ForkSessionResponse } from "@agentclientprotocol/sdk";
+import type { ForkSessionResponse as V2ForkSessionResponse } from "@agentclientprotocol/sdk/experimental/v2";
+import type { SpawnFactory } from "../src/agy/cli.js";
+
+class FakeProcess extends EventEmitter {
+  stdin = new Writable({ write: (_chunk, _encoding, callback) => callback() });
+  stdout: Readable;
+  stderr: Readable;
+  exitCode = 0;
+  pid = 1;
+
+  constructor(
+    chunks: string[],
+    options: { exitCode?: number; stderr?: string } = {}
+  ) {
+    super();
+    this.exitCode = options.exitCode ?? 0;
+    this.stdout = Readable.from(chunks);
+    this.stderr = Readable.from(options.stderr ? [options.stderr] : []);
+    queueMicrotask(() => this.emit("exit", this.exitCode, null));
+  }
+
+  kill() {
+    this.exitCode = -15;
+    this.emit("exit", -15, "SIGTERM");
+    return true;
+  }
+}
+
+const TEST_MODELS = "gemini-2.5-flash\ngemini-3.7-pro\n";
+
+function makeSpawnProcess() {
+  return (_command: string, args: string[]) => {
+    if (args[0] === "models") {
+      return new FakeProcess([TEST_MODELS]);
+    }
+    return new FakeProcess(["ok"]);
+  };
+}
+
+function spawnAgyWritingConversation(
+  dir: string,
+  conversationId: string,
+  steps: Parameters<typeof insertStep>[1][]
+): SpawnFactory {
+  return ((command: string, args: string[]) => {
+    if (args[0] === "models") {
+      return new FakeProcess([TEST_MODELS]);
+    }
+    const db = createConversationDb(dir, conversationId);
+    for (const step of steps) insertStep(db, step);
+    db.close();
+    return new FakeProcess([]);
+  }) as unknown as SpawnFactory;
+}
+
+function flushDeferredNotifications(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("forkConversation", () => {
+  it("duplicates sqlite conversation db, updates trajectory_meta, and copies brain artifacts", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const brainDir = path.join(tmpDir, "brain");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(brainDir, { recursive: true });
+
+    try {
+      const srcId = "src-conv-1234";
+      const targetId = "target-conv-5678";
+
+      // 1. Create source conversation DB with steps and trajectory_meta
+      createConversationDb(convDir, srcId);
+      const srcDbPath = path.join(convDir, `${srcId}.db`);
+      const srcDb = new Database(srcDbPath);
+      srcDb.exec(`
+        CREATE TABLE IF NOT EXISTS trajectory_meta (
+          trajectory_id text,
+          cascade_id text,
+          trajectory_type integer,
+          source integer,
+          PRIMARY KEY (trajectory_id)
+        );
+        INSERT INTO trajectory_meta VALUES ('traj-1', '${srcId}', 4, 17);
+      `);
+      insertStep(srcDb, {
+        idx: 0,
+        stepType: 1,
+        status: 3,
+        stepPayload: encodeStepPayload({ userPrompt: "initial prompt" })
+      });
+      insertStep(srcDb, {
+        idx: 1,
+        stepType: 2,
+        status: 3,
+        stepPayload: encodeStepPayload({ agentText: "agent response" })
+      });
+      srcDb.close();
+
+      // 2. Create source brain directory with artifacts
+      const srcBrainPath = path.join(brainDir, srcId);
+      fs.mkdirSync(srcBrainPath, { recursive: true });
+      fs.writeFileSync(path.join(srcBrainPath, "plan.md"), "# Initial Plan\n- [ ] Task 1");
+
+      // 3. Fork conversation
+      await forkConversation(convDir, srcId, targetId, brainDir);
+
+      // 4. Verify target conversation DB
+      const targetDbPath = path.join(convDir, `${targetId}.db`);
+      expect(fs.existsSync(targetDbPath)).toBe(true);
+
+      const targetDb = new Database(targetDbPath, { readonly: true });
+      const targetMeta = targetDb.prepare("SELECT * FROM trajectory_meta").all() as Array<{
+        cascade_id: string;
+        trajectory_id: string;
+      }>;
+      expect(targetMeta).toHaveLength(1);
+      expect(targetMeta[0]?.cascade_id).toBe(targetId);
+
+      const targetSteps = targetDb.prepare("SELECT idx, step_type FROM steps ORDER BY idx").all() as Array<{
+        idx: number;
+        step_type: number;
+      }>;
+      expect(targetSteps).toEqual([
+        { idx: 0, step_type: 1 },
+        { idx: 1, step_type: 2 }
+      ]);
+      targetDb.close();
+
+      // 5. Verify target brain directory
+      const targetBrainPath = path.join(brainDir, targetId);
+      expect(fs.existsSync(targetBrainPath)).toBe(true);
+      expect(fs.readFileSync(path.join(targetBrainPath, "plan.md"), "utf-8")).toBe(
+        "# Initial Plan\n- [ ] Task 1"
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("handles non-existent source conversation db gracefully", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
+    try {
+      await expect(
+        forkConversation(path.join(tmpDir, "conv"), "non-existent-src", "target-id", path.join(tmpDir, "brain"))
+      ).resolves.toBeUndefined();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("ACP v1 session/fork", () => {
+  it("advertises fork capability in v1 initialize response", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const connection = acpClient({ name: "test-client" }).connect(
+      createAcpApp({
+        argv: ["--no-interactive-permissions"],
+        spawnProcess: makeSpawnProcess() as unknown as SpawnFactory
+      })
+    );
+    try {
+      const response = await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+      expect(response.agentCapabilities?.sessionCapabilities?.fork).toEqual({});
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+    }
+  });
+
+  it("forks an idle unstarted session into a new independent session", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-state-"));
+    const agent = new AcpAgent({
+      stateDir: tmpStateDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess: makeSpawnProcess() as unknown as SpawnFactory
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      // Create parent session
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/parent/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+
+      // Change config on parent session
+      await connection.agent.request(methods.agent.session.setConfigOption, {
+        sessionId: parent.sessionId,
+        configId: "model",
+        value: "gemini-3.7-pro"
+      });
+
+      // Fork parent session
+      const forked = (await connection.agent.request(methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/forked/workspace"
+      })) as V1ForkSessionResponse;
+      await flushDeferredNotifications();
+
+      expect(forked.sessionId).toBeDefined();
+      expect(forked.sessionId).not.toBe(parent.sessionId);
+
+      // Verify inherited config options on forked session
+      const modelOption = forked.configOptions?.find((opt) => opt.id === "model");
+      expect(modelOption?.id).toBe("model");
+      expect(modelOption?.currentValue).toMatch(/gemini-3.7-pro|Gemini 3.7 Pro/i);
+
+      // Verify sessions are listed separately
+      const list = await connection.agent.request(methods.agent.session.list, {});
+      expect(list.sessions).toHaveLength(2);
+      expect(list.sessions.map((s) => s.sessionId)).toContain(parent.sessionId);
+      expect(list.sessions.map((s) => s.sessionId)).toContain(forked.sessionId);
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("forks an active conversation session and duplicates conversation history", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-active-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const parentConvId = "parent-conv-uuid";
+    const spawnProcess = spawnAgyWritingConversation(convDir, parentConvId, [
+      {
+        idx: 1,
+        stepType: 8,
+        stepPayload: encodeStepPayload({
+          toolRun: encodeToolRun({
+            call: encodeToolCall({
+              callId: "view-1",
+              namePrimary: "view_file",
+              rawInputJson: '{"AbsolutePath":"/repo/README.md"}'
+            })
+          })
+        })
+      },
+      { idx: 2, stepType: 15, stepPayload: encodeStepPayload({ agentText: "hello from agent" }) }
+    ]);
+
+    const agent = new AcpAgent({
+      stateDir,
+      conversationsDir: convDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess
+    });
+
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      // Create parent session and execute first prompt turn to bind to parentConvId
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+
+      await connection.agent.request(methods.agent.session.prompt, {
+        sessionId: parent.sessionId,
+        prompt: [{ type: "text", text: "tell me a joke" }]
+      });
+
+      // Fork parent session
+      const forked = (await connection.agent.request(methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/forked-workspace"
+      })) as V1ForkSessionResponse;
+      await flushDeferredNotifications();
+
+      expect(forked.sessionId).toBeDefined();
+      expect(forked.sessionId).not.toBe(parent.sessionId);
+
+      // Verify forked session's conversation ID on disk is a new UUID and contains parent steps
+      const storeAfterFork = JSON.parse(fs.readFileSync(path.join(stateDir, "sessions.json"), "utf-8"));
+      const forkedConvId = storeAfterFork.sessions[forked.sessionId].conversationId;
+      expect(forkedConvId).toBeDefined();
+      expect(forkedConvId).not.toBe(parentConvId);
+
+      const forkedDbPath = path.join(convDir, `${forkedConvId}.db`);
+      expect(fs.existsSync(forkedDbPath)).toBe(true);
+
+      const forkedDb = new Database(forkedDbPath, { readonly: true });
+      const forkedSteps = forkedDb.prepare("SELECT idx, step_type FROM steps ORDER BY idx").all();
+      expect(forkedSteps).toHaveLength(2);
+      forkedDb.close();
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns an error when forking a non-existent session", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const connection = acpClient({ name: "test-client" }).connect(
+      createAcpApp({
+        argv: ["--no-interactive-permissions"],
+        spawnProcess: makeSpawnProcess() as unknown as SpawnFactory
+      })
+    );
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      await expect(
+        connection.agent.request(methods.agent.session.fork, {
+          sessionId: "unknown-session-id"
+        })
+      ).rejects.toThrow();
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+    }
+  });
+});
+
+describe("ACP v2 session/fork", () => {
+  it("advertises fork capability in v2 initialize response", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const connection = acpV2.client({ name: "test-client" }).connect(
+      createAcpV2App({
+        argv: ["--no-interactive-permissions"],
+        spawnProcess: makeSpawnProcess() as unknown as SpawnFactory
+      })
+    );
+    try {
+      const response = (await connection.agent.request(acpV2.methods.agent.initialize, {
+        protocolVersion: acpV2.PROTOCOL_VERSION,
+        info: { name: "test-client-v2", version: "0.0.0" },
+        capabilities: {}
+      })) as acpV2.InitializeResponse;
+      expect(response.capabilities?.session).toMatchObject({
+        fork: {}
+      });
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+    }
+  });
+
+  it("forks a session in v2 returning sessionId and configOptions", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v2-state-"));
+    const agent = new AcpAgent({
+      stateDir: tmpStateDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess: makeSpawnProcess() as unknown as SpawnFactory
+    });
+    const connection = acpV2.client({ name: "test-client" }).connect(createAcpV2App(agent));
+
+    try {
+      await connection.agent.request(acpV2.methods.agent.initialize, {
+        protocolVersion: acpV2.PROTOCOL_VERSION,
+        info: { name: "test-client-v2", version: "0.0.0" },
+        capabilities: {}
+      });
+
+      const parent = await connection.agent.request(acpV2.methods.agent.session.new, {
+        cwd: "/v2/workspace"
+      });
+      await flushDeferredNotifications();
+
+      const forked = (await connection.agent.request(acpV2.methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/v2/forked-workspace"
+      })) as V2ForkSessionResponse;
+      await flushDeferredNotifications();
+
+      expect(forked.sessionId).toBeDefined();
+      expect(forked.sessionId).not.toBe(parent.sessionId);
+      expect(forked.configOptions?.length).toBeGreaterThan(0);
+
+      const modelOption = forked.configOptions?.find((opt) => opt.configId === "model");
+      expect(modelOption).toMatchObject({
+        configId: "model"
+      });
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpStateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -157,12 +157,12 @@ describe("forkConversation", () => {
     }
   });
 
-  it("handles non-existent source conversation db gracefully", async () => {
+  it("rejects fork when source conversation db does not exist", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
     try {
       await expect(
         forkConversation(path.join(tmpDir, "conv"), "non-existent-src", "target-id", path.join(tmpDir, "brain"))
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow("Source conversation database not found: non-existent-src");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -327,6 +327,66 @@ describe("ACP v1 session/fork", () => {
       installSpy.mockRestore();
       connection.close();
       fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects fork when parent session turn is active", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-busy-"));
+
+    const hangingProcess = new EventEmitter() as any;
+    hangingProcess.stdin = new Writable({ write: (_c, _e, cb) => cb() });
+    hangingProcess.stdout = new Readable({ read() {} });
+    hangingProcess.stderr = new Readable({ read() {} });
+    hangingProcess.exitCode = 0;
+    hangingProcess.pid = 123;
+    hangingProcess.kill = () => true;
+
+    const spawnProcess = ((command: string, args: string[]) => {
+      if (args[0] === "models") return new FakeProcess([TEST_MODELS]);
+      return hangingProcess;
+    }) as unknown as SpawnFactory;
+
+    const agent = new AcpAgent({
+      stateDir: tmpStateDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/parent/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+
+      // Start prompt turn without awaiting completion
+      const promptPromise = connection.agent.request(methods.agent.session.prompt, {
+        sessionId: parent.sessionId,
+        prompt: [{ type: "text", text: "run slow task" }]
+      });
+
+      // Attempt to fork parent session while turn is active
+      await expect(
+        connection.agent.request(methods.agent.session.fork, {
+          sessionId: parent.sessionId,
+          cwd: "/forked/workspace"
+        })
+      ).rejects.toThrow();
+
+      // Terminate hanging turn
+      hangingProcess.emit("exit", 0, null);
+      await promptPromise.catch(() => {});
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpStateDir, { recursive: true, force: true });
     }
   });
 

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -12,9 +12,11 @@ import {
   createAcpApp,
   createAcpV2App
 } from "../src/agent.js";
-import { forkConversation } from "../src/agy/db/fork.js";
+import { discardForkedConversation, forkConversation } from "../src/agy/db/fork.js";
+import { forkSession } from "../src/acp/session/setup.js";
 import { SessionStore } from "../src/acp/session/store.js";
 import { KeyedAsyncLock } from "../src/acp/session/setup-lock.js";
+import type { AgyCliBackend } from "../src/agy/cli.js";
 import { createConversationDb, insertStep } from "./fixtures/conversation-db.js";
 import { encodeStepPayload, encodeToolCall, encodeToolRun } from "./fixtures/step-encoder.js";
 import * as installer from "../src/agy/installer.js";
@@ -196,6 +198,85 @@ describe("forkConversation", () => {
       await expect(
         forkConversation(path.join(tmpDir, "conv"), "non-existent-src", "target-id", path.join(tmpDir, "brain"))
       ).rejects.toThrow("Source conversation database not found: non-existent-src");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("discardForkedConversation removes dest db and brain artifacts", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const brainDir = path.join(tmpDir, "brain");
+    fs.mkdirSync(path.join(brainDir, "child-id"), { recursive: true });
+    fs.writeFileSync(path.join(brainDir, "child-id", "plan.md"), "x");
+    createConversationDb(convDir, "child-id").close();
+    try {
+      discardForkedConversation(convDir, "child-id", brainDir);
+      expect(fs.existsSync(path.join(convDir, "child-id.db"))).toBe(false);
+      expect(fs.existsSync(path.join(brainDir, "child-id"))).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("forkSession artifact cleanup", () => {
+  it("discards copied conversation artifacts if child setup fails after snapshot", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-cleanup-"));
+    const convDir = path.join(tmpDir, "conversations");
+    const brainDir = path.join(tmpDir, "brain");
+    const stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(convDir, { recursive: true });
+    fs.mkdirSync(brainDir, { recursive: true });
+
+    const srcId = "src-cleanup";
+    const srcDb = createConversationDb(convDir, srcId);
+    insertStep(srcDb, {
+      idx: 0,
+      stepType: 1,
+      status: 3,
+      stepPayload: encodeStepPayload({ userPrompt: "prompt" })
+    });
+    srcDb.close();
+    fs.mkdirSync(path.join(brainDir, srcId), { recursive: true });
+    fs.writeFileSync(path.join(brainDir, srcId, "plan.md"), "# plan");
+
+    const parentId = "parent-cleanup";
+    const store = new SessionStore(stateDir);
+    await store.persist(parentId, {
+      cwd: "/workspace",
+      additionalDirectories: [],
+      conversationId: srcId,
+      lastStepIdx: 0,
+      model: "gemini-2.5-flash",
+      reasoningEffort: "",
+      v2UserMessageIdsByStep: {},
+      updatedAt: new Date().toISOString()
+    });
+
+    try {
+      await expect(
+        forkSession(parentId, "/workspace", [], {
+          env: process.env,
+          argv: ["--no-interactive-permissions"],
+          backend: { startSession: async () => {
+            throw new Error("start failed");
+          } } as unknown as AgyCliBackend,
+          getModelOptions: async () => {
+            throw new Error("catalog failed");
+          },
+          conversationsDir: convDir,
+          store,
+          sessions: new Map(),
+          maxActiveSessions: 8,
+          persistSession: async () => {},
+          setupLocks: new KeyedAsyncLock()
+        })
+      ).rejects.toThrow("catalog failed");
+
+      const leftoverDbs = fs.readdirSync(convDir).filter((name) => name.endsWith(".db"));
+      expect(leftoverDbs).toEqual([`${srcId}.db`]);
+      expect(fs.readdirSync(brainDir)).toEqual([srcId]);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -390,6 +390,49 @@ describe("ACP v1 session/fork", () => {
     }
   });
 
+  it("holds turn reservation on parent session during fork and releases cleanly", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-res-"));
+
+    const agent = new AcpAgent({
+      stateDir: tmpStateDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess: makeSpawnProcess() as unknown as SpawnFactory
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      const parent = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/parent/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+
+      const forked = (await connection.agent.request(methods.agent.session.fork, {
+        sessionId: parent.sessionId,
+        cwd: "/forked/workspace"
+      })) as V1ForkSessionResponse;
+      expect(forked.sessionId).toBeDefined();
+
+      // Ensure parent session is completely idle and clean after fork
+      await expect(
+        connection.agent.request(methods.agent.session.prompt, {
+          sessionId: parent.sessionId,
+          prompt: [{ type: "text", text: "hello after fork" }]
+        })
+      ).resolves.toBeDefined();
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpStateDir, { recursive: true, force: true });
+    }
+  });
+
   it("returns an error when forking a non-existent session", async () => {
     const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
     const connection = acpClient({ name: "test-client" }).connect(

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -160,6 +160,36 @@ describe("forkConversation", () => {
     }
   });
 
+  it("rejects fork and discards dest db when cascade_id cannot be rebound", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
+    const convDir = path.join(tmpDir, "conversations");
+    fs.mkdirSync(convDir, { recursive: true });
+
+    try {
+      const srcId = "src-bad-meta";
+      const targetId = "target-bad-meta";
+      const srcDb = createConversationDb(convDir, srcId);
+      srcDb.exec(`
+        CREATE TABLE trajectory_meta (foo text);
+        INSERT INTO trajectory_meta VALUES ('x');
+      `);
+      insertStep(srcDb, {
+        idx: 0,
+        stepType: 1,
+        status: 3,
+        stepPayload: encodeStepPayload({ userPrompt: "prompt" })
+      });
+      srcDb.close();
+
+      await expect(forkConversation(convDir, srcId, targetId)).rejects.toThrow(
+        /Failed to rebind forked conversation database/
+      );
+      expect(fs.existsSync(path.join(convDir, `${targetId}.db`))).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects fork when source conversation db does not exist", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-test-"));
     try {

--- a/tests/session-fork.test.ts
+++ b/tests/session-fork.test.ts
@@ -433,6 +433,67 @@ describe("ACP v1 session/fork", () => {
     }
   });
 
+  it("rejects session replacement while turn or fork claim is active", async () => {
+    const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
+    const tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agy-acp-fork-v1-replace-"));
+
+    const hangingProcess = new EventEmitter() as any;
+    hangingProcess.stdin = new Writable({ write: (_c, _e, cb) => cb() });
+    hangingProcess.stdout = new Readable({ read() {} });
+    hangingProcess.stderr = new Readable({ read() {} });
+    hangingProcess.exitCode = 0;
+    hangingProcess.pid = 123;
+    hangingProcess.kill = () => true;
+
+    const spawnProcess = ((command: string, args: string[]) => {
+      if (args[0] === "models") return new FakeProcess([TEST_MODELS]);
+      return hangingProcess;
+    }) as unknown as SpawnFactory;
+
+    const agent = new AcpAgent({
+      stateDir: tmpStateDir,
+      argv: ["--no-interactive-permissions"],
+      spawnProcess
+    });
+    const connection = acpClient({ name: "test-client" }).connect(createAcpApp(agent));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {}
+      });
+
+      const session = await connection.agent.request(methods.agent.session.new, {
+        cwd: "/parent/workspace",
+        mcpServers: []
+      });
+      await flushDeferredNotifications();
+
+      // Start prompt turn to make session busy
+      const promptPromise = connection.agent.request(methods.agent.session.prompt, {
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "run slow task" }]
+      });
+
+      // Attempt to load/resume and replace the busy session
+      await expect(
+        connection.agent.request(methods.agent.session.load, {
+          sessionId: session.sessionId,
+          cwd: "/parent/workspace",
+          mcpServers: []
+        })
+      ).rejects.toThrow();
+
+      // Clean up hanging turn
+      hangingProcess.emit("exit", 0, null);
+      await promptPromise.catch(() => {});
+    } finally {
+      installSpy.mockRestore();
+      connection.close();
+      fs.rmSync(tmpStateDir, { recursive: true, force: true });
+    }
+  });
+
   it("returns an error when forking a non-existent session", async () => {
     const installSpy = vi.spyOn(installer, "ensureAgyInstalled").mockResolvedValue("/opt/homebrew/bin/agy");
     const connection = acpClient({ name: "test-client" }).connect(


### PR DESCRIPTION
## Description

Support `session/fork` across ACP v1 and v2 protocol methods:
- Implement `forkConversation` in `src/agy/db/fork.ts` using `better-sqlite3` atomic `.backup()`, update `trajectory_meta.cascade_id`, and copy brain directory artifacts.
- Implement `handleForkSessionV1` and `handleForkSessionV2` in `src/acp/session/fork.ts` to clone session state, propagate inherited configuration options (`model`, `reasoningEffort`, `mode`), and register the child session.
- Advertise `sessionCapabilities.fork` in ACP v1 and `capabilities.session.fork` in ACP v2 `initialize` responses.
- Register `session/fork` request handlers in ACP v1 and v2 app routers.
- Verified end-to-end with real `agy` CLI and SQLite DB, plus comprehensive unit and integration test suite.

## Related Issues

Closes #58

## Type of Change

- [x] New feature (non-breaking change adding functionality)

## Verification Checklist

- [x] I have executed `pnpm run build` and it completed without errors
- [x] I have executed `pnpm test` and all tests pass
- [x] I verified Node entry point syntax:
  - [x] `node --check dist/main.js`
  - [x] `node --check dist/agent.js`
  - [x] `node --check dist/agy/cli.js`
- [x] I have added or updated tests covering my changes
- [x] I have updated documentation (`CHANGELOG.md`)
- [x] I confirmed no generated build output, local logs, or API keys are committed
